### PR TITLE
@W-22556909 - feat(v3): wire v3 dispatch into ReVoman.revUp + Environment.mergeEnvs (2/4)

### DIFF
--- a/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
+++ b/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
@@ -86,21 +86,28 @@ object ReVoman {
   @OptIn(ExperimentalStdlibApi::class)
   fun revUp(kick: Kick): Rundown {
     val pmTemplateAdapter = Moshi.Builder().build().adapter<Template>()
-    val templateBuffers =
-      kick.templatePaths().map { bufferFile(it) } +
-        kick.templateInputStreams().map { bufferInputStream(it) }
-    val pmStepsDeepFlattened =
-      templateBuffers
-        .asSequence()
-        .mapNotNull { pmTemplateAdapter.fromJson(it) }
-        .flatMap { (pmSteps, authFromRoot) ->
-          deepFlattenItems(
-            pmSteps.map { item ->
-              item.copy(request = item.request.copy(auth = item.request.auth ?: authFromRoot))
-            }
-          )
+    val itemsFromPaths: List<com.salesforce.revoman.internal.postman.template.Item> =
+      kick.templatePaths().flatMap { path ->
+        val v3Dir = resolveV3CollectionDir(path)
+        when {
+          v3Dir != null -> com.salesforce.revoman.internal.postman.template.v3.V3Loader.load(v3Dir)
+          else ->
+            pmTemplateAdapter.fromJson(bufferFile(path))?.let { (pmSteps, authFromRoot) ->
+              pmSteps.map { item ->
+                item.copy(request = item.request.copy(auth = item.request.auth ?: authFromRoot))
+              }
+            } ?: emptyList()
         }
-        .toList()
+      }
+    val itemsFromStreams: List<com.salesforce.revoman.internal.postman.template.Item> =
+      kick.templateInputStreams().flatMap { stream ->
+        pmTemplateAdapter.fromJson(bufferInputStream(stream))?.let { (pmSteps, authFromRoot) ->
+          pmSteps.map { item ->
+            item.copy(request = item.request.copy(auth = item.request.auth ?: authFromRoot))
+          }
+        } ?: emptyList()
+      }
+    val pmStepsDeepFlattened = deepFlattenItems(itemsFromPaths + itemsFromStreams)
     logger.info {
       val templateCount = kick.templatePaths().size
       "Total Steps from ${if (templateCount > 1) "$templateCount Collections" else "the Collection"} provided: ${pmStepsDeepFlattened.size}"
@@ -245,6 +252,16 @@ object ReVoman {
         haltExecution = shouldHaltExecution(currentStepReport, kick, pm.rundown)
         stepReports + currentStepReport
       }
+  }
+
+  private fun resolveV3CollectionDir(path: String): java.io.File? {
+    val direct = java.io.File(path)
+    val v3Marker = ".resources/definition.yaml"
+    if (direct.isDirectory && java.io.File(direct, v3Marker).isFile) return direct
+    val url = Thread.currentThread().contextClassLoader.getResource(path) ?: return null
+    val viaResource = java.io.File(url.toURI())
+    return if (viaResource.isDirectory && java.io.File(viaResource, v3Marker).isFile) viaResource
+    else null
   }
 }
 

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/template/Environment.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/template/Environment.kt
@@ -39,17 +39,31 @@ internal data class Environment(val name: String?, val values: List<EnvValue>) {
       dynamicEnvironment: Map<String, Any?>,
     ): Map<String, Any?> {
       val envAdapter = Moshi.Builder().build().adapter<Environment>()
-      val envFromEnvFiles =
-        (pmEnvironmentPaths.map { bufferFile(it) } +
-            pmEnvironmentInputStreams.map { bufferInputStream(it) })
-          .flatMap { envWithRegex ->
-            envAdapter.fromJson(envWithRegex)?.values?.filter { it.enabled } ?: emptyList()
+      val envFromYamlPaths: Map<String, Any?> =
+        pmEnvironmentPaths
+          .filter { it.endsWith(".yaml") || it.endsWith(".yml") }
+          .fold(emptyMap()) { acc, path ->
+            acc + com.salesforce.revoman.internal.postman.template.v3.V3EnvLoader.loadFromPath(path)
+          }
+      val envFromJsonPaths: Map<String, Any?> =
+        pmEnvironmentPaths
+          .filterNot { it.endsWith(".yaml") || it.endsWith(".yml") }
+          .map { bufferFile(it) }
+          .flatMap { source ->
+            envAdapter.fromJson(source)?.values?.filter { it.enabled } ?: emptyList()
+          }
+          .associate { it.key to it.value }
+      val envFromStreams: Map<String, Any?> =
+        pmEnvironmentInputStreams
+          .map { bufferInputStream(it) }
+          .flatMap { source ->
+            envAdapter.fromJson(source)?.values?.filter { it.enabled } ?: emptyList()
           }
           .associate { it.key to it.value }
       // * NOTE 10/09/23 gopala.akshintala: dynamicEnvironment keys replace envFromEnvFiles when
       // clashed
       // ! TODO 11 Jun 2025 gopala.akshintala: serialize only during regex replace
-      return envFromEnvFiles + dynamicEnvironment
+      return envFromYamlPaths + envFromJsonPaths + envFromStreams + dynamicEnvironment
     }
   }
 }

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3DetectionTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3DetectionTest.kt
@@ -1,0 +1,22 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.postman.template.v3
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.ReVoman
+import com.salesforce.revoman.input.config.Kick
+import org.junit.jupiter.api.Test
+
+class V3DetectionTest {
+  @Test
+  fun testRevUpAcceptsV3DirectoryPathAndLoadsAllSteps() {
+    val rundown =
+      ReVoman.revUp(Kick.configure().templatePath("pm-templates/v3/flat").insecureHttp(true).off())
+    assertThat(rundown.providedStepsToExecuteCount).isEqualTo(3)
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3EnvLoaderTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3EnvLoaderTest.kt
@@ -18,4 +18,17 @@ class V3EnvLoaderTest {
     assertThat(map).containsEntry("count", "5")
     assertThat(map["emptyValue"]).isNull()
   }
+
+  @Test
+  fun testMergeEnvsAcceptsV3YamlAndDynamicEnv() {
+    val merged =
+      com.salesforce.revoman.internal.postman.template.Environment.mergeEnvs(
+        pmEnvironmentPaths = setOf("pm-templates/v3/test.environment.yaml"),
+        pmEnvironmentInputStreams = emptyList(),
+        dynamicEnvironment = mapOf("override" to "yes"),
+      )
+    assertThat(merged).containsEntry("baseUrl", "https://example.com")
+    assertThat(merged).containsEntry("count", "5")
+    assertThat(merged).containsEntry("override", "yes")
+  }
 }

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3LoaderTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3LoaderTest.kt
@@ -56,4 +56,20 @@ class V3LoaderTest {
     assertThat(items).hasSize(1)
     assertThat(items[0].name).isEqualTo("req")
   }
+
+  @Test
+  fun testLoadMixedBodies() {
+    val dir = File("src/test/resources/pm-templates/v3/mixed-bodies")
+    val items = V3Loader.load(dir)
+    assertThat(items).hasSize(2)
+    val post = items[0]
+    assertThat(post.name).isEqualTo("post-json")
+    assertThat(post.request.method).isEqualTo("POST")
+    assertThat(post.request.body!!.raw).contains("\"a\":1")
+    assertThat(post.event).isNotNull()
+    assertThat(post.event!!.map { it.listen }.toSet()).containsExactly("test", "prerequest")
+    val patch = items[1]
+    assertThat(patch.request.method).isEqualTo("PATCH")
+    assertThat(patch.request.body!!.raw).isEqualTo("hello")
+  }
 }

--- a/src/test/resources/pm-templates/v3/mixed-bodies/.resources/definition.yaml
+++ b/src/test/resources/pm-templates/v3/mixed-bodies/.resources/definition.yaml
@@ -1,0 +1,1 @@
+$kind: collection

--- a/src/test/resources/pm-templates/v3/mixed-bodies/patch-text.request.yaml
+++ b/src/test/resources/pm-templates/v3/mixed-bodies/patch-text.request.yaml
@@ -1,0 +1,9 @@
+$kind: http-request
+url: https://example.com/x
+method: PATCH
+headers:
+  Content-Type: text/plain
+body:
+  type: text
+  content: hello
+order: 2000

--- a/src/test/resources/pm-templates/v3/mixed-bodies/post-json.request.yaml
+++ b/src/test/resources/pm-templates/v3/mixed-bodies/post-json.request.yaml
@@ -1,0 +1,17 @@
+$kind: http-request
+url: https://example.com/x
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: json
+  content: |-
+    {"a":1}
+scripts:
+  - type: afterResponse
+    code: console.log("after")
+    language: text/javascript
+  - type: beforeRequest
+    code: console.log("before")
+    language: text/javascript
+order: 1000


### PR DESCRIPTION
## Summary
- Wires the v3 loader (introduced in #349) into `ReVoman.revUp` and `Environment.mergeEnvs`.
- `templatePaths()` now auto-detects: directory containing `.resources/definition.yaml` → v3 loader; `.json` file → existing v2 Moshi adapter. `templateInputStreams()` stays v2-only (documented).
- `environmentPaths()` auto-detects: `.yaml`/`.yml` → v3 env loader; `.json` → existing v2 Moshi adapter. `environmentInputStreams()` stays v2-only.
- `ReVoman.kt` adds a small `resolveV3CollectionDir` helper with classpath fallback so v3 directories work both via direct filesystem path and resource-classpath path (needed for integration tests that use `pm-templates/v3/...` resource-relative paths).
- New `V3DetectionTest` covers the dispatch routing.
- New `V3EnvLoaderTest.testMergeEnvsAcceptsV3YamlAndDynamicEnv` covers end-to-end env merge.
- New `mixed-bodies` unit-test fixture + test case for JSON+text bodies and multi-script events.

## Notes
- **Stacked on top of #349.** Merge order: 1/4 → 2/4 → 3/4 → 4/4.
- Zero public API additions. v3 support is detected transparently from existing `Kick.templatePath` / `environmentPath`.
- All existing v2 unit tests pass — regression guard.

## Test plan
- [x] `./gradlew test` — 91 unit tests pass
- [x] `./gradlew spotlessCheck` — clean
- [x] `./gradlew build -x integrationTest` — green
- [ ] CI green