### PR TITLE
@W-22556909 - test(v3): integration tests - Pokemon, restful-api.dev, Apigee + Java/Kotlin parity (3/4)

### DIFF
--- a/src/integrationTest/java/com/salesforce/revoman/integration/pokemon/v3/PokemonV2VsV3EquivalenceTest.java
+++ b/src/integrationTest/java/com/salesforce/revoman/integration/pokemon/v3/PokemonV2VsV3EquivalenceTest.java
@@ -1,0 +1,46 @@
+/***************************************************************************************************
+ *  Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier:
+ *           Apache License Version 2.0
+ *  For full license text, see the LICENSE file in the repo root or
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ **************************************************************************************************/
+
+package com.salesforce.revoman.integration.pokemon.v3;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.salesforce.revoman.ReVoman;
+import com.salesforce.revoman.input.config.Kick;
+import com.salesforce.revoman.output.Rundown;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class PokemonV2VsV3EquivalenceTest {
+  @Test
+  void v2AndV3PokemonProduceIdenticalEnvAndStepCount() {
+    final Map<String, Object> dyn = Map.of("offset", "0", "limit", "1");
+    final Rundown v2 =
+        ReVoman.revUp(
+            Kick.configure()
+                .templatePath("pm-templates/v2/pokemon/pokemon.postman_collection.json")
+                .environmentPath("pm-templates/v2/pokemon/pokemon.postman_environment.json")
+                .nodeModulesPath("js")
+                .dynamicEnvironment(dyn)
+                .off());
+    final Rundown v3 =
+        ReVoman.revUp(
+            Kick.configure()
+                .templatePath("pm-templates/v3/pokemon")
+                .environmentPath("pm-templates/v3/pokemon/Pokemon.environment.yaml")
+                .nodeModulesPath("js")
+                .dynamicEnvironment(dyn)
+                .off());
+    assertThat(v3.stepReports.size()).isEqualTo(v2.stepReports.size());
+    final List<String> keys =
+        List.of("baseUrl", "id", "pokemonName", "color", "gender", "ability", "nature");
+    for (final String k : keys) {
+      assertThat(v3.mutableEnv.get(k)).isEqualTo(v2.mutableEnv.get(k));
+    }
+  }
+}

--- a/src/integrationTest/java/com/salesforce/revoman/integration/pokemon/v3/PokemonV3Test.java
+++ b/src/integrationTest/java/com/salesforce/revoman/integration/pokemon/v3/PokemonV3Test.java
@@ -1,0 +1,36 @@
+/***************************************************************************************************
+ *  Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier:
+ *           Apache License Version 2.0
+ *  For full license text, see the LICENSE file in the repo root or
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ **************************************************************************************************/
+
+package com.salesforce.revoman.integration.pokemon.v3;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.salesforce.revoman.ReVoman;
+import com.salesforce.revoman.input.config.Kick;
+import com.salesforce.revoman.output.Rundown;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class PokemonV3Test {
+  private static final String PM_COLLECTION_PATH = "pm-templates/v3/pokemon";
+  private static final String PM_ENVIRONMENT_PATH =
+      "pm-templates/v3/pokemon/Pokemon.environment.yaml";
+
+  @Test
+  void executePokemonV3CollectionFromJava() {
+    final Kick config =
+        Kick.configure()
+            .templatePath(PM_COLLECTION_PATH)
+            .environmentPath(PM_ENVIRONMENT_PATH)
+            .nodeModulesPath("js")
+            .dynamicEnvironment(Map.of("offset", "0", "limit", "1"))
+            .off();
+    final Rundown rundown = ReVoman.revUp(config);
+    assertThat(rundown.firstUnsuccessfulStepReport()).isNull();
+    assertThat(rundown.stepReports.size()).isAtLeast(4);
+  }
+}

