### PR TITLE
feat(ledger): step-level skip + warm-run inject (A+B)

### DIFF
--- a/src/integrationTest/kotlin/com/salesforce/revoman/integration/restfulapidev/v3/LedgerRoundTripKtTest.kt
+++ b/src/integrationTest/kotlin/com/salesforce/revoman/integration/restfulapidev/v3/LedgerRoundTripKtTest.kt
@@ -1,0 +1,122 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.integration.restfulapidev.v3
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.ReVoman
+import com.salesforce.revoman.input.config.Kick
+import com.salesforce.revoman.output.ledger.LedgerEntry
+import com.salesforce.revoman.output.ledger.LedgerSnapshot
+import org.junit.jupiter.api.Test
+
+/**
+ * End-to-end validation of the ledger warm-skip feature against the REAL public restful-api.dev API
+ * (no auth, free). Companion to the network-free [com.salesforce.revoman.LedgerSkipE2ETest] (which
+ * uses a JDK loopback server): this one proves the same cold→warm→skip cycle survives a real HTTP
+ * round-trip and a real V3-loaded `sourceHash`.
+ *
+ * Uses the **V3** collection `pm-templates/v3/restful-api.dev` on purpose: `Step.sourceHash` is
+ * computed only at V3 load (`V3Loader` → sha256 of each `.request.yaml`), so V3 steps carry a real,
+ * non-empty hash. The ledger-skip predicate
+ * ([com.salesforce.revoman.internal.exe.ledgerSkipDecision]) gates on non-empty hashes on BOTH
+ * sides, so only a V3 collection can demonstrate a genuine end-to-end skip. (The V2 JSON variant's
+ * steps would have `sourceHash == ""`, which can never match → no skip.)
+ *
+ * Producer step: `add-object` (POST /objects) whose `afterResponse` script does
+ * `pm.environment.set("objId"/"productName"/"data", ...)`. Downstream `update-object` (PATCH) and
+ * `get-object-by-id` (GET) consume `{{objId}}`.
+ */
+class LedgerRoundTripKtTest {
+
+  /** Cold run = LEARN: a real POST to restful-api.dev produces keys → they land in learnedLedger. */
+  @Test
+  fun `cold run learns producer keys from a real API call`() {
+    val cold = revUp()
+    // The real API succeeded for all 4 steps (no skip yet — EMPTY ledger).
+    assertThat(cold.firstUnsuccessfulStepReport).isNull()
+    assertThat(cold.stepReports).hasSize(4)
+
+    // learnedLedger is keyed on Step.path; the add-object entry carries the produced keys.
+    val producerEntry = cold.stepReports.first { it.envVars.produced.contains("objId") }
+    val learnedForProducer = cold.learnedLedger[producerEntry.step.path]
+    assertThat(learnedForProducer).isNotNull()
+    assertThat(learnedForProducer!!.produces).containsAtLeast("objId", "productName")
+    // V3 load computed a real, non-empty sourceHash — the precondition for warm-skip to ever fire.
+    assertThat(learnedForProducer.hash).isNotEmpty()
+    assertThat(learnedForProducer.hash).isEqualTo(producerEntry.step.sourceHash)
+  }
+
+  /**
+   * Warm run = SKIP + INJECT: with a ledger entry matching the producer's real path + sourceHash and
+   * its produced keys, the producer step's HTTP dispatch is SKIPPED and the ledgered values are
+   * injected into the env instead.
+   *
+   * HONEST CAVEAT against a real API: because `add-object` is skipped, `objId` comes from the ledger
+   * (a fixed, non-server id). The downstream PATCH/GET then call the REAL api.restful-api.dev with
+   * that ledgered id, which legitimately 404s (no such server-side object). That's fine — it does
+   * NOT undermine what we're validating (the PRODUCER step was skipped, no HTTP, value injected). So
+   * we deliberately do NOT assert `firstUnsuccessfulStepReport == null` on the warm run; we assert
+   * only the producer-step skip properties.
+   */
+  @Test
+  fun `warm run with ledger skips the producer step yet injects the ledgered value`() {
+    // 1. Cold run to obtain the producer step's REAL path + sourceHash (no hand-crafting).
+    val cold = revUp()
+    val producer = cold.stepReports.first { it.envVars.produced.contains("objId") }
+    val stepPath = producer.step.path
+    val hash = producer.step.sourceHash
+    // V3 → real sha256. (If this were ever empty, the skip predicate would refuse to fire.)
+    assertThat(hash).isNotEmpty()
+
+    // 2. Warm run: ledger says objId/productName already produced (with the REAL hash). The library
+    // seeds `ledger.values` into the env as the lowest-precedence floor, which satisfies the
+    // skip predicate's env-superset precondition — we do NOT pre-seed manually.
+    val ledgeredId = "ledgered-obj-id"
+    val snap =
+      LedgerSnapshot(
+        orgId = null,
+        steps = mapOf(stepPath to LedgerEntry(setOf("objId", "productName"), hash)),
+        values = mapOf("objId" to ledgeredId, "productName" to "Ledgered Widget"),
+      )
+    val warm = revUp(snap)
+
+    // The producer step was SKIPPED: recorded (not absent) but with NO HTTP req/resp info.
+    val skipped = warm.reportForStepName(stepPath)!!
+    assertThat(skipped.requestInfo).isNull()
+    assertThat(skipped.responseInfo).isNull()
+    assertThat(skipped.envVars.produced).containsAtLeast("objId", "productName")
+
+    // The ledgered value was injected into the env at skip time (so downstream {{objId}} resolves
+    // to it). We assert on the skipped step's pmEnvSnapshot — the env AS OF the skip+inject — NOT
+    // the final live env: against the REAL API the downstream PATCH (called with the ledgered id)
+    // 404s, and its `afterResponse` does pm.environment.set("objId", responseJson.id), clobbering
+    // the final live `objId` with the 404 body's (null) id. The snapshot is immune to that and is
+    // the authoritative proof that the inject ran.
+    assertThat(skipped.pmEnvSnapshot.getAsString("objId")).isEqualTo(ledgeredId)
+
+    // The warm run re-emits the skipped step's entry into learnedLedger against its current hash.
+    assertThat(warm.learnedLedger[stepPath])
+      .isEqualTo(LedgerEntry(setOf("objId", "productName"), hash))
+  }
+
+  private fun revUp(ledger: LedgerSnapshot? = null): com.salesforce.revoman.output.Rundown {
+    var builder =
+      Kick.configure()
+        .templatePath(PM_COLLECTION_PATH)
+        .environmentPath(PM_ENVIRONMENT_PATH)
+        .nodeModulesPath("js")
+    if (ledger != null) builder = builder.ledger(ledger)
+    return ReVoman.revUp(builder.off())
+  }
+
+  companion object {
+    private const val PM_COLLECTION_PATH = "pm-templates/v3/restful-api.dev"
+    private const val PM_ENVIRONMENT_PATH =
+      "pm-templates/v3/restful-api.dev/restful-api.dev.environment.yaml"
+  }
+}

--- a/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
+++ b/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
@@ -146,7 +146,10 @@ object ReVoman {
     val learnedLedger =
       stepNameToReport
         .filter { it.envVars.produced.isNotEmpty() }
-        .associate { it.step.path to LedgerEntry(it.envVars.produced, it.step.sourceHash) }
+        .associate {
+          it.step.path to
+            LedgerEntry(it.envVars.produced, it.step.sourceHash, it.envVars.consumed)
+        }
     return Rundown(
       stepNameToReport,
       pm.environment,
@@ -193,7 +196,7 @@ object ReVoman {
             }
           }
           return@fold stepReports +
-            StepReport.ledgerSkipped(step, skipEntry.produces, pm.environment)
+            StepReport.ledgerSkipped(step, skipEntry.produces, pm.environment, skipEntry.consumed)
         }
         if (
           entry != null &&

--- a/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
+++ b/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
@@ -48,6 +48,7 @@ import com.salesforce.revoman.output.ExeType.UNMARSHALL_REQUEST
 import com.salesforce.revoman.output.ExeType.UNMARSHALL_RESPONSE
 import com.salesforce.revoman.output.Rundown
 import com.salesforce.revoman.output.report.Step
+import com.salesforce.revoman.output.report.StepEnvVars
 import com.salesforce.revoman.output.report.StepReport
 import com.salesforce.revoman.output.report.StepReport.Companion.toVavr
 import com.salesforce.revoman.output.report.TxnInfo
@@ -249,6 +250,11 @@ object ReVoman {
               exeTimings = exeTimings,
               pmEnvSnapshot =
                 pm.environment.copy(mutableEnv = pm.environment.mutableEnv.toMutableMap()),
+              envVars =
+                StepEnvVars(
+                  produced = pm.environment.producedKeysFor(step),
+                  consumed = pm.environment.consumedKeysFor(step),
+                ),
             )
         haltExecution = shouldHaltExecution(currentStepReport, kick, pm.rundown)
         stepReports + currentStepReport

--- a/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
+++ b/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
@@ -143,6 +143,16 @@ object ReVoman {
       PostmanSDK(moshiReVoman, kick.nodeModulesPath(), regexReplacer, environment.toMutableMap())
     val stepNameToReport =
       executeStepsSerially(pmStepsDeepFlattened, kick, moshiReVoman, regexReplacer, pm)
+    // --- LEDGER CAPTURE CONTRACT (what becomes a ledgered producer) ---
+    // A step's `envVars` is snapshotted at the END of its fold iteration (below), AFTER its
+    // post-step hooks run, so a var a step-qualified PostStepHook/PreStepHook `.set()`s IS captured
+    // as produced BY that triggering step — matching the design intent that a hook-set var belongs
+    // to the step that qualified the hook. Two writes are intentionally NOT captured: (1) the
+    // delegated index-set `mutableEnv[k]=` (the same bypass the warm-skip inject uses, so reused
+    // keys are not re-recorded as produced), and (2) a var set in the collection-level PostExeHook,
+    // which fires in the OUTER kick-fold AFTER this learnedLedger is already frozen — it has no
+    // single triggering step, so it is excluded rather than mis-attributed. Hook producers that
+    // want to be ledgered must use `pm.environment.set(...)` from a step-qualified hook.
     val learnedLedger =
       stepNameToReport
         .filter { it.envVars.produced.isNotEmpty() }

--- a/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
+++ b/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
@@ -21,6 +21,7 @@ import com.salesforce.revoman.internal.exe.executePolling
 import com.salesforce.revoman.internal.exe.executePostResJS
 import com.salesforce.revoman.internal.exe.executePreReqJS
 import com.salesforce.revoman.internal.exe.fireHttpRequest
+import com.salesforce.revoman.internal.exe.ledgerSkipDecision
 import com.salesforce.revoman.internal.exe.postStepHookExe
 import com.salesforce.revoman.internal.exe.preStepHookExe
 import com.salesforce.revoman.internal.exe.shouldHaltExecution
@@ -47,6 +48,7 @@ import com.salesforce.revoman.output.ExeType.PRE_STEP_HOOK
 import com.salesforce.revoman.output.ExeType.UNMARSHALL_REQUEST
 import com.salesforce.revoman.output.ExeType.UNMARSHALL_RESPONSE
 import com.salesforce.revoman.output.Rundown
+import com.salesforce.revoman.output.ledger.LedgerEntry
 import com.salesforce.revoman.output.report.Step
 import com.salesforce.revoman.output.report.StepEnvVars
 import com.salesforce.revoman.output.report.StepReport
@@ -128,11 +130,16 @@ object ReVoman {
       PostmanSDK(moshiReVoman, kick.nodeModulesPath(), regexReplacer, environment.toMutableMap())
     val stepNameToReport =
       executeStepsSerially(pmStepsDeepFlattened, kick, moshiReVoman, regexReplacer, pm)
+    val learnedLedger =
+      stepNameToReport
+        .filter { it.envVars.produced.isNotEmpty() }
+        .associate { it.step.path to LedgerEntry(it.envVars.produced, it.step.sourceHash) }
     return Rundown(
       stepNameToReport,
       pm.environment,
       kick.haltOnFailureOfTypeExcept(),
       pmStepsDeepFlattened.size,
+      learnedLedger,
     )
   }
 
@@ -148,10 +155,34 @@ object ReVoman {
       .asSequence()
       .takeWhile { !haltExecution }
       .filter { shouldStepBePicked(it, kick.runOnlySteps(), kick.skipSteps()) }
-      .fold(listOf()) { stepReports, step ->
+      .fold(listOf<StepReport>()) { stepReports, step ->
+        pm.environment.currentStep = step
+        // --------### LEDGER WARM-PATH: skip+inject / warn-and-run ###--------
+        val ledger = kick.ledger()
+        val entry = ledger.steps[step.path]
+        val envKeys = pm.environment.keys
+        if (ledgerSkipDecision(step, ledger, envKeys)) {
+          logger.info { "***** Ledger-skip Step (reusing ${entry!!.produces}): $step *****" }
+          // Inject ledgered values via the delegated index-set (NOT `set()`), so the reused keys
+          // are NOT recorded as "produced" by this skipped step — keeps learnedLedger clean.
+          entry!!.produces.forEach { key -> pm.environment[key] = ledger.values[key] }
+          return@fold stepReports + StepReport.ledgerSkipped(step, entry.produces, pm.environment)
+        }
+        if (
+          entry != null &&
+            entry.produces.isNotEmpty() &&
+            entry.hash.isNotEmpty() &&
+            step.sourceHash.isNotEmpty() &&
+            entry.hash != step.sourceHash &&
+            envKeys.containsAll(entry.produces)
+        ) {
+          logger.warn {
+            "[ledger] stale: ${step.path} producer def changed " +
+              "(hash ${entry.hash} -> ${step.sourceHash}) -> running step, refreshing entry"
+          }
+        }
         logger.info { "***** Executing Step: $step *****" }
         val exeTimings: MutableMap<ExeType, Duration> = mutableMapOf()
-        pm.environment.currentStep = step
         val itemWithRegex = step.rawPMStep
         val preStepReport =
           StepReport(

--- a/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
+++ b/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
@@ -24,6 +24,7 @@ import com.salesforce.revoman.internal.exe.fireHttpRequest
 import com.salesforce.revoman.internal.exe.ledgerSkipDecision
 import com.salesforce.revoman.internal.exe.postStepHookExe
 import com.salesforce.revoman.internal.exe.preStepHookExe
+import com.salesforce.revoman.internal.exe.shadowedProducerPaths
 import com.salesforce.revoman.internal.exe.shouldHaltExecution
 import com.salesforce.revoman.internal.exe.shouldStepBePicked
 import com.salesforce.revoman.internal.exe.timed
@@ -177,17 +178,24 @@ object ReVoman {
     pm: PostmanSDK,
   ): List<StepReport> {
     var haltExecution = false
-    return pmStepsFlattened
+    val pickedSteps =
+      pmStepsFlattened.filter { shouldStepBePicked(it, kick.runOnlySteps(), kick.skipSteps()) }
+    // Collision guard (computed once over the picked steps in execution order): a key produced by
+    // >1 step is only safely ledger-skippable at its LAST producer. Earlier producers of a re-set
+    // key must always run, else a skipped earlier step would be injected with the LATER value and
+    // an intermediate consumer of the earlier value would read it wrong. Empty for collision-free
+    // collections (every key produced once) — zero behavior change there.
+    val shadowedPaths = shadowedProducerPaths(pickedSteps, kick.ledger())
+    return pickedSteps
       .asSequence()
       .takeWhile { !haltExecution }
-      .filter { shouldStepBePicked(it, kick.runOnlySteps(), kick.skipSteps()) }
       .fold(listOf<StepReport>()) { stepReports, step ->
         pm.environment.currentStep = step
         // --------### LEDGER WARM-PATH: skip+inject / warn-and-run ###--------
         val ledger = kick.ledger()
         val entry = ledger.steps[step.path]
         val envKeys = pm.environment.keys
-        if (ledgerSkipDecision(step, ledger, envKeys)) {
+        if (step.path !in shadowedPaths && ledgerSkipDecision(step, ledger, envKeys)) {
           val skipEntry = entry!!
           logger.info { "***** Ledger-skip Step (reusing ${skipEntry.produces}): $step *****" }
           // Inject ledgered values via the delegated index-set (NOT `set()`), so the reused keys

--- a/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
+++ b/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
@@ -124,8 +124,21 @@ object ReVoman {
         kick.customTypeAdaptersFromRequestConfig() + kick.customTypeAdaptersFromResponseConfig(),
         kick.globalSkipTypes(),
       )
+    // Seed the ledger snapshot's produced-key values as the lowest-precedence FLOOR: a real warm
+    // run satisfies the `ledgerSkipDecision` env-superset precondition only if the produced keys
+    // are
+    // already present in the env. `Map.plus` lets the right-hand side win on key clash, so the real
+    // env (mergeEnvs) OVERRIDES the ledger values — ledger is only a fallback. For non-ledger runs
+    // `kick.ledger().values` is empty (LedgerSnapshot.EMPTY), so this prepends an empty map =
+    // no-op.
+    val ledgerValues: Map<String, Any?> = kick.ledger().values
     val environment =
-      mergeEnvs(kick.environmentPaths(), kick.environmentInputStreams(), kick.dynamicEnvironment())
+      ledgerValues +
+        mergeEnvs(
+          kick.environmentPaths(),
+          kick.environmentInputStreams(),
+          kick.dynamicEnvironment(),
+        )
     val pm =
       PostmanSDK(moshiReVoman, kick.nodeModulesPath(), regexReplacer, environment.toMutableMap())
     val stepNameToReport =

--- a/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
+++ b/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
@@ -162,11 +162,25 @@ object ReVoman {
         val entry = ledger.steps[step.path]
         val envKeys = pm.environment.keys
         if (ledgerSkipDecision(step, ledger, envKeys)) {
-          logger.info { "***** Ledger-skip Step (reusing ${entry!!.produces}): $step *****" }
+          val skipEntry = entry!!
+          logger.info { "***** Ledger-skip Step (reusing ${skipEntry.produces}): $step *****" }
           // Inject ledgered values via the delegated index-set (NOT `set()`), so the reused keys
-          // are NOT recorded as "produced" by this skipped step — keeps learnedLedger clean.
-          entry!!.produces.forEach { key -> pm.environment[key] = ledger.values[key] }
-          return@fold stepReports + StepReport.ledgerSkipped(step, entry.produces, pm.environment)
+          // are NOT recorded as "produced" by this skipped step in the live per-step capture. A
+          // produced key absent from `ledger.values` (partial/corrupt ledger) is NOT injected as a
+          // silent null (which would stringify to "null" downstream): warn and leave the existing
+          // env value, which the env-superset precondition guarantees is present.
+          skipEntry.produces.forEach { key ->
+            if (ledger.values.containsKey(key)) {
+              pm.environment[key] = ledger.values[key]
+            } else {
+              logger.warn {
+                "[ledger] ${step.path} reuses produced key '$key' but it is missing from " +
+                  "ledger.values -> keeping existing env value, not injecting null"
+              }
+            }
+          }
+          return@fold stepReports +
+            StepReport.ledgerSkipped(step, skipEntry.produces, pm.environment)
         }
         if (
           entry != null &&

--- a/src/main/kotlin/com/salesforce/revoman/input/FileUtils.kt
+++ b/src/main/kotlin/com/salesforce/revoman/input/FileUtils.kt
@@ -79,6 +79,14 @@ fun readLedgerYaml(filePath: String): LedgerFile =
   V3YamlReader.readLedger(readFileToString(filePath))
 
 /**
+ * Read a flat top-level YAML mapping (e.g. a human-friendly `config.yaml` of `key: value` lines)
+ * into a plain map. Unlike [readLedgerYaml], this does NOT expect a postman-env `values` array.
+ * Returns an empty map for empty/blank content.
+ */
+fun readYamlMap(filePath: String): Map<String, Any?> =
+  V3YamlReader.readFlatMap(readFileToString(filePath))
+
+/**
  * Write a ledger file. `values` stays postman-importable; metadata in the `x-revoman-ledger`
  * sibling.
  */

--- a/src/main/kotlin/com/salesforce/revoman/input/FileUtils.kt
+++ b/src/main/kotlin/com/salesforce/revoman/input/FileUtils.kt
@@ -9,7 +9,10 @@
 
 package com.salesforce.revoman.input
 
+import com.salesforce.revoman.internal.postman.template.v3.V3YamlReader
+import com.salesforce.revoman.internal.postman.template.v3.V3YamlWriter
 import com.salesforce.revoman.internal.postman.template.v3.V3_DEFINITION_REL_PATH
+import com.salesforce.revoman.output.ledger.LedgerFile
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.InputStream
@@ -70,3 +73,14 @@ fun bufferV3Definition(collectionDir: String): BufferedSource {
       ?: throw FileNotFoundException("v3 collection not found on classpath: $collectionDir")
   return fs.source(p / V3_DEFINITION_REL_PATH).buffer()
 }
+
+/** Read a ledger file (postman-env `values` + `x-revoman-ledger` sibling). */
+fun readLedgerYaml(filePath: String): LedgerFile =
+  V3YamlReader.readLedger(readFileToString(filePath))
+
+/**
+ * Write a ledger file. `values` stays postman-importable; metadata in the `x-revoman-ledger`
+ * sibling.
+ */
+fun writeLedgerYaml(filePath: String, ledger: LedgerFile) =
+  writeToFile(filePath, V3YamlWriter.dump(ledger))

--- a/src/main/kotlin/com/salesforce/revoman/input/FileUtils.kt
+++ b/src/main/kotlin/com/salesforce/revoman/input/FileUtils.kt
@@ -81,7 +81,8 @@ fun readLedgerYaml(filePath: String): LedgerFile =
 /**
  * Read a flat top-level YAML mapping (e.g. a human-friendly `config.yaml` of `key: value` lines)
  * into a plain map. Unlike [readLedgerYaml], this does NOT expect a postman-env `values` array.
- * Returns an empty map for empty/blank content.
+ * Returns an empty map for empty/blank content OR for non-mapping content (a top-level list or bare
+ * scalar) — so a malformed config silently reads as empty rather than erroring.
  */
 fun readYamlMap(filePath: String): Map<String, Any?> =
   V3YamlReader.readFlatMap(readFileToString(filePath))

--- a/src/main/kotlin/com/salesforce/revoman/input/config/KickDef.kt
+++ b/src/main/kotlin/com/salesforce/revoman/input/config/KickDef.kt
@@ -12,6 +12,7 @@ import com.salesforce.revoman.input.config.StepPick.PostTxnStepPick
 import com.salesforce.revoman.input.config.StepPick.PreTxnStepPick
 import com.salesforce.revoman.output.ExeType
 import com.salesforce.revoman.output.Rundown
+import com.salesforce.revoman.output.ledger.LedgerSnapshot
 import com.salesforce.revoman.output.report.StepReport
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonAdapter.Factory
@@ -49,6 +50,8 @@ internal interface KickDef {
   fun runOnlySteps(): List<ExeStepPick>
 
   fun skipSteps(): List<ExeStepPick>
+
+  @Value.Default fun ledger(): LedgerSnapshot = LedgerSnapshot.EMPTY
 
   fun pollingConfig(): List<PollingConfig>
 

--- a/src/main/kotlin/com/salesforce/revoman/internal/exe/ExeUtils.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/exe/ExeUtils.kt
@@ -18,6 +18,7 @@ import com.salesforce.revoman.internal.postman.template.Item
 import com.salesforce.revoman.output.ExeType
 import com.salesforce.revoman.output.Rundown
 import com.salesforce.revoman.output.Rundown.Companion.isStepIgnoredForFailure
+import com.salesforce.revoman.output.ledger.LedgerSnapshot
 import com.salesforce.revoman.output.report.Folder
 import com.salesforce.revoman.output.report.Step
 import com.salesforce.revoman.output.report.StepReport
@@ -72,6 +73,19 @@ internal fun shouldStepBePicked(
     return false
   }
   return runOnlySteps.isEmpty() || explicitlyRunStep
+}
+
+/**
+ * Ledger-skip predicate: skip a step's HTTP dispatch iff the ledger has an entry for it whose
+ * produced keys are ALL already in [env] AND whose producer fingerprint matches the step's current
+ * [Step.sourceHash]. Empty-produces entries are NEVER skippable (read-only steps must always run);
+ * a hash mismatch falls through to run (warn-and-run, handled by the caller).
+ */
+internal fun ledgerSkipDecision(step: Step, ledger: LedgerSnapshot, env: Set<String>): Boolean {
+  val entry = ledger.steps[step.path] ?: return false
+  if (entry.produces.isEmpty()) return false
+  if (entry.hash != step.sourceHash) return false
+  return env.containsAll(entry.produces)
 }
 
 internal fun <T> runCatching(

--- a/src/main/kotlin/com/salesforce/revoman/internal/exe/ExeUtils.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/exe/ExeUtils.kt
@@ -79,11 +79,15 @@ internal fun shouldStepBePicked(
  * Ledger-skip predicate: skip a step's HTTP dispatch iff the ledger has an entry for it whose
  * produced keys are ALL already in [env] AND whose producer fingerprint matches the step's current
  * [Step.sourceHash]. Empty-produces entries are NEVER skippable (read-only steps must always run);
- * a hash mismatch falls through to run (warn-and-run, handled by the caller).
+ * a hash mismatch falls through to run (warn-and-run, handled by the caller). An EMPTY hash on
+ * either side is treated as "unknown" and never matches — a real v3-loaded step and a real ledgered
+ * entry both carry a computed sha256, so an empty hash can only come from a non-v3 step or a
+ * corrupt/hand-crafted ledger; in that case we must run, not skip on an incidental "" == "".
  */
 internal fun ledgerSkipDecision(step: Step, ledger: LedgerSnapshot, env: Set<String>): Boolean {
   val entry = ledger.steps[step.path] ?: return false
   if (entry.produces.isEmpty()) return false
+  if (entry.hash.isEmpty() || step.sourceHash.isEmpty()) return false
   if (entry.hash != step.sourceHash) return false
   return env.containsAll(entry.produces)
 }

--- a/src/main/kotlin/com/salesforce/revoman/internal/exe/ExeUtils.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/exe/ExeUtils.kt
@@ -47,7 +47,7 @@ internal fun deepFlattenItems(
           val currentFolder = Folder(item.name, parentFolder)
           parentFolder?.subFolders?.add(currentFolder)
           deepFlattenItems(it, currentFolder, stepIndex)
-        } ?: listOf(Step(stepIndex, item, parentFolder))
+        } ?: listOf(Step(stepIndex, item, parentFolder, item.sourceHash))
     }
     .toList()
 

--- a/src/main/kotlin/com/salesforce/revoman/internal/exe/ExeUtils.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/exe/ExeUtils.kt
@@ -92,6 +92,39 @@ internal fun ledgerSkipDecision(step: Step, ledger: LedgerSnapshot, env: Set<Str
   return env.containsAll(entry.produces)
 }
 
+/**
+ * Collision guard: the set of step paths that must NOT be ledger-skipped because they are an
+ * EARLIER producer of a key that a LATER step also produces. Skipping such a step would inject the
+ * LATER (final) value in place of the value the earlier step actually wrote — and any step BETWEEN
+ * them that consumed the earlier value would then read the wrong value (silently wrong, no loud
+ * failure). So only the LAST producer of a re-set key is safely skippable; every earlier producer
+ * of it always runs.
+ *
+ * Pure over the run's picked steps in EXECUTION ORDER ([orderedSteps]) and the [ledger]: a step is
+ * shadowed iff ANY key in its ledgered `produces` is also produced by a step appearing later in
+ * [orderedSteps]. Steps with no ledger entry are ignored (they run anyway). Collision-free
+ * collections (every key produced by exactly one step) yield an empty set — zero behavior change.
+ */
+internal fun shadowedProducerPaths(
+  orderedSteps: List<Step>,
+  ledger: LedgerSnapshot,
+): Set<String> {
+  // Last execution index at which each key is produced (by any ledgered step).
+  val lastProducerIndexByKey = mutableMapOf<String, Int>()
+  orderedSteps.forEachIndexed { index, step ->
+    ledger.steps[step.path]?.produces?.forEach { key -> lastProducerIndexByKey[key] = index }
+  }
+  return orderedSteps
+    .asSequence()
+    .withIndex()
+    .filter { (index, step) ->
+      ledger.steps[step.path]?.produces?.any { key -> lastProducerIndexByKey[key]!! > index }
+        ?: false
+    }
+    .map { (_, step) -> step.path }
+    .toSet()
+}
+
 internal fun <T> runCatching(
   currentStep: Step,
   exeType: ExeType,

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/RegexReplacer.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/RegexReplacer.kt
@@ -46,6 +46,7 @@ class RegexReplacer(
           }
           ?: replaceVariablesRecursively(pm.environment.getAsString(variableKey), pm)?.also { value
             ->
+            pm.environment.recordConsumed(variableKey)
             setItBackInEnvironment(variableKey, value, pm)
           }
           ?: variable.value

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/template/Template.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/template/Template.kt
@@ -29,6 +29,13 @@ data class Item(
   val item: List<Item>? = null,
   val request: Request = Request(),
   val event: List<Event>? = null,
+  /**
+   * Transient (not part of the Postman schema) sha256 of this item's `.request.yaml` source,
+   * populated for v3-loaded leaf items. Carried forward to [Step.sourceHash]. "" when unknown.
+   */
+  @field:[com.squareup.moshi.Json(ignore = true)]
+  @JvmField
+  val sourceHash: String = "",
 ) {
   @JvmField val httpMethod = request.method
 }

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3Loader.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3Loader.kt
@@ -66,14 +66,16 @@ internal object V3Loader {
       children
         .filter { fs.metadataOrNull(it)?.isRegularFile == true && it.name.endsWith(REQUEST_SUFFIX) }
         .map { file ->
-          val v3req = V3YamlReader.readRequest(fs.source(file).buffer().readUtf8())
+          val rawYaml = fs.source(file).buffer().readUtf8()
+          val v3req = V3YamlReader.readRequest(rawYaml)
           val fallbackName = file.name.removeSuffix(REQUEST_SUFFIX)
           val item =
             V3ToV2Converter.toItem(
-              v3req,
-              fallbackName = fallbackName,
-              inheritedAuth = effectiveAuth,
-            )
+                v3req,
+                fallbackName = fallbackName,
+                inheritedAuth = effectiveAuth,
+              )
+              .copy(sourceHash = sha256Hex(rawYaml))
           item to (v3req.order ?: Int.MAX_VALUE)
         }
 
@@ -102,5 +104,10 @@ internal object V3Loader {
     readDefOrNull(dir, fs)
       ?: error("Not a v3 collection root: $dir. Missing $V3_DEFINITION_REL_PATH")
 }
+
+internal fun sha256Hex(s: String): String =
+  java.security.MessageDigest.getInstance("SHA-256")
+    .digest(s.toByteArray(Charsets.UTF_8))
+    .joinToString("") { "%02x".format(it) }
 
 private val logger = KotlinLogging.logger {}

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3YamlReader.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3YamlReader.kt
@@ -7,6 +7,8 @@
  */
 package com.salesforce.revoman.internal.postman.template.v3
 
+import com.salesforce.revoman.output.ledger.LedgerEntry
+import com.salesforce.revoman.output.ledger.LedgerFile
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.yaml.snakeyaml.Yaml
 
@@ -34,6 +36,32 @@ internal object V3YamlReader {
             value = m["value"]?.toString(),
           )
         },
+    )
+  }
+
+  fun readLedger(yaml: String): LedgerFile {
+    val map = parseYaml(yaml)
+    @Suppress("UNCHECKED_CAST")
+    val values = (map["values"] as? List<Map<String, Any?>>) ?: emptyList()
+    val valueMap =
+      values.associate { m ->
+        (m["key"]?.toString() ?: error("ledger value missing 'key'")) to m["value"]?.toString()
+      }
+    @Suppress("UNCHECKED_CAST")
+    val ledgerMeta = (map["x-revoman-ledger"] as? Map<String, Any?>) ?: emptyMap()
+    @Suppress("UNCHECKED_CAST")
+    val stepsRaw = (ledgerMeta["steps"] as? Map<String, Map<String, Any?>>) ?: emptyMap()
+    val steps =
+      stepsRaw.mapValues { (_, e) ->
+        @Suppress("UNCHECKED_CAST")
+        val produces = (e["produces"] as? List<Any?>)?.map { it.toString() }?.toSet() ?: emptySet()
+        LedgerEntry(produces, e["hash"]?.toString() ?: "")
+      }
+    return LedgerFile(
+      name = map["name"]?.toString(),
+      values = valueMap,
+      orgId = ledgerMeta["orgId"]?.toString(),
+      steps = steps,
     )
   }
 

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3YamlReader.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3YamlReader.kt
@@ -39,6 +39,9 @@ internal object V3YamlReader {
     )
   }
 
+  /** Parse a flat top-level YAML mapping (e.g. a config file) to a plain map. */
+  fun readFlatMap(yaml: String): Map<String, Any?> = parseYaml(yaml)
+
   fun readLedger(yaml: String): LedgerFile {
     val map = parseYaml(yaml)
     @Suppress("UNCHECKED_CAST")

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3YamlReader.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3YamlReader.kt
@@ -39,7 +39,10 @@ internal object V3YamlReader {
     )
   }
 
-  /** Parse a flat top-level YAML mapping (e.g. a config file) to a plain map. */
+  /**
+   * Parse a flat top-level YAML mapping (e.g. a config file) to a plain map. Non-mapping content (a
+   * top-level list or bare scalar) and empty/blank input yield an empty map.
+   */
   fun readFlatMap(yaml: String): Map<String, Any?> = parseYaml(yaml)
 
   fun readLedger(yaml: String): LedgerFile {

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3YamlReader.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3YamlReader.kt
@@ -61,7 +61,9 @@ internal object V3YamlReader {
       stepsRaw.mapValues { (_, e) ->
         @Suppress("UNCHECKED_CAST")
         val produces = (e["produces"] as? List<Any?>)?.map { it.toString() }?.toSet() ?: emptySet()
-        LedgerEntry(produces, e["hash"]?.toString() ?: "")
+        @Suppress("UNCHECKED_CAST")
+        val consumed = (e["consumed"] as? List<Any?>)?.map { it.toString() }?.toSet() ?: emptySet()
+        LedgerEntry(produces, e["hash"]?.toString() ?: "", consumed)
       }
     return LedgerFile(
       name = map["name"]?.toString(),

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3YamlWriter.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3YamlWriter.kt
@@ -1,0 +1,37 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.postman.template.v3
+
+import com.salesforce.revoman.output.ledger.LedgerFile
+import org.yaml.snakeyaml.DumperOptions
+import org.yaml.snakeyaml.Yaml
+
+internal object V3YamlWriter {
+  fun dump(file: LedgerFile): String {
+    val root = linkedMapOf<String, Any?>()
+    file.name?.let { root["name"] = it }
+    // `values` in postman-env shape so the file imports into Postman unchanged.
+    root["values"] =
+      file.values.map { (k, v) -> linkedMapOf("key" to k, "value" to v, "enabled" to true) }
+    // `x-revoman-ledger` is a SIBLING of `values` — Postman ignores it, readLedger reads it.
+    root["x-revoman-ledger"] =
+      linkedMapOf(
+        "orgId" to file.orgId,
+        "steps" to
+          file.steps.mapValues { (_, e) ->
+            linkedMapOf("produces" to e.produces.toList(), "hash" to e.hash)
+          },
+      )
+    val opts =
+      DumperOptions().apply {
+        defaultFlowStyle = DumperOptions.FlowStyle.BLOCK
+        isPrettyFlow = true
+      }
+    return Yaml(opts).dump(root)
+  }
+}

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3YamlWriter.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3YamlWriter.kt
@@ -24,7 +24,11 @@ internal object V3YamlWriter {
         "orgId" to file.orgId,
         "steps" to
           file.steps.mapValues { (_, e) ->
-            linkedMapOf("produces" to e.produces.toList(), "hash" to e.hash)
+            linkedMapOf<String, Any?>("produces" to e.produces.toList(), "hash" to e.hash).apply {
+              // `consumed` is provenance metadata — emit only when non-empty so files stay tidy;
+              // an absent key parses back to an empty set (round-trip-equal).
+              if (e.consumed.isNotEmpty()) this["consumed"] = e.consumed.toList()
+            }
           },
       )
     val opts =

--- a/src/main/kotlin/com/salesforce/revoman/output/Rundown.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/Rundown.kt
@@ -8,6 +8,7 @@
 package com.salesforce.revoman.output
 
 import com.salesforce.revoman.input.config.StepPick.PostTxnStepPick
+import com.salesforce.revoman.output.ledger.LedgerEntry
 import com.salesforce.revoman.output.postman.PostmanEnvironment
 import com.salesforce.revoman.output.report.Folder.Companion.FOLDER_DELIMITER
 import com.salesforce.revoman.output.report.StepReport
@@ -17,6 +18,7 @@ data class Rundown(
   @JvmField val mutableEnv: PostmanEnvironment<Any?>,
   private val haltOnFailureOfTypeExcept: Map<ExeType, PostTxnStepPick?>,
   @JvmField val providedStepsToExecuteCount: Int,
+  @JvmField val learnedLedger: Map<String, LedgerEntry> = emptyMap(),
 ) {
   @get:JvmName("immutableEnv") val immutableEnv: Map<String, Any?> by lazy { mutableEnv.toMap() }
 

--- a/src/main/kotlin/com/salesforce/revoman/output/ledger/Ledger.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/ledger/Ledger.kt
@@ -7,8 +7,22 @@
  */
 package com.salesforce.revoman.output.ledger
 
-/** One ledgered step: which env keys it produced + a fingerprint of its producer definition. */
-data class LedgerEntry(@JvmField val produces: Set<String>, @JvmField val hash: String)
+/**
+ * One ledgered step: which env keys it produced + a fingerprint of its producer definition, plus
+ * the keys it consumed (read via `{{key}}`). [consumed] is provenance/transparency only — it does
+ * NOT gate the skip decision (that is [produces] + [hash]); it yields a self-documenting
+ * producer→consumer graph. Last positionally + defaulted so the historical `(produces, hash)`
+ * constructor stays source-compatible.
+ */
+data class LedgerEntry
+@JvmOverloads
+constructor(
+  @JvmField val produces: Set<String>,
+  @JvmField val hash: String,
+  // `@JvmOverloads` keeps the historical 2-arg `LedgerEntry(produces, hash)` constructor visible to
+  // Java callers — a Kotlin default alone only telescopes for Kotlin callers, not Java.
+  @JvmField val consumed: Set<String> = emptySet(),
+)
 
 /** What revUp consults on a warm run: per-step entries (keyed on `Step.path`) + produced values. */
 data class LedgerSnapshot(

--- a/src/main/kotlin/com/salesforce/revoman/output/ledger/Ledger.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/ledger/Ledger.kt
@@ -1,0 +1,40 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.output.ledger
+
+/** One ledgered step: which env keys it produced + a fingerprint of its producer definition. */
+data class LedgerEntry(@JvmField val produces: Set<String>, @JvmField val hash: String)
+
+/** What revUp consults on a warm run: per-step entries (keyed on `Step.path`) + produced values. */
+data class LedgerSnapshot(
+  @JvmField val orgId: String?,
+  @JvmField val steps: Map<String, LedgerEntry>,
+  @JvmField val values: Map<String, String?>,
+) {
+  companion object {
+    @JvmField val EMPTY = LedgerSnapshot(null, emptyMap(), emptyMap())
+  }
+}
+
+/**
+ * The full ledger file: postman-env `values` (importable) + the `x-revoman-ledger` sibling. [name]
+ * is the postman-env name; [values] are the produced-key values; [orgId]/[steps] are the sibling
+ * metadata.
+ */
+data class LedgerFile(
+  @JvmField val name: String?,
+  @JvmField val values: Map<String, String?>,
+  @JvmField val orgId: String?,
+  @JvmField val steps: Map<String, LedgerEntry>,
+) {
+  fun toSnapshot(): LedgerSnapshot = LedgerSnapshot(orgId, steps, values)
+
+  companion object {
+    @JvmField val EMPTY = LedgerFile(null, emptyMap(), null, emptyMap())
+  }
+}

--- a/src/main/kotlin/com/salesforce/revoman/output/postman/PostmanEnvironment.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/postman/PostmanEnvironment.kt
@@ -28,6 +28,22 @@ constructor(
 
   internal lateinit var currentStep: Step
 
+  // --- Ledger capture: per-step produced/consumed env keys. Keyed by Step identity so a
+  //     reused-thread env can carry multiple steps' deltas; read out when StepReport is built. ---
+  private val producedKeysByStep: MutableMap<Step, MutableSet<String>> = mutableMapOf()
+  private val consumedKeysByStep: MutableMap<Step, MutableSet<String>> = mutableMapOf()
+
+  fun producedKeysFor(step: Step): Set<String> = producedKeysByStep[step]?.toSet() ?: emptySet()
+
+  fun consumedKeysFor(step: Step): Set<String> = consumedKeysByStep[step]?.toSet() ?: emptySet()
+
+  /** Record a READ of [key] during the current step (regex `{{key}}` resolved against env). */
+  fun recordConsumed(key: String) {
+    if (::currentStep.isInitialized) {
+      consumedKeysByStep.getOrPut(currentStep) { mutableSetOf() }.add(key)
+    }
+  }
+
   @get:JvmName("immutableEnv") val immutableEnv: Map<String, ValueT> by lazy { mutableEnv.toMap() }
 
   @get:JvmName("postmanEnvJSONFormat")
@@ -37,6 +53,9 @@ constructor(
 
   fun set(key: String, value: ValueT) {
     mutableEnv[key] = value
+    if (::currentStep.isInitialized) {
+      producedKeysByStep.getOrPut(currentStep) { mutableSetOf() }.add(key)
+    }
     logger.info {
       "pm environment variable set in Step: $currentStep - key: $key, value: ${pprint(value)}"
     }
@@ -45,6 +64,7 @@ constructor(
   @Suppress("unused")
   fun unset(key: String) {
     mutableEnv.remove(key)
+    if (::currentStep.isInitialized) producedKeysByStep[currentStep]?.remove(key)
     logger.info { "pm environment variable unset through JS in Step: $currentStep - key: $key" }
   }
 

--- a/src/main/kotlin/com/salesforce/revoman/output/report/Step.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/report/Step.kt
@@ -16,6 +16,8 @@ data class Step(
   @JvmField val index: String,
   @JvmField val rawPMStep: Item,
   @JvmField val parentFolder: Folder? = null,
+  /** sha256 of this step's `.request.yaml` source; "" when unknown. Staleness fingerprint. */
+  @JvmField val sourceHash: String = "",
 ) {
   @JvmField val name: String = rawPMStep.name
   @JvmField var preStepHookCount: Int = 0

--- a/src/main/kotlin/com/salesforce/revoman/output/report/StepEnvVars.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/report/StepEnvVars.kt
@@ -1,0 +1,19 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.output.report
+
+/**
+ * Env keys a step touched during execution. Vocabulary aligns with the ledger producer/consumer
+ * thesis: producers WRITE ids (skippable on reuse); consumers/asserters only READ.
+ */
+data class StepEnvVars(
+  /** Keys WRITTEN via `pm.environment.set(...)` / beforeRequest. The producer signal. */
+  @JvmField val produced: Set<String> = emptySet(),
+  /** Keys READ via `{{key}}` substitution or pm getters. Idea-3 mutation-set fuel. */
+  @JvmField val consumed: Set<String> = emptySet(),
+)

--- a/src/main/kotlin/com/salesforce/revoman/output/report/StepReport.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/report/StepReport.kt
@@ -75,6 +75,23 @@ internal constructor(
     failure?.fold({ it !is PostStepHookFailure }, { true }) != true
 
   companion object {
+    /**
+     * A RECORDED report for a step whose HTTP dispatch was skipped on a warm run because the ledger
+     * already carried its [produced] keys (reused, not re-executed). [env] is snapshotted so the
+     * report reflects the env AFTER the ledgered values were injected.
+     */
+    @JvmStatic
+    fun ledgerSkipped(
+      step: Step,
+      produced: Set<String>,
+      env: PostmanEnvironment<Any?>,
+    ): StepReport =
+      StepReport(
+        step = step,
+        pmEnvSnapshot = env.copy(mutableEnv = env.mutableEnv.toMutableMap()),
+        envVars = StepEnvVars(produced = produced),
+      )
+
     private fun failure(
       requestInfo: Either<out ExeFailure, TxnInfo<Request>>? = null,
       preStepHookFailure: PreStepHookFailure? = null,

--- a/src/main/kotlin/com/salesforce/revoman/output/report/StepReport.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/report/StepReport.kt
@@ -36,6 +36,7 @@ internal constructor(
   @JvmField val pollingReport: PollingReport? = null,
   @JvmField val exeTimings: Map<ExeType, Duration> = emptyMap(),
   @JvmField val pmEnvSnapshot: PostmanEnvironment<Any?>,
+  @JvmField val envVars: StepEnvVars = StepEnvVars(),
 ) {
   internal constructor(
     step: Step,

--- a/src/main/kotlin/com/salesforce/revoman/output/report/StepReport.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/report/StepReport.kt
@@ -78,18 +78,22 @@ internal constructor(
     /**
      * A RECORDED report for a step whose HTTP dispatch was skipped on a warm run because the ledger
      * already carried its [produced] keys (reused, not re-executed). [env] is snapshotted so the
-     * report reflects the env AFTER the ledgered values were injected.
+     * report reflects the env AFTER the ledgered values were injected. [consumed] is carried through
+     * from the reused ledger entry so the re-emitted `learnedLedger` keeps the provenance graph —
+     * otherwise a warm-run merge (last-write-wins) would erase consumed on every loop.
      */
     @JvmStatic
+    @JvmOverloads
     fun ledgerSkipped(
       step: Step,
       produced: Set<String>,
       env: PostmanEnvironment<Any?>,
+      consumed: Set<String> = emptySet(),
     ): StepReport =
       StepReport(
         step = step,
         pmEnvSnapshot = env.copy(mutableEnv = env.mutableEnv.toMutableMap()),
-        envVars = StepEnvVars(produced = produced),
+        envVars = StepEnvVars(produced = produced, consumed = consumed),
       )
 
     private fun failure(

--- a/src/test/kotlin/com/salesforce/revoman/LedgerSkipE2ETest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/LedgerSkipE2ETest.kt
@@ -74,11 +74,12 @@ class LedgerSkipE2ETest {
       )
 
     // The skip predicate requires the produced keys to ALREADY be in env (env-superset). In the
-    // real warm flow the ledger file's `values` are imported into the postman env up front; here we
-    // simulate that precondition with a placeholder, then assert the skip branch OVERWRITES it with
-    // the authoritative ledgered value (proving the inject ran, not the HTTP-producing step).
+    // real warm flow `revUp` seeds the ledger snapshot's `values` into the env up front (as the
+    // lowest-precedence floor), which is what satisfies that precondition — no manual pre-seed. We
+    // pass ONLY the snapshot and assert the skip branch injected the authoritative ledgered value
+    // (proving the seeding + inject ran, not the HTTP-producing step).
     val hitsBefore = serverHits.get()
-    val warm = ReVoman.revUp(kick(snap, producedKey to "PLACEHOLDER"))
+    val warm = ReVoman.revUp(kick(snap)) // NO producedKey pre-seed — ledger.values must seed it
 
     // The single step was skipped -> ZERO requests reached the loopback server. This structurally
     // proves "skipped, not run", independent of the report shape.

--- a/src/test/kotlin/com/salesforce/revoman/LedgerSkipE2ETest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/LedgerSkipE2ETest.kt
@@ -195,6 +195,58 @@ class LedgerSkipE2ETest {
   }
 
   @Test
+  fun `collision guard - earlier producer of a re-set key still runs on a warm run, only the last is skipped`() {
+    val collision = "pm-templates/v3/ledger-collision"
+    // Cold run to learn the two real step paths + hashes.
+    val cold =
+      ReVoman.revUp(
+        Kick.configure()
+          .templatePath(collision)
+          .dynamicEnvironment("baseUrl", baseUrl)
+          .insecureHttp(true)
+          .off()
+      )
+    val early = cold.stepReports[0].step
+    val late = cold.stepReports[1].step
+    assertThat(early.name).contains("early")
+    assertThat(late.name).contains("late")
+
+    // Warm ledger: BOTH steps produce `sharedId`, with `sharedId` already present in env so the
+    // env-superset precondition is met for both. Without the collision guard, the EARLY step would
+    // be skipped + injected with the final value — wrong. The guard must keep EARLY running.
+    val snap =
+      LedgerSnapshot(
+        orgId = null,
+        steps =
+          mapOf(
+            early.path to LedgerEntry(setOf("sharedId"), early.sourceHash),
+            late.path to LedgerEntry(setOf("sharedId"), late.sourceHash),
+          ),
+        values = mapOf("sharedId" to "LEDGERED"),
+      )
+    val hitsBefore = serverHits.get()
+    val warm =
+      ReVoman.revUp(
+        Kick.configure()
+          .templatePath(collision)
+          .dynamicEnvironment("baseUrl", baseUrl)
+          .insecureHttp(true)
+          .ledger(snap)
+          .off()
+      )
+
+    val earlyReport = warm.reportForStepName(early.path)!!
+    val lateReport = warm.reportForStepName(late.path)!!
+    // EARLY ran (shadowed by the later producer of sharedId): it made a real HTTP request.
+    assertThat(earlyReport.requestInfo).isNotNull()
+    // LATE was ledger-skipped (last producer, safe): no HTTP.
+    assertThat(lateReport.requestInfo).isNull()
+    assertThat(lateReport.responseInfo).isNull()
+    // Exactly ONE request reached the server (early only, not late).
+    assertThat(serverHits.get()).isEqualTo(hitsBefore + 1)
+  }
+
+  @Test
   fun `learnedLedger entry carries the keys a producing step consumed (provenance)`() {
     // A step that reads {{seedKey}} (consumed) in its URL AND sets producedId (produced). The
     // learned entry must record BOTH: produces for skip, consumed for the provenance graph.

--- a/src/test/kotlin/com/salesforce/revoman/LedgerSkipE2ETest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/LedgerSkipE2ETest.kt
@@ -123,6 +123,78 @@ class LedgerSkipE2ETest {
   }
 
   @Test
+  fun `a var set in a PostStepHook attributes to the triggering step's produces`() {
+    // The user's design position: a var set inside a step-qualified hook belongs to that step's
+    // ledger entry. PostStepHook fires INSIDE the step fold (currentStep still the triggering
+    // step), so a hook .set() must be captured as produced BY that step.
+    val kick =
+      Kick.configure()
+        .templatePath(collection) // single GET step, produces nothing on its own
+        .dynamicEnvironment("baseUrl", baseUrl)
+        .insecureHttp(true)
+        .hooks(
+          com.salesforce.revoman.input.config.HookConfig.post(
+            com.salesforce.revoman.input.config.StepPick.PostTxnStepPick.afterStepName("produce-id")
+          ) { stepReport, rundown ->
+            rundown.mutableEnv.set("hookProducedId", "H1")
+          }
+        )
+        .off()
+    val rundown = ReVoman.revUp(kick)
+    val stepPath = rundown.stepReports.first().step.path
+    assertThat(rundown.learnedLedger[stepPath]!!.produces).contains("hookProducedId")
+  }
+
+  @Test
+  fun `a var set in a collection-level PostExeHook does NOT leak into any step's learned ledger`() {
+    // The collection-level PostExeHook fires in the OUTER kick-fold (ReVoman.kt:85), AFTER each
+    // kick's learnedLedger is already frozen (:151). So a var it sets cannot retroactively attach
+    // to any step's ledger entry. This LOCKS that a PostExeHook write is excluded from the
+    // persisted ledger (not mis-attributed to a stale step) — the safe outcome.
+    val kick =
+      Kick.configure()
+        .templatePath(collection)
+        .dynamicEnvironment("baseUrl", baseUrl)
+        .insecureHttp(true)
+        .off()
+    val rundowns =
+      ReVoman.revUp(
+        listOf(kick),
+        { currentRundown, _ -> currentRundown.mutableEnv.set("postExeHookId", "PEH1") },
+      )
+    val learned = rundowns.single().learnedLedger
+    // No step entry claims to produce the PostExeHook-set key.
+    assertThat(learned.values.flatMap { it.produces }).doesNotContain("postExeHookId")
+  }
+
+  @Test
+  fun `a PostStepHook index-set write is NOT captured as produced (only set() is)`() {
+    // Capture contract: only pm.environment.set(...) records a produced key. The delegated
+    // index-set (mutableEnv[k]=) is intentionally bypassed — that is the SAME bypass the warm-skip
+    // inject relies on (ReVoman.kt:187 injects via index-set so reused keys are not re-recorded as
+    // produced). A hook that writes via index-set is therefore invisible to the ledger BY DESIGN;
+    // hook producers must use .set() to be ledgered.
+    val kick =
+      Kick.configure()
+        .templatePath(collection)
+        .dynamicEnvironment("baseUrl", baseUrl)
+        .insecureHttp(true)
+        .hooks(
+          com.salesforce.revoman.input.config.HookConfig.post(
+            com.salesforce.revoman.input.config.StepPick.PostTxnStepPick.afterStepName("produce-id")
+          ) { _, rundown ->
+            rundown.mutableEnv["indexSetId"] = "IDX1" // index-set, NOT .set()
+          }
+        )
+        .off()
+    val rundown = ReVoman.revUp(kick)
+    // The key IS in the env (the write happened)...
+    assertThat(rundown.mutableEnv.getAsString("indexSetId")).isEqualTo("IDX1")
+    // ...but no step claims to PRODUCE it (index-set is not captured).
+    assertThat(rundown.learnedLedger.values.flatMap { it.produces }).doesNotContain("indexSetId")
+  }
+
+  @Test
   fun `learnedLedger entry carries the keys a producing step consumed (provenance)`() {
     // A step that reads {{seedKey}} (consumed) in its URL AND sets producedId (produced). The
     // learned entry must record BOTH: produces for skip, consumed for the provenance graph.

--- a/src/test/kotlin/com/salesforce/revoman/LedgerSkipE2ETest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/LedgerSkipE2ETest.kt
@@ -11,36 +11,55 @@ import com.google.common.truth.Truth.assertThat
 import com.salesforce.revoman.input.config.Kick
 import com.salesforce.revoman.output.ledger.LedgerEntry
 import com.salesforce.revoman.output.ledger.LedgerSnapshot
+import com.sun.net.httpserver.HttpServer
+import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 
 /**
  * E2E for the warm-path centerpiece in [ReVoman.executeStepsSerially]: ledger-skip + inject, and
  * [com.salesforce.revoman.output.Rundown.learnedLedger] emission.
  *
- * Fixture: `pm-templates/v3/flat` — 3 v3 steps (`a`, `b`, `c`) each a plain GET to example.com with
- * no `pm.environment.set(...)`, so none of them PRODUCE env keys. That's exactly what makes the
- * skip-path test offline: a ledgered, hash-matching, produced-keys-present entry makes the
- * producing step's HTTP dispatch get SKIPPED — no network. We bootstrap the step's
- * `path`/`sourceHash` from a cold run's step reports (the v3 loader computes a real sha256
- * fingerprint).
+ * Network-free by design: a JDK [HttpServer] is bound to loopback on an ephemeral port in
+ * [BeforeAll] and torn down in [AfterAll] — no internet dependency, so this runs in an isolated CI
+ * sandbox. The collection URL is templated `{{baseUrl}}/...` and resolved against `baseUrl`
+ * injected via `dynamicEnvironment`. The single-step fixture `pm-templates/v3/ledger-skip` is a
+ * plain GET that PRODUCES nothing on its own (the loopback server just returns 200) — which is what
+ * lets the warm run prove the skip: a hash-matching, produced-keys-present ledger entry makes that
+ * one step's HTTP dispatch get SKIPPED, so the warm run makes ZERO requests to the server.
  */
 class LedgerSkipE2ETest {
-  private val collection = "pm-templates/v3/flat"
+  private val collection = "pm-templates/v3/ledger-skip"
+
+  private fun kick(snap: LedgerSnapshot? = null, vararg env: Pair<String, Any?>): Kick {
+    var builder =
+      Kick.configure()
+        .templatePath(collection)
+        .dynamicEnvironment("baseUrl", baseUrl)
+        .insecureHttp(true)
+    env.forEach { (k, v) -> builder = builder.dynamicEnvironment(k, v) }
+    if (snap != null) builder = builder.ledger(snap)
+    return builder.off()
+  }
 
   @Test
-  fun `cold run emits a learnedLedger built only from producing steps`() {
-    val rundown = ReVoman.revUp(Kick.configure().templatePath(collection).insecureHttp(true).off())
-    // None of the flat steps call pm.environment.set, so nothing is produced -> empty
-    // learnedLedger.
-    // This proves the extraction filters to producing steps only (no spurious entries).
+  fun `cold run hits the loopback server and emits learnedLedger only from producing steps`() {
+    val hitsBefore = serverHits.get()
+    val rundown = ReVoman.revUp(kick())
+    // Cold run dispatched real (loopback) HTTP for the one step.
+    assertThat(serverHits.get()).isEqualTo(hitsBefore + 1)
+    // The step calls no pm.environment.set, so nothing is produced -> empty learnedLedger.
+    // Proves the extraction filters to producing steps only (no spurious entries).
     assertThat(rundown.learnedLedger).isEmpty()
-    assertThat(rundown.stepReports).hasSize(3)
+    assertThat(rundown.stepReports).hasSize(1)
   }
 
   @Test
   fun `warm run with matching ledger skips the producing step and injects the ledgered value`() {
-    // Cold run to learn the real step path + sourceHash (offline-safe: assertions don't need HTTP).
-    val cold = ReVoman.revUp(Kick.configure().templatePath(collection).insecureHttp(true).off())
+    // Cold run to learn the real step path + sourceHash (v3 loader computes a real sha256).
+    val cold = ReVoman.revUp(kick())
     val firstStep = cold.stepReports.first().step
     val stepPath = firstStep.path
     val hash = firstStep.sourceHash
@@ -58,24 +77,50 @@ class LedgerSkipE2ETest {
     // real warm flow the ledger file's `values` are imported into the postman env up front; here we
     // simulate that precondition with a placeholder, then assert the skip branch OVERWRITES it with
     // the authoritative ledgered value (proving the inject ran, not the HTTP-producing step).
-    val warm =
-      ReVoman.revUp(
-        Kick.configure()
-          .templatePath(collection)
-          .dynamicEnvironment(producedKey, "PLACEHOLDER")
-          .ledger(snap)
-          .insecureHttp(true)
-          .off()
-      )
+    val hitsBefore = serverHits.get()
+    val warm = ReVoman.revUp(kick(snap, producedKey to "PLACEHOLDER"))
 
+    // The single step was skipped -> ZERO requests reached the loopback server. This structurally
+    // proves "skipped, not run", independent of the report shape.
+    assertThat(serverHits.get()).isEqualTo(hitsBefore)
     // Injected value survives (overwrote the placeholder) so downstream steps could resolve it.
     assertThat(warm.mutableEnv.getAsString(producedKey)).isEqualTo("LEDGERED_VALUE")
-    // The skipped step is RECORDED (not absent) in the report list.
-    assertThat(warm.reportForStepName(stepPath)).isNotNull()
-    assertThat(warm.stepReports).hasSize(3)
+
+    // The skipped step is RECORDED (not absent) in the report list, and its SHAPE proves no HTTP
+    // ran: a ledgerSkipped report carries neither a requestInfo nor a responseInfo.
+    val skipped = warm.reportForStepName(stepPath)!!
+    assertThat(skipped.requestInfo).isNull()
+    assertThat(skipped.responseInfo).isNull()
+    assertThat(warm.stepReports).hasSize(1)
+
     // The warm run re-emits the skipped step's entry into learnedLedger: the reused produced keys
-    // carried forward against the step's CURRENT sourceHash (so the ledger can be refreshed). The
-    // index-set injection did NOT add spurious produced keys for the other (HTTP-run) steps.
+    // carried forward against the step's CURRENT sourceHash (so the ledger can be refreshed).
     assertThat(warm.learnedLedger).containsExactly(stepPath, LedgerEntry(setOf(producedKey), hash))
+  }
+
+  companion object {
+    private lateinit var server: HttpServer
+    private val serverHits = AtomicInteger(0)
+    private lateinit var baseUrl: String
+
+    @BeforeAll
+    @JvmStatic
+    fun startServer() {
+      server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+      server.createContext("/") { exchange ->
+        serverHits.incrementAndGet()
+        val body = "{}".toByteArray()
+        exchange.sendResponseHeaders(200, body.size.toLong())
+        exchange.responseBody.use { it.write(body) }
+      }
+      server.start()
+      baseUrl = "http://127.0.0.1:${server.address.port}"
+    }
+
+    @AfterAll
+    @JvmStatic
+    fun stopServer() {
+      server.stop(0)
+    }
   }
 }

--- a/src/test/kotlin/com/salesforce/revoman/LedgerSkipE2ETest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/LedgerSkipE2ETest.kt
@@ -247,6 +247,28 @@ class LedgerSkipE2ETest {
   }
 
   @Test
+  fun `consumed in a POST body of a key produced by a PRIOR step is captured (real-shape repro)`() {
+    // Mirrors the real UnifiedValidation link steps: step1 sets ruleId via afterResponse; step2
+    // POSTs with {{ruleId}} in its JSON BODY (not the URL) and also produces linkId. The link
+    // step's learned entry MUST record ruleId as consumed.
+    val rundown =
+      ReVoman.revUp(
+        Kick.configure()
+          .templatePath("pm-templates/v3/ledger-body-consume")
+          .dynamicEnvironment("baseUrl", baseUrl)
+          .insecureHttp(true)
+          .off()
+      )
+    val linkStep = rundown.stepReports.first { it.step.name.contains("link") }.step
+    val entry = rundown.learnedLedger[linkStep.path]!!
+    assertThat(entry.produces).contains("linkId")
+    assertThat(entry.consumed).contains("ruleId")
+    // baseUrl is a dynamicEnvironment key consumed in the URL of EVERY step — if consumed capture
+    // works at all, it must be recorded here too (sanity: capture isn't selective to body-only).
+    assertThat(entry.consumed).contains("baseUrl")
+  }
+
+  @Test
   fun `learnedLedger entry carries the keys a producing step consumed (provenance)`() {
     // A step that reads {{seedKey}} (consumed) in its URL AND sets producedId (produced). The
     // learned entry must record BOTH: produces for skip, consumed for the provenance graph.

--- a/src/test/kotlin/com/salesforce/revoman/LedgerSkipE2ETest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/LedgerSkipE2ETest.kt
@@ -99,6 +99,47 @@ class LedgerSkipE2ETest {
     assertThat(warm.learnedLedger).containsExactly(stepPath, LedgerEntry(setOf(producedKey), hash))
   }
 
+  @Test
+  fun `warm skip re-emits the reused entry's consumed (provenance survives warm runs)`() {
+    // Cold run to learn the real step path + sourceHash.
+    val cold = ReVoman.revUp(kick())
+    val firstStep = cold.stepReports.first().step
+    val stepPath = firstStep.path
+    val hash = firstStep.sourceHash
+
+    val producedKey = "ledgeredKey"
+    // The ledgered entry carries CONSUMED provenance (as a cold run would have recorded).
+    val snap =
+      LedgerSnapshot(
+        orgId = null,
+        steps =
+          mapOf(stepPath to LedgerEntry(setOf(producedKey), hash, consumed = setOf("seedKey"))),
+        values = mapOf(producedKey to "LEDGERED_VALUE"),
+      )
+    val warm = ReVoman.revUp(kick(snap))
+    // Skipped step re-emits the entry; consumed must NOT be silently dropped, else a warm-run
+    // LedgerStore.merge (last-write-wins putAll) would erase the provenance on every loop.
+    assertThat(warm.learnedLedger[stepPath]!!.consumed).containsExactly("seedKey")
+  }
+
+  @Test
+  fun `learnedLedger entry carries the keys a producing step consumed (provenance)`() {
+    // A step that reads {{seedKey}} (consumed) in its URL AND sets producedId (produced). The
+    // learned entry must record BOTH: produces for skip, consumed for the provenance graph.
+    val kick =
+      Kick.configure()
+        .templatePath("pm-templates/v3/ledger-consume")
+        .dynamicEnvironment("baseUrl", baseUrl)
+        .dynamicEnvironment("seedKey", "SEED")
+        .insecureHttp(true)
+        .off()
+    val rundown = ReVoman.revUp(kick)
+    val stepPath = rundown.stepReports.first().step.path
+    val entry = rundown.learnedLedger[stepPath]!!
+    assertThat(entry.produces).containsExactly("producedId")
+    assertThat(entry.consumed).contains("seedKey")
+  }
+
   companion object {
     private lateinit var server: HttpServer
     private val serverHits = AtomicInteger(0)

--- a/src/test/kotlin/com/salesforce/revoman/LedgerSkipE2ETest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/LedgerSkipE2ETest.kt
@@ -1,0 +1,81 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.input.config.Kick
+import com.salesforce.revoman.output.ledger.LedgerEntry
+import com.salesforce.revoman.output.ledger.LedgerSnapshot
+import org.junit.jupiter.api.Test
+
+/**
+ * E2E for the warm-path centerpiece in [ReVoman.executeStepsSerially]: ledger-skip + inject, and
+ * [com.salesforce.revoman.output.Rundown.learnedLedger] emission.
+ *
+ * Fixture: `pm-templates/v3/flat` — 3 v3 steps (`a`, `b`, `c`) each a plain GET to example.com with
+ * no `pm.environment.set(...)`, so none of them PRODUCE env keys. That's exactly what makes the
+ * skip-path test offline: a ledgered, hash-matching, produced-keys-present entry makes the
+ * producing step's HTTP dispatch get SKIPPED — no network. We bootstrap the step's
+ * `path`/`sourceHash` from a cold run's step reports (the v3 loader computes a real sha256
+ * fingerprint).
+ */
+class LedgerSkipE2ETest {
+  private val collection = "pm-templates/v3/flat"
+
+  @Test
+  fun `cold run emits a learnedLedger built only from producing steps`() {
+    val rundown = ReVoman.revUp(Kick.configure().templatePath(collection).insecureHttp(true).off())
+    // None of the flat steps call pm.environment.set, so nothing is produced -> empty
+    // learnedLedger.
+    // This proves the extraction filters to producing steps only (no spurious entries).
+    assertThat(rundown.learnedLedger).isEmpty()
+    assertThat(rundown.stepReports).hasSize(3)
+  }
+
+  @Test
+  fun `warm run with matching ledger skips the producing step and injects the ledgered value`() {
+    // Cold run to learn the real step path + sourceHash (offline-safe: assertions don't need HTTP).
+    val cold = ReVoman.revUp(Kick.configure().templatePath(collection).insecureHttp(true).off())
+    val firstStep = cold.stepReports.first().step
+    val stepPath = firstStep.path
+    val hash = firstStep.sourceHash
+    assertThat(hash).isNotEmpty()
+
+    val producedKey = "ledgeredKey"
+    val snap =
+      LedgerSnapshot(
+        orgId = null,
+        steps = mapOf(stepPath to LedgerEntry(setOf(producedKey), hash)),
+        values = mapOf(producedKey to "LEDGERED_VALUE"),
+      )
+
+    // The skip predicate requires the produced keys to ALREADY be in env (env-superset). In the
+    // real warm flow the ledger file's `values` are imported into the postman env up front; here we
+    // simulate that precondition with a placeholder, then assert the skip branch OVERWRITES it with
+    // the authoritative ledgered value (proving the inject ran, not the HTTP-producing step).
+    val warm =
+      ReVoman.revUp(
+        Kick.configure()
+          .templatePath(collection)
+          .dynamicEnvironment(producedKey, "PLACEHOLDER")
+          .ledger(snap)
+          .insecureHttp(true)
+          .off()
+      )
+
+    // Injected value survives (overwrote the placeholder) so downstream steps could resolve it.
+    assertThat(warm.mutableEnv.getAsString(producedKey)).isEqualTo("LEDGERED_VALUE")
+    // The skipped step is RECORDED (not absent) in the report list.
+    assertThat(warm.reportForStepName(stepPath)).isNotNull()
+    assertThat(warm.stepReports).hasSize(3)
+    // The warm run re-emits the skipped step's entry into learnedLedger: the reused produced keys
+    // carried forward against the step's CURRENT sourceHash (so the ledger can be refreshed). The
+    // index-set injection did NOT add spurious produced keys for the other (HTTP-run) steps.
+    assertThat(warm.learnedLedger).containsExactly(stepPath, LedgerEntry(setOf(producedKey), hash))
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/input/FileUtilsLedgerTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/input/FileUtilsLedgerTest.kt
@@ -1,0 +1,30 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.input
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.output.ledger.LedgerEntry
+import com.salesforce.revoman.output.ledger.LedgerFile
+import java.nio.file.Files
+import org.junit.jupiter.api.Test
+
+class FileUtilsLedgerTest {
+  @Test
+  fun `write then read round-trips a LedgerFile via absolute path`() {
+    val tmp = Files.createTempFile("ledger", ".environment.yaml").toAbsolutePath().toString()
+    val file =
+      LedgerFile(
+        name = "ledger-00Dxx",
+        values = mapOf("saId1" to "08p1"),
+        orgId = "00Dxx",
+        steps = mapOf("fixtures|>sa<|||create-sa|||>" to LedgerEntry(setOf("saId1"), "abc")),
+      )
+    writeLedgerYaml(tmp, file)
+    assertThat(readLedgerYaml(tmp)).isEqualTo(file)
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/input/FileUtilsTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/input/FileUtilsTest.kt
@@ -10,6 +10,7 @@ package com.salesforce.revoman.input
 import com.google.common.truth.Truth.assertThat
 import io.kotest.matchers.string.shouldNotBeBlank
 import java.io.File
+import java.nio.file.Files
 import org.junit.jupiter.api.Test
 
 class FileUtilsTest {
@@ -67,5 +68,38 @@ class FileUtilsTest {
     org.junit.jupiter.api.Assertions.assertThrows(java.io.FileNotFoundException::class.java) {
       bufferV3Definition("pm-templates/v3/no-def").use { it.readUtf8() }
     }
+  }
+
+  @Test
+  fun `readYamlMap parses a flat key-value yaml`() {
+    val tmp = Files.createTempFile("config", ".yaml")
+    Files.writeString(
+      tmp,
+      """
+      baseUrl: https://localhost:6101
+      username: admin@local.org
+      password: secret
+      apiVersion: 68.0
+      """
+        .trimIndent(),
+    )
+    val map = readYamlMap(tmp.toAbsolutePath().toString())
+    assertThat(map)
+      .containsExactly(
+        "baseUrl",
+        "https://localhost:6101",
+        "username",
+        "admin@local.org",
+        "password",
+        "secret",
+        "apiVersion",
+        68.0,
+      )
+  }
+
+  @Test
+  fun `readYamlMap returns empty for empty yaml`() {
+    val tmp = Files.createTempFile("empty", ".yaml")
+    assertThat(readYamlMap(tmp.toAbsolutePath().toString())).isEmpty()
   }
 }

--- a/src/test/kotlin/com/salesforce/revoman/internal/exe/LedgerDecisionTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/exe/LedgerDecisionTest.kt
@@ -95,6 +95,90 @@ class LedgerDecisionTest {
     assertThat(ledgerSkipDecision(s, snap, setOf("saId1"))).isFalse()
   }
 
+  // --- Collision guard: a key produced by >1 step is only safely skippable at its LAST producer ---
+
+  private fun namedStep(name: String, hash: String = "h"): Step =
+    Step(index = "1", rawPMStep = Item(name = name), sourceHash = hash)
+
+  @Test
+  fun `no collision - every key produced by one step - nothing shadowed`() {
+    val s1 = namedStep("create-sa-1")
+    val s2 = namedStep("create-sa-2")
+    val snap =
+      LedgerSnapshot(
+        "00D",
+        mapOf(
+          s1.path to LedgerEntry(setOf("saId1"), "h"),
+          s2.path to LedgerEntry(setOf("saId2"), "h"),
+        ),
+        emptyMap(),
+      )
+    assertThat(shadowedProducerPaths(listOf(s1, s2), snap)).isEmpty()
+  }
+
+  @Test
+  fun `two steps set the same key - only the EARLIER producer is shadowed`() {
+    val early = namedStep("create-sa-early")
+    val late = namedStep("recreate-sa-late")
+    val snap =
+      LedgerSnapshot(
+        "00D",
+        mapOf(
+          early.path to LedgerEntry(setOf("saId1"), "h"),
+          late.path to LedgerEntry(setOf("saId1"), "h"),
+        ),
+        emptyMap(),
+      )
+    // Execution order is the list order: early before late.
+    val shadowed = shadowedProducerPaths(listOf(early, late), snap)
+    assertThat(shadowed).containsExactly(early.path)
+    assertThat(shadowed).doesNotContain(late.path)
+  }
+
+  @Test
+  fun `three producers of one key - all but the last are shadowed`() {
+    val a = namedStep("set-x-a")
+    val b = namedStep("set-x-b")
+    val c = namedStep("set-x-c")
+    val snap =
+      LedgerSnapshot(
+        "00D",
+        mapOf(
+          a.path to LedgerEntry(setOf("x"), "h"),
+          b.path to LedgerEntry(setOf("x"), "h"),
+          c.path to LedgerEntry(setOf("x"), "h"),
+        ),
+        emptyMap(),
+      )
+    assertThat(shadowedProducerPaths(listOf(a, b, c), snap)).containsExactly(a.path, b.path)
+  }
+
+  @Test
+  fun `a step producing a collision key AND a unique key is still shadowed (must run)`() {
+    // If skipped, the collision key would be injected with the LATER value -> intermediate consumer
+    // wrong. So a step is shadowed if ANY produced key is re-set by a later step.
+    val early = namedStep("create-both")
+    val late = namedStep("recreate-shared")
+    val snap =
+      LedgerSnapshot(
+        "00D",
+        mapOf(
+          early.path to LedgerEntry(setOf("shared", "uniqueToEarly"), "h"),
+          late.path to LedgerEntry(setOf("shared"), "h"),
+        ),
+        emptyMap(),
+      )
+    assertThat(shadowedProducerPaths(listOf(early, late), snap)).containsExactly(early.path)
+  }
+
+  @Test
+  fun `steps without a ledger entry are ignored by the collision scan`() {
+    val ledgered = namedStep("ledgered")
+    val unledgered = namedStep("not-in-ledger")
+    val snap = LedgerSnapshot("00D", mapOf(ledgered.path to LedgerEntry(setOf("k"), "h")), emptyMap())
+    assertThat(shadowedProducerPaths(listOf(unledgered, ledgered), snap)).isEmpty()
+  }
+
   @Test
   fun `Kick defaults to EMPTY ledger - builder ledger() and immutable overrideLedger() set it`() {
     val kick = Kick.configure().off()

--- a/src/test/kotlin/com/salesforce/revoman/internal/exe/LedgerDecisionTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/exe/LedgerDecisionTest.kt
@@ -8,6 +8,7 @@
 package com.salesforce.revoman.internal.exe
 
 import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.input.config.Kick
 import com.salesforce.revoman.internal.postman.template.Item
 import com.salesforce.revoman.output.ledger.LedgerEntry
 import com.salesforce.revoman.output.ledger.LedgerSnapshot
@@ -82,12 +83,25 @@ class LedgerDecisionTest {
   }
 
   @Test
+  fun `does NOT skip when either hash is empty (unknown never matches unknown)`() {
+    // A non-v3 step (sourceHash "") against an entry with an empty hash must NOT skip on "" == "".
+    val s = step("")
+    val snap =
+      LedgerSnapshot(
+        "00D",
+        mapOf(s.path to LedgerEntry(setOf("saId1"), "")),
+        mapOf("saId1" to "08p1"),
+      )
+    assertThat(ledgerSkipDecision(s, snap, setOf("saId1"))).isFalse()
+  }
+
+  @Test
   fun `Kick defaults to EMPTY ledger - builder ledger() and immutable overrideLedger() set it`() {
-    val kick = com.salesforce.revoman.input.config.Kick.configure().off()
+    val kick = Kick.configure().off()
     assertThat(kick.ledger()).isEqualTo(LedgerSnapshot.EMPTY)
     val snap = LedgerSnapshot("00D", emptyMap(), emptyMap())
     // builder setter (mirrors haltOnAnyFailure/insecureHttp `@Value.Default` setters)
-    val kick2 = com.salesforce.revoman.input.config.Kick.configure().ledger(snap).off()
+    val kick2 = Kick.configure().ledger(snap).off()
     assertThat(kick2.ledger()).isEqualTo(snap)
     // copy-with on the built immutable (the `with="override*"` style)
     assertThat(kick.overrideLedger(snap).ledger()).isEqualTo(snap)

--- a/src/test/kotlin/com/salesforce/revoman/internal/exe/LedgerDecisionTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/exe/LedgerDecisionTest.kt
@@ -1,0 +1,95 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.exe
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.internal.postman.template.Item
+import com.salesforce.revoman.output.ledger.LedgerEntry
+import com.salesforce.revoman.output.ledger.LedgerSnapshot
+import com.salesforce.revoman.output.report.Step
+import org.junit.jupiter.api.Test
+
+class LedgerDecisionTest {
+  private fun step(hash: String): Step =
+    Step(index = "1", rawPMStep = Item(name = "create-sa"), sourceHash = hash)
+
+  @Test
+  fun `skips when produced keys present and hash matches`() {
+    val s = step("h1")
+    val snap =
+      LedgerSnapshot(
+        "00D",
+        mapOf(s.path to LedgerEntry(setOf("saId1"), s.sourceHash)),
+        mapOf("saId1" to "08p1"),
+      )
+    assertThat(ledgerSkipDecision(s, snap, setOf("saId1"))).isTrue()
+  }
+
+  @Test
+  fun `does NOT skip when a produced key is missing from env`() {
+    val s = step("h1")
+    val snap =
+      LedgerSnapshot(
+        "00D",
+        mapOf(s.path to LedgerEntry(setOf("saId1"), s.sourceHash)),
+        mapOf("saId1" to "08p1"),
+      )
+    assertThat(ledgerSkipDecision(s, snap, emptySet())).isFalse()
+  }
+
+  @Test
+  fun `does NOT skip when produces is empty (read-only step)`() {
+    val s = step("h1")
+    val snap =
+      LedgerSnapshot("00D", mapOf(s.path to LedgerEntry(emptySet(), s.sourceHash)), emptyMap())
+    assertThat(ledgerSkipDecision(s, snap, setOf("anything"))).isFalse()
+  }
+
+  @Test
+  fun `does NOT skip on hash mismatch (warn-and-run)`() {
+    val s = step("NEW")
+    val snap =
+      LedgerSnapshot(
+        "00D",
+        mapOf(s.path to LedgerEntry(setOf("saId1"), "OLD")),
+        mapOf("saId1" to "08p1"),
+      )
+    assertThat(ledgerSkipDecision(s, snap, setOf("saId1"))).isFalse()
+  }
+
+  @Test
+  fun `does NOT skip when no entry for the step`() {
+    val s = step("h1")
+    assertThat(ledgerSkipDecision(s, LedgerSnapshot.EMPTY, setOf("saId1"))).isFalse()
+  }
+
+  @Test
+  fun `skips only when env is a SUPERSET of all produced keys`() {
+    val s = step("h1")
+    val snap =
+      LedgerSnapshot(
+        "00D",
+        mapOf(s.path to LedgerEntry(setOf("saId1", "saId2"), s.sourceHash)),
+        mapOf("saId1" to "08p1", "saId2" to "08p2"),
+      )
+    assertThat(ledgerSkipDecision(s, snap, setOf("saId1"))).isFalse() // missing saId2
+    assertThat(ledgerSkipDecision(s, snap, setOf("saId1", "saId2"))).isTrue() // both present
+  }
+
+  @Test
+  fun `Kick defaults to EMPTY ledger - builder ledger() and immutable overrideLedger() set it`() {
+    val kick = com.salesforce.revoman.input.config.Kick.configure().off()
+    assertThat(kick.ledger()).isEqualTo(LedgerSnapshot.EMPTY)
+    val snap = LedgerSnapshot("00D", emptyMap(), emptyMap())
+    // builder setter (mirrors haltOnAnyFailure/insecureHttp `@Value.Default` setters)
+    val kick2 = com.salesforce.revoman.input.config.Kick.configure().ledger(snap).off()
+    assertThat(kick2.ledger()).isEqualTo(snap)
+    // copy-with on the built immutable (the `with="override*"` style)
+    assertThat(kick.overrideLedger(snap).ledger()).isEqualTo(snap)
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/RegexReplacerConsumedTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/RegexReplacerConsumedTest.kt
@@ -1,0 +1,28 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.postman
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
+import com.salesforce.revoman.internal.postman.template.Item
+import com.salesforce.revoman.output.report.Step
+import org.junit.jupiter.api.Test
+
+class RegexReplacerConsumedTest {
+  @Test
+  fun `resolving a double-brace var records it as consumed`() {
+    val regexReplacer = RegexReplacer()
+    val pm = PostmanSDK(initMoshi(), null, regexReplacer)
+    pm.environment.currentStep = Step(index = "1", rawPMStep = Item(name = "validate"))
+    // present in env (also marks produced for this step — fine)
+    pm.environment.set("policyId", "0Pol1")
+    val out = regexReplacer.replaceVariablesRecursively("id={{policyId}}", pm)
+    assertThat(out).isEqualTo("id=0Pol1")
+    assertThat(pm.environment.consumedKeysFor(pm.environment.currentStep)).contains("policyId")
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3YamlLedgerTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3YamlLedgerTest.kt
@@ -1,0 +1,69 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.postman.template.v3
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.output.ledger.LedgerEntry
+import com.salesforce.revoman.output.ledger.LedgerFile
+import org.junit.jupiter.api.Test
+
+class V3YamlLedgerTest {
+  @Test
+  fun `readLedger parses values and x-revoman-ledger sibling`() {
+    val yaml =
+      """
+      name: ledger-00Dxx
+      values:
+        - {key: saId1, value: '08p1', enabled: true}
+      x-revoman-ledger:
+        orgId: 00Dxx
+        steps:
+          "fixtures|>sa<|||create-sa|||>":
+            produces: [saId1]
+            hash: abc
+      """
+        .trimIndent()
+    val f = V3YamlReader.readLedger(yaml)
+    assertThat(f.values).containsEntry("saId1", "08p1")
+    assertThat(f.orgId).isEqualTo("00Dxx")
+    assertThat(f.steps["fixtures|>sa<|||create-sa|||>"])
+      .isEqualTo(LedgerEntry(produces = setOf("saId1"), hash = "abc"))
+  }
+
+  @Test
+  fun `writer output is re-readable AND parses as a plain v3 env (values only)`() {
+    val file =
+      LedgerFile(
+        name = "ledger-00Dxx",
+        values = mapOf("saId1" to "08p1"),
+        orgId = "00Dxx",
+        steps = mapOf("fixtures|>sa<|||create-sa|||>" to LedgerEntry(setOf("saId1"), "abc")),
+      )
+    val dumped = V3YamlWriter.dump(file)
+    // Round-trips as a ledger
+    assertThat(V3YamlReader.readLedger(dumped)).isEqualTo(file)
+    // And still parses as a plain postman env (sibling ignored, values intact)
+    val asEnv = V3YamlReader.readEnv(dumped)
+    assertThat(asEnv.values.map { it.key }).contains("saId1")
+  }
+
+  @Test
+  fun `readLedger tolerates a file with no x-revoman-ledger sibling (plain env)`() {
+    val yaml =
+      """
+      name: plain
+      values:
+        - {key: foo, value: bar, enabled: true}
+      """
+        .trimIndent()
+    val f = V3YamlReader.readLedger(yaml)
+    assertThat(f.values).containsEntry("foo", "bar")
+    assertThat(f.orgId).isNull()
+    assertThat(f.steps).isEmpty()
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3YamlLedgerTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3YamlLedgerTest.kt
@@ -36,16 +36,46 @@ class V3YamlLedgerTest {
   }
 
   @Test
+  fun `readLedger parses consumed list (provenance), absent consumed yields empty`() {
+    val yaml =
+      """
+      name: ledger-00Dxx
+      values:
+        - {key: schedulingPolicyId, value: '0Sp1', enabled: true}
+      x-revoman-ledger:
+        orgId: 00Dxx
+        steps:
+          "policies|>create<|||create-policy|||>":
+            produces: [schedulingPolicyId]
+            consumed: [ruleId, resourceId]
+            hash: abc
+          "fixtures|>sa<|||create-sa|||>":
+            produces: [saId1]
+            hash: def
+      """
+        .trimIndent()
+    val f = V3YamlReader.readLedger(yaml)
+    assertThat(f.steps["policies|>create<|||create-policy|||>"]!!.consumed)
+      .containsExactly("ruleId", "resourceId")
+    // A step with no `consumed:` key parses to an empty set, not null.
+    assertThat(f.steps["fixtures|>sa<|||create-sa|||>"]!!.consumed).isEmpty()
+  }
+
+  @Test
   fun `writer output is re-readable AND parses as a plain v3 env (values only)`() {
     val file =
       LedgerFile(
         name = "ledger-00Dxx",
         values = mapOf("saId1" to "08p1"),
         orgId = "00Dxx",
-        steps = mapOf("fixtures|>sa<|||create-sa|||>" to LedgerEntry(setOf("saId1"), "abc")),
+        steps =
+          mapOf(
+            "fixtures|>sa<|||create-sa|||>" to
+              LedgerEntry(setOf("saId1"), "abc", consumed = setOf("policyId"))
+          ),
       )
     val dumped = V3YamlWriter.dump(file)
-    // Round-trips as a ledger
+    // Round-trips as a ledger (incl. consumed provenance)
     assertThat(V3YamlReader.readLedger(dumped)).isEqualTo(file)
     // And still parses as a plain postman env (sibling ignored, values intact)
     val asEnv = V3YamlReader.readEnv(dumped)

--- a/src/test/kotlin/com/salesforce/revoman/output/ledger/LedgerTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/output/ledger/LedgerTest.kt
@@ -1,0 +1,56 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.output.ledger
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class LedgerTest {
+  @Test
+  fun `LedgerEntry holds produces and hash`() {
+    val e = LedgerEntry(produces = setOf("saId1"), hash = "abc")
+    assertThat(e.produces).containsExactly("saId1")
+    assertThat(e.hash).isEqualTo("abc")
+  }
+
+  @Test
+  fun `empty snapshot has no steps and no values`() {
+    val s = LedgerSnapshot(orgId = null, steps = emptyMap(), values = emptyMap())
+    assertThat(s.steps).isEmpty()
+    assertThat(s.values).isEmpty()
+  }
+
+  @Test
+  fun `LedgerSnapshot EMPTY constant is empty`() {
+    assertThat(LedgerSnapshot.EMPTY.steps).isEmpty()
+    assertThat(LedgerSnapshot.EMPTY.values).isEmpty()
+    assertThat(LedgerSnapshot.EMPTY.orgId).isNull()
+  }
+
+  @Test
+  fun `LedgerFile toSnapshot copies orgId steps and values`() {
+    val file =
+      LedgerFile(
+        name = "ledger-00Dxx",
+        values = mapOf("saId1" to "08p1"),
+        orgId = "00Dxx",
+        steps = mapOf("fixtures|>sa<|||create-sa|||>" to LedgerEntry(setOf("saId1"), "abc")),
+      )
+    val snap = file.toSnapshot()
+    assertThat(snap.orgId).isEqualTo("00Dxx")
+    assertThat(snap.steps).containsKey("fixtures|>sa<|||create-sa|||>")
+    assertThat(snap.values).containsEntry("saId1", "08p1")
+  }
+
+  @Test
+  fun `LedgerFile EMPTY is empty`() {
+    assertThat(LedgerFile.EMPTY.steps).isEmpty()
+    assertThat(LedgerFile.EMPTY.values).isEmpty()
+    assertThat(LedgerFile.EMPTY.orgId).isNull()
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/output/ledger/LedgerTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/output/ledger/LedgerTest.kt
@@ -19,6 +19,15 @@ class LedgerTest {
   }
 
   @Test
+  fun `LedgerEntry carries consumed keys (provenance) defaulting empty`() {
+    val withConsumed =
+      LedgerEntry(produces = setOf("schedulingPolicyId"), consumed = setOf("ruleId"), hash = "abc")
+    assertThat(withConsumed.consumed).containsExactly("ruleId")
+    // Backward-compat: a positionally-constructed entry (produces, hash) has empty consumed.
+    assertThat(LedgerEntry(setOf("saId1"), "abc").consumed).isEmpty()
+  }
+
+  @Test
   fun `empty snapshot has no steps and no values`() {
     val s = LedgerSnapshot(orgId = null, steps = emptyMap(), values = emptyMap())
     assertThat(s.steps).isEmpty()

--- a/src/test/kotlin/com/salesforce/revoman/output/postman/PostmanEnvironmentEnvVarsTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/output/postman/PostmanEnvironmentEnvVarsTest.kt
@@ -1,0 +1,50 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.output.postman
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.internal.postman.template.Item
+import com.salesforce.revoman.output.report.Step
+import org.junit.jupiter.api.Test
+
+class PostmanEnvironmentEnvVarsTest {
+  private fun stepNamed(name: String): Step = Step(index = "1", rawPMStep = Item(name = name))
+
+  @Test
+  fun `set records produced key against current step`() {
+    val env = PostmanEnvironment<Any?>()
+    env.currentStep = stepNamed("create-sa")
+    env.set("saId1", "08p1")
+    assertThat(env.producedKeysFor(env.currentStep)).containsExactly("saId1")
+  }
+
+  @Test
+  fun `index-set does NOT record as produced (regex write-back path)`() {
+    val env = PostmanEnvironment<Any?>()
+    env.currentStep = stepNamed("create-sa")
+    env["someRegexKey"] = "v" // delegated map put, bypasses set()
+    assertThat(env.producedKeysFor(env.currentStep)).isEmpty()
+  }
+
+  @Test
+  fun `recordConsumed records read key against current step`() {
+    val env = PostmanEnvironment<Any?>()
+    env.currentStep = stepNamed("validate")
+    env.recordConsumed("policyId")
+    assertThat(env.consumedKeysFor(env.currentStep)).containsExactly("policyId")
+  }
+
+  @Test
+  fun `unset removes a previously produced key`() {
+    val env = PostmanEnvironment<Any?>()
+    env.currentStep = stepNamed("create-sa")
+    env.set("saId1", "08p1")
+    env.unset("saId1")
+    assertThat(env.producedKeysFor(env.currentStep)).isEmpty()
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/output/report/StepEnvVarsTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/output/report/StepEnvVarsTest.kt
@@ -1,0 +1,27 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.output.report
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class StepEnvVarsTest {
+  @Test
+  fun `defaults to empty produced and consumed`() {
+    val v = StepEnvVars()
+    assertThat(v.produced).isEmpty()
+    assertThat(v.consumed).isEmpty()
+  }
+
+  @Test
+  fun `holds produced and consumed sets`() {
+    val v = StepEnvVars(produced = setOf("saId1"), consumed = setOf("policyId"))
+    assertThat(v.produced).containsExactly("saId1")
+    assertThat(v.consumed).containsExactly("policyId")
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/output/report/StepReportEnvVarsTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/output/report/StepReportEnvVarsTest.kt
@@ -1,0 +1,37 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.output.report
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.internal.postman.template.Item
+import com.salesforce.revoman.output.postman.PostmanEnvironment
+import org.junit.jupiter.api.Test
+
+class StepReportEnvVarsTest {
+  @Test
+  fun `envVars defaults to empty when not set`() {
+    val step = Step(index = "1", rawPMStep = Item(name = "s"))
+    val report =
+      StepReport(step = step, pmEnvSnapshot = PostmanEnvironment(), envVars = StepEnvVars())
+    assertThat(report.envVars.produced).isEmpty()
+    assertThat(report.envVars.consumed).isEmpty()
+  }
+
+  @Test
+  fun `envVars carries provided produced and consumed`() {
+    val step = Step(index = "1", rawPMStep = Item(name = "s"))
+    val report =
+      StepReport(
+        step = step,
+        pmEnvSnapshot = PostmanEnvironment(),
+        envVars = StepEnvVars(produced = setOf("saId1"), consumed = setOf("policyId")),
+      )
+    assertThat(report.envVars.produced).containsExactly("saId1")
+    assertThat(report.envVars.consumed).containsExactly("policyId")
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/output/report/StepSourceHashTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/output/report/StepSourceHashTest.kt
@@ -11,6 +11,7 @@ import com.google.common.truth.Truth.assertThat
 import com.salesforce.revoman.internal.exe.deepFlattenItems
 import com.salesforce.revoman.internal.postman.template.Item
 import com.salesforce.revoman.internal.postman.template.v3.V3Loader
+import com.salesforce.revoman.internal.postman.template.v3.sha256Hex
 import org.junit.jupiter.api.Test
 
 class StepSourceHashTest {
@@ -42,5 +43,15 @@ class StepSourceHashTest {
     assertThat(steps.all { it.sourceHash.isNotEmpty() }).isTrue()
     // And each Step's hash matches its source Item's hash.
     assertThat(steps.all { it.sourceHash == it.rawPMStep.sourceHash }).isTrue()
+  }
+
+  @Test
+  fun `editing the request source changes the hash, identical source keeps it`() {
+    // The staleness signal: a producer-definition edit must yield a different fingerprint, so a
+    // warm run detects the change and re-runs instead of reusing a stale ledgered id.
+    val original = "url: /a\nmethod: GET\n"
+    val edited = "url: /b\nmethod: GET\n"
+    assertThat(sha256Hex(original)).isNotEqualTo(sha256Hex(edited))
+    assertThat(sha256Hex(original)).isEqualTo(sha256Hex(original))
   }
 }

--- a/src/test/kotlin/com/salesforce/revoman/output/report/StepSourceHashTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/output/report/StepSourceHashTest.kt
@@ -1,0 +1,46 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.output.report
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.internal.exe.deepFlattenItems
+import com.salesforce.revoman.internal.postman.template.Item
+import com.salesforce.revoman.internal.postman.template.v3.V3Loader
+import org.junit.jupiter.api.Test
+
+class StepSourceHashTest {
+  @Test
+  fun `sourceHash defaults to empty when not provided`() {
+    val step = Step(index = "1", rawPMStep = Item(name = "s"))
+    assertThat(step.sourceHash).isEmpty()
+  }
+
+  @Test
+  fun `sourceHash carries provided fingerprint`() {
+    val step = Step(index = "1", rawPMStep = Item(name = "s"), sourceHash = "deadbeef")
+    assertThat(step.sourceHash).isEqualTo("deadbeef")
+  }
+
+  @Test
+  fun `v3-loaded items carry a non-empty sourceHash`() {
+    // V3Loader.load returns List<Item>; the staleness fingerprint lands on Item.sourceHash.
+    val items = V3Loader.load("pm-templates/v3/flat")
+    assertThat(items).isNotEmpty()
+    assertThat(items.all { it.sourceHash.isNotEmpty() }).isTrue()
+  }
+
+  @Test
+  fun `Step built from a v3-loaded item carries the item sourceHash`() {
+    // Mirror ReVoman.revUp: load -> deepFlattenItems -> Step. Verify the hash is carried forward.
+    val steps = deepFlattenItems(V3Loader.load("pm-templates/v3/flat"))
+    assertThat(steps).isNotEmpty()
+    assertThat(steps.all { it.sourceHash.isNotEmpty() }).isTrue()
+    // And each Step's hash matches its source Item's hash.
+    assertThat(steps.all { it.sourceHash == it.rawPMStep.sourceHash }).isTrue()
+  }
+}

--- a/src/test/resources/pm-templates/v3/ledger-body-consume/.resources/definition.yaml
+++ b/src/test/resources/pm-templates/v3/ledger-body-consume/.resources/definition.yaml
@@ -1,0 +1,1 @@
+$kind: collection

--- a/src/test/resources/pm-templates/v3/ledger-body-consume/01-produce-rule.request.yaml
+++ b/src/test/resources/pm-templates/v3/ledger-body-consume/01-produce-rule.request.yaml
@@ -1,0 +1,8 @@
+$kind: http-request
+url: "{{baseUrl}}/rule"
+method: GET
+order: 1000
+scripts:
+  - type: afterResponse
+    code: pm.environment.set("ruleId", "R1")
+    language: text/javascript

--- a/src/test/resources/pm-templates/v3/ledger-body-consume/02-link-uses-rule-in-body.request.yaml
+++ b/src/test/resources/pm-templates/v3/ledger-body-consume/02-link-uses-rule-in-body.request.yaml
@@ -1,0 +1,17 @@
+$kind: http-request
+url: "{{baseUrl}}/link"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: json
+  content: |-
+    {
+      "SchedulingRuleId": "{{ruleId}}",
+      "IsActive": true
+    }
+order: 2000
+scripts:
+  - type: afterResponse
+    code: pm.environment.set("linkId", "L1")
+    language: text/javascript

--- a/src/test/resources/pm-templates/v3/ledger-collision/.resources/definition.yaml
+++ b/src/test/resources/pm-templates/v3/ledger-collision/.resources/definition.yaml
@@ -1,0 +1,1 @@
+$kind: collection

--- a/src/test/resources/pm-templates/v3/ledger-collision/01-set-shared-early.request.yaml
+++ b/src/test/resources/pm-templates/v3/ledger-collision/01-set-shared-early.request.yaml
@@ -1,0 +1,8 @@
+$kind: http-request
+url: "{{baseUrl}}/early"
+method: GET
+order: 1000
+scripts:
+  - type: afterResponse
+    code: pm.environment.set("sharedId", "EARLY")
+    language: text/javascript

--- a/src/test/resources/pm-templates/v3/ledger-collision/02-set-shared-late.request.yaml
+++ b/src/test/resources/pm-templates/v3/ledger-collision/02-set-shared-late.request.yaml
@@ -1,0 +1,8 @@
+$kind: http-request
+url: "{{baseUrl}}/late"
+method: GET
+order: 2000
+scripts:
+  - type: afterResponse
+    code: pm.environment.set("sharedId", "LATE")
+    language: text/javascript

--- a/src/test/resources/pm-templates/v3/ledger-consume/.resources/definition.yaml
+++ b/src/test/resources/pm-templates/v3/ledger-consume/.resources/definition.yaml
@@ -1,0 +1,1 @@
+$kind: collection

--- a/src/test/resources/pm-templates/v3/ledger-consume/produce-and-consume.request.yaml
+++ b/src/test/resources/pm-templates/v3/ledger-consume/produce-and-consume.request.yaml
@@ -1,0 +1,8 @@
+$kind: http-request
+url: "{{baseUrl}}/echo?seed={{seedKey}}"
+method: GET
+order: 1000
+scripts:
+  - type: afterResponse
+    code: pm.environment.set("producedId", "P1")
+    language: text/javascript

--- a/src/test/resources/pm-templates/v3/ledger-skip/.resources/definition.yaml
+++ b/src/test/resources/pm-templates/v3/ledger-skip/.resources/definition.yaml
@@ -1,0 +1,1 @@
+$kind: collection

--- a/src/test/resources/pm-templates/v3/ledger-skip/produce-id.request.yaml
+++ b/src/test/resources/pm-templates/v3/ledger-skip/produce-id.request.yaml
@@ -1,0 +1,4 @@
+$kind: http-request
+url: "{{baseUrl}}/produce-id"
+method: GET
+order: 1000


### PR DESCRIPTION
## Ledger (A+B): step-level skip + warm-run inject

Adds an opt-in **ledger** mechanism so a warm ReVoman run can skip producer
steps whose env output is already known, and inject the ledgered values in
place of re-dispatching the HTTP step. First run **learns** (records
`stepPath -> {produces, sourceHash}` plus the produced env values); warm runs
**skip + inject**. Read-only steps (no `afterResponse` writes → empty
`produces`) are never skippable, so validation always runs.

Designed for the data-setup-heavy TDD inner loop: a cold run pays the full
setup cost once, warm runs collapse toward test-body-only.

### What's here
- **Capture** — per-step produced/consumed env keys surfaced on `StepReport`
  (`StepEnvVars`); consumed keys recorded on regex resolve.
- **Model** — `LedgerEntry` / `LedgerSnapshot` / `LedgerFile`.
- **Persistence** — `V3YamlReader.readLedger` + `V3YamlWriter` keep the ledger
  under an `x-revoman-ledger` **sibling** of `values:`, so the file stays a
  valid Postman environment (importable); `FileUtils.readLedgerYaml /
  writeLedgerYaml` facade; `FileUtils.readYamlMap` for flat config.
- **Staleness** — `Step.sourceHash` (sha256 of the `.request.yaml`) folded into
  each ledger entry; a changed producer flips the hash and re-runs that step
  alone.
- **Skip path** — `Kick.ledger()` + `ledgerSkipDecision` predicate; warm-path
  skip + inject in `executeStepsSerially`, emitting `learnedLedger`.

### Verification
- Full suite green (~153 tests).
- End-to-end **cold → warm → skip** round-trip proven against a real API
  (restful-api.dev) in the integration-tests module (final commit).
- Proven end-to-end in Salesforce Core (separate downstream PR): warm run skips
  all 22 producer steps, **~85–97% faster** than cold.

### Notes for reviewers
- The `x-revoman-ledger` key is intentionally a sibling of `values:` — never
  inside a value entry — so Postman ignores it and `Environment.kt`'s parser
  (top-level `values:` only) is unaffected.
- Empty produced-set is **never** skippable (guards against subset-match
  skipping everything).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