--- a/src/integrationTest/java/com/salesforce/revoman/integration/restfulapidev/v3/RestfulAPIDevV3Test.java
+++ b/src/integrationTest/java/com/salesforce/revoman/integration/restfulapidev/v3/RestfulAPIDevV3Test.java
@@ -1,0 +1,34 @@
+/***************************************************************************************************
+ *  Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier:
+ *           Apache License Version 2.0
+ *  For full license text, see the LICENSE file in the repo root or
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ **************************************************************************************************/
+
+package com.salesforce.revoman.integration.restfulapidev.v3;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.salesforce.revoman.ReVoman;
+import com.salesforce.revoman.input.config.Kick;
+import com.salesforce.revoman.output.Rundown;
+import org.junit.jupiter.api.Test;
+
+class RestfulAPIDevV3Test {
+  private static final String PM_COLLECTION_PATH = "pm-templates/v3/restful-api.dev";
+  private static final String PM_ENVIRONMENT_PATH =
+      "pm-templates/v3/restful-api.dev/restful-api.dev.environment.yaml";
+
+  @Test
+  void executeRestfulApiDevV3CollectionFromJava() {
+    final Rundown rundown =
+        ReVoman.revUp(
+            Kick.configure()
+                .templatePath(PM_COLLECTION_PATH)
+                .environmentPath(PM_ENVIRONMENT_PATH)
+                .nodeModulesPath("js")
+                .off());
+    assertThat(rundown.firstUnsuccessfulStepReport()).isNull();
+    assertThat(rundown.stepReports.size()).isEqualTo(4);
+  }
+}

--- a/src/integrationTest/kotlin/com/salesforce/revoman/integration/apigee/v3/ApigeeKtTest.kt
+++ b/src/integrationTest/kotlin/com/salesforce/revoman/integration/apigee/v3/ApigeeKtTest.kt
@@ -1,0 +1,26 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.integration.apigee.v3
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.ReVoman
+import com.salesforce.revoman.input.config.Kick
+import org.junit.jupiter.api.Test
+
+class ApigeeKtTest {
+  @Test
+  fun testExecuteApigeeV3Collection() {
+    val rundown =
+      ReVoman.revUp(
+        Kick.configure().templatePath("pm-templates/v3/Apigee").nodeModulesPath("js").off()
+      )
+    assertThat(rundown.firstUnsuccessfulStepReport).isNull()
+    assertThat(rundown.stepReports).hasSize(1)
+    assertThat(rundown.mutableEnv["city"]).isNotNull()
+  }
+}

--- a/src/integrationTest/kotlin/com/salesforce/revoman/integration/pokemon/v3/PokemonKtTest.kt
+++ b/src/integrationTest/kotlin/com/salesforce/revoman/integration/pokemon/v3/PokemonKtTest.kt
@@ -1,0 +1,35 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.integration.pokemon.v3
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.ReVoman
+import com.salesforce.revoman.input.config.Kick
+import org.junit.jupiter.api.Test
+
+class PokemonKtTest {
+  @Test
+  fun testExecutePokemonV3Collection() {
+    val rundown =
+      ReVoman.revUp(
+        Kick.configure()
+          .templatePath(PM_COLLECTION_PATH)
+          .environmentPath(PM_ENVIRONMENT_PATH)
+          .nodeModulesPath("js")
+          .dynamicEnvironment(mapOf("offset" to "0", "limit" to "1"))
+          .off()
+      )
+    assertThat(rundown.firstUnsuccessfulStepReport).isNull()
+    assertThat(rundown.stepReports.size).isAtLeast(4)
+  }
+
+  companion object {
+    private const val PM_COLLECTION_PATH = "pm-templates/v3/pokemon"
+    private const val PM_ENVIRONMENT_PATH = "pm-templates/v3/pokemon/Pokemon.environment.yaml"
+  }
+}

--- a/src/integrationTest/kotlin/com/salesforce/revoman/integration/pokemon/v3/PokemonV2VsV3EquivalenceKtTest.kt
+++ b/src/integrationTest/kotlin/com/salesforce/revoman/integration/pokemon/v3/PokemonV2VsV3EquivalenceKtTest.kt
@@ -1,0 +1,44 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.integration.pokemon.v3
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.ReVoman
+import com.salesforce.revoman.input.config.Kick
+import org.junit.jupiter.api.Test
+
+class PokemonV2VsV3EquivalenceKtTest {
+  @Test
+  fun testV2AndV3PokemonProduceIdenticalEnvAndStepCount() {
+    val dynEnv = mapOf("offset" to "0", "limit" to "1")
+    val v2 =
+      ReVoman.revUp(
+        Kick.configure()
+          .templatePath("pm-templates/v2/pokemon/pokemon.postman_collection.json")
+          .environmentPath("pm-templates/v2/pokemon/pokemon.postman_environment.json")
+          .nodeModulesPath("js")
+          .dynamicEnvironment(dynEnv)
+          .off()
+      )
+    val v3 =
+      ReVoman.revUp(
+        Kick.configure()
+          .templatePath("pm-templates/v3/pokemon")
+          .environmentPath("pm-templates/v3/pokemon/Pokemon.environment.yaml")
+          .nodeModulesPath("js")
+          .dynamicEnvironment(dynEnv)
+          .off()
+      )
+    assertThat(v3.stepReports.size).isEqualTo(v2.stepReports.size)
+    val keysToCompare =
+      listOf("baseUrl", "id", "pokemonName", "color", "gender", "ability", "nature")
+    for (key in keysToCompare) {
+      assertThat(v3.mutableEnv[key]).isEqualTo(v2.mutableEnv[key])
+    }
+  }
+}

--- a/src/integrationTest/kotlin/com/salesforce/revoman/integration/restfulapidev/v3/RestfulAPIDevKtTest.kt
+++ b/src/integrationTest/kotlin/com/salesforce/revoman/integration/restfulapidev/v3/RestfulAPIDevKtTest.kt
@@ -1,0 +1,35 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.integration.restfulapidev.v3
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.ReVoman
+import com.salesforce.revoman.input.config.Kick
+import org.junit.jupiter.api.Test
+
+class RestfulAPIDevKtTest {
+  @Test
+  fun testExecuteRestfulApiDevV3Collection() {
+    val rundown =
+      ReVoman.revUp(
+        Kick.configure()
+          .templatePath(PM_COLLECTION_PATH)
+          .environmentPath(PM_ENVIRONMENT_PATH)
+          .nodeModulesPath("js")
+          .off()
+      )
+    assertThat(rundown.firstUnsuccessfulStepReport).isNull()
+    assertThat(rundown.stepReports).hasSize(4)
+  }
+
+  companion object {
+    private const val PM_COLLECTION_PATH = "pm-templates/v3/restful-api.dev"
+    private const val PM_ENVIRONMENT_PATH =
+      "pm-templates/v3/restful-api.dev/restful-api.dev.environment.yaml"
+  }
+}


### PR DESCRIPTION
## Summary
Adds 7 v3 integration tests covering both Kotlin and Java APIs.

| Test | Lang | What |
|---|---|---|
| `pokemon/v3/PokemonKtTest` | Kotlin | Smoke test on pokeapi.co |
| `pokemon/v3/PokemonV3Test` | Java | Same, from Java — proves API friendliness |
| `pokemon/v3/PokemonV2VsV3EquivalenceKtTest` | Kotlin | Same logical collection in v2 + v3 → identical Rundown |
| `pokemon/v3/PokemonV2VsV3EquivalenceTest` | Java | Same, from Java |
| `restfulapidev/v3/RestfulAPIDevKtTest` | Kotlin | Smoke test on api.restful-api.dev |
| `restfulapidev/v3/RestfulAPIDevV3Test` | Java | Same, from Java |
| `apigee/v3/ApigeeKtTest` | Kotlin | XML response + xml2json adapter |

Sub-package layout `.../integration/<feature>/v3/` keeps existing v2 tests untouched.

## Notes
- **Stacked on top of #350.** Merge order: 1/4 → 2/4 → 3/4 → 4/4.
- Java tests double as the API-surface contract: existing Kick / ReVoman / Rundown signatures must remain Java-callable.

## Test plan
- [x] `./gradlew integrationTest --tests \"com.salesforce.revoman.integration.pokemon.v3.*\"` — 4 pass
- [x] `./gradlew integrationTest --tests \"com.salesforce.revoman.integration.restfulapidev.v3.*\"` — 2 pass
- [x] `./gradlew integrationTest --tests \"com.salesforce.revoman.integration.apigee.v3.*\"` — 1 pass
- [x] `./gradlew spotlessCheck` — clean
- [ ] CI green