### PR TITLE
@W-22337427 - Comprehensive per-run logs: HTTP exchange + env values, precision-safe JSON pretty-print

### DIFF
--- a/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
+++ b/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
@@ -377,13 +377,19 @@ object ReVoman {
             tookMs = currentStepReport.exeTimings.values.sumOf { it.toMillis() },
             outcome = if (currentStepReport.isSuccessful) Outcome.SUCCESS else Outcome.FAILED,
             requestMsg =
-              if (captureForSink &&
-                currentStepReport.requestInfo != null && currentStepReport.requestInfo.isRight)
+              if (
+                captureForSink &&
+                  currentStepReport.requestInfo != null &&
+                  currentStepReport.requestInfo.isRight
+              )
                 renderHttpMsg(currentStepReport.requestInfo.get().httpMsg)
               else null,
             responseMsg =
-              if (captureForSink &&
-                currentStepReport.responseInfo != null && currentStepReport.responseInfo.isRight)
+              if (
+                captureForSink &&
+                  currentStepReport.responseInfo != null &&
+                  currentStepReport.responseInfo.isRight
+              )
                 renderHttpMsg(currentStepReport.responseInfo.get().httpMsg)
               else null,
             producedValues =

--- a/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
+++ b/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
@@ -24,6 +24,7 @@ import com.salesforce.revoman.internal.exe.fireHttpRequest
 import com.salesforce.revoman.internal.exe.ledgerSkipDecision
 import com.salesforce.revoman.internal.exe.postStepHookExe
 import com.salesforce.revoman.internal.exe.preStepHookExe
+import com.salesforce.revoman.internal.exe.renderHttpMsg
 import com.salesforce.revoman.internal.exe.shadowedProducerPaths
 import com.salesforce.revoman.internal.exe.shouldHaltExecution
 import com.salesforce.revoman.internal.exe.shouldStepBePicked
@@ -363,6 +364,7 @@ object ReVoman {
                 ),
             )
         haltExecution = shouldHaltExecution(currentStepReport, kick, pm.rundown)
+        val captureForSink = RunLogContext.hasActiveSink()
         RevomanLog.event(
           StepEvent.StepFinished(
             path = step.path,
@@ -374,6 +376,28 @@ object ReVoman {
             consumed = currentStepReport.envVars.consumed,
             tookMs = currentStepReport.exeTimings.values.sumOf { it.toMillis() },
             outcome = if (currentStepReport.isSuccessful) Outcome.SUCCESS else Outcome.FAILED,
+            requestMsg =
+              if (captureForSink &&
+                currentStepReport.requestInfo != null && currentStepReport.requestInfo.isRight)
+                renderHttpMsg(currentStepReport.requestInfo.get().httpMsg)
+              else null,
+            responseMsg =
+              if (captureForSink &&
+                currentStepReport.responseInfo != null && currentStepReport.responseInfo.isRight)
+                renderHttpMsg(currentStepReport.responseInfo.get().httpMsg)
+              else null,
+            producedValues =
+              if (captureForSink)
+                currentStepReport.envVars.produced.associateWith {
+                  currentStepReport.pmEnvSnapshot[it]?.toString()
+                }
+              else emptyMap(),
+            consumedValues =
+              if (captureForSink)
+                currentStepReport.envVars.consumed.associateWith {
+                  currentStepReport.pmEnvSnapshot[it]?.toString()
+                }
+              else emptyMap(),
           )
         )
         stepReports + currentStepReport

--- a/src/main/kotlin/com/salesforce/revoman/internal/exe/HttpRequest.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/exe/HttpRequest.kt
@@ -10,6 +10,7 @@ package com.salesforce.revoman.internal.exe
 import arrow.core.Either
 import com.salesforce.revoman.internal.json.MoshiReVoman
 import com.salesforce.revoman.output.ExeType.HTTP_REQUEST
+import com.salesforce.revoman.output.json.JsonPretty
 import com.salesforce.revoman.output.report.Step
 import com.salesforce.revoman.output.report.TxnInfo
 import com.salesforce.revoman.output.report.failure.RequestFailure.HttpRequestFailure
@@ -21,6 +22,7 @@ import org.apache.hc.client5.http.ssl.NoopHostnameVerifier
 import org.apache.hc.core5.ssl.SSLContextBuilder
 import org.http4k.client.ApacheClient
 import org.http4k.core.HttpHandler
+import org.http4k.core.HttpMessage
 import org.http4k.core.Request
 import org.http4k.core.Response
 import org.http4k.core.then
@@ -41,6 +43,23 @@ internal fun fireHttpRequest(
     }
     .mapLeft { HttpRequestFailure(it, TxnInfo(httpMsg = httpRequest, moshiReVoman = moshiReVoman)) }
     .map { TxnInfo(httpMsg = it, moshiReVoman = moshiReVoman) }
+
+/**
+ * Render an http4k [HttpMessage] for the run log: the wire text with `\r\n` normalized to `\n`, and
+ * the body (everything after the first blank line) pretty-printed via [JsonPretty] when it is JSON
+ * (non-JSON bodies pass through unchanged). The request/status line and headers are left as-is.
+ * Single source of truth for the http4k message shape, so any
+ * [com.salesforce.revoman.output.log.RunLogSink] consumer receives an already-beautified exchange.
+ */
+@JvmSynthetic
+internal fun renderHttpMsg(httpMsg: HttpMessage): String {
+  val normalized = httpMsg.toString().replace("\r\n", "\n")
+  val sep = normalized.indexOf("\n\n")
+  if (sep < 0) return normalized // no body
+  val head = normalized.substring(0, sep + 2)
+  val body = normalized.substring(sep + 2)
+  return head + JsonPretty.pretty(body)
+}
 
 internal fun prepareHttpClient(insecureHttp: Boolean): HttpHandler =
   DebuggingFilters.PrintRequestAndResponse()

--- a/src/main/kotlin/com/salesforce/revoman/internal/exe/HttpRequest.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/exe/HttpRequest.kt
@@ -25,8 +25,6 @@ import org.http4k.core.HttpHandler
 import org.http4k.core.HttpMessage
 import org.http4k.core.Request
 import org.http4k.core.Response
-import org.http4k.core.then
-import org.http4k.filter.DebuggingFilters
 
 @JvmSynthetic
 internal fun fireHttpRequest(
@@ -62,8 +60,7 @@ internal fun renderHttpMsg(httpMsg: HttpMessage): String {
 }
 
 internal fun prepareHttpClient(insecureHttp: Boolean): HttpHandler =
-  DebuggingFilters.PrintRequestAndResponse()
-    .then(if (insecureHttp) ApacheClient(client = insecureApacheHttpClient()) else ApacheClient())
+  if (insecureHttp) ApacheClient(client = insecureApacheHttpClient()) else ApacheClient()
 
 /** WARNING: Only for Testing. DO NOT USE IN PROD */
 private fun insecureApacheHttpClient(): CloseableHttpClient =

--- a/src/main/kotlin/com/salesforce/revoman/internal/json/adapters/BigDecimalAdapter.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/json/adapters/BigDecimalAdapter.kt
@@ -16,10 +16,12 @@ object BigDecimalAdapter {
   // Write the BigDecimal as an EXACT JSON number. JsonWriter.value(Number) emits the Number's
   // toString() verbatim as a bare JSON number — no Double hop, so full precision is preserved
   // (the old `value.toDouble()` rounded, e.g. 5 -> 5.0 and large/high-scale values to E-notation).
-  @ToJson fun toJson(writer: JsonWriter, value: BigDecimal) {
+  @ToJson
+  fun toJson(writer: JsonWriter, value: BigDecimal) {
     writer.value(value as Number)
   }
 
-  // Read side is already exact: the number token is consumed as its literal string and reconstructed.
+  // Read side is already exact: the number token is consumed as its literal string and
+  // reconstructed.
   @FromJson fun fromJson(string: String): BigDecimal = BigDecimal(string)
 }

--- a/src/main/kotlin/com/salesforce/revoman/internal/json/adapters/BigDecimalAdapter.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/json/adapters/BigDecimalAdapter.kt
@@ -8,11 +8,18 @@
 package com.salesforce.revoman.internal.json.adapters
 
 import com.squareup.moshi.FromJson
+import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.ToJson
 import java.math.BigDecimal
 
 object BigDecimalAdapter {
-  @ToJson fun toJson(value: BigDecimal) = value.toDouble()
+  // Write the BigDecimal as an EXACT JSON number. JsonWriter.value(Number) emits the Number's
+  // toString() verbatim as a bare JSON number — no Double hop, so full precision is preserved
+  // (the old `value.toDouble()` rounded, e.g. 5 -> 5.0 and large/high-scale values to E-notation).
+  @ToJson fun toJson(writer: JsonWriter, value: BigDecimal) {
+    writer.value(value as Number)
+  }
 
-  @FromJson fun fromJson(string: String) = BigDecimal(string)
+  // Read side is already exact: the number token is consumed as its literal string and reconstructed.
+  @FromJson fun fromJson(string: String): BigDecimal = BigDecimal(string)
 }

--- a/src/main/kotlin/com/salesforce/revoman/internal/log/RunLogContext.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/log/RunLogContext.kt
@@ -28,6 +28,17 @@ internal object RunLogContext {
 
   fun current(): RunLogSink? = holder.get()
 
+  /**
+   * True only when a NON-NoOp sink is installed for the current run. The emit site uses this to
+   * SKIP eagerly rendering the (potentially large) HTTP request/response + env-value maps when no
+   * real consumer will read them — so the default no-sink path (every library consumer that does
+   * not set `runLogSink`) pays zero rendering cost, exactly as before this capture existed.
+   */
+  fun hasActiveSink(): Boolean {
+    val sink = holder.get()
+    return sink != null && sink !== RunLogSink.NoOp
+  }
+
   fun remove() = holder.remove()
 }
 

--- a/src/main/kotlin/com/salesforce/revoman/output/json/JsonPretty.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/json/JsonPretty.kt
@@ -49,7 +49,8 @@ object JsonPretty {
           i = end + 1
           continue
         }
-        '{', '[' -> {
+        '{',
+        '[' -> {
           val next = nextNonWs(json, i + 1)
           if (next < n && ((c == '{' && json[next] == '}') || (c == '[' && json[next] == ']'))) {
             sb.append(c).append(json[next])
@@ -59,13 +60,17 @@ object JsonPretty {
           depth++
           sb.append(c).append('\n').append(indent.repeat(depth))
         }
-        '}', ']' -> {
+        '}',
+        ']' -> {
           depth--
           sb.append('\n').append(indent.repeat(depth)).append(c)
         }
         ',' -> sb.append(",\n").append(indent.repeat(depth))
         ':' -> sb.append(": ")
-        ' ', '\t', '\n', '\r' -> {} // drop existing insignificant whitespace
+        ' ',
+        '\t',
+        '\n',
+        '\r' -> {} // drop existing insignificant whitespace
         else -> sb.append(c)
       }
       i++

--- a/src/main/kotlin/com/salesforce/revoman/output/json/JsonPretty.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/json/JsonPretty.kt
@@ -1,0 +1,94 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.output.json
+
+/**
+ * Re-indents already-valid JSON to a pretty, multi-line form WITHOUT reparsing values — a
+ * whitespace-only transform. Unlike a parse→model→serialize round-trip (e.g. Moshi, whose
+ * `BigDecimalAdapter` historically collapsed numbers to `Double`), this copies every
+ * string/number/literal byte-for-byte, so `5` stays `5` (not `5.0`) and a large numeric id keeps
+ * full precision — the guarantee a verbatim run-log needs.
+ *
+ * Structural tokens `{ } [ ] , :` outside string literals drive indentation; everything inside a
+ * string literal (quotes + `\`-escapes respected) is emitted unchanged. Input that is not
+ * well-formed JSON (an HTML error body, an empty/blank string, a bare token) is returned unchanged
+ * — best-effort, since an HTTP body may not be JSON at all.
+ *
+ * Public, library-owned API: used internally by ReVoman (HTTP request/response body rendering) and
+ * consumed by external sinks (e.g. Core's per-test run log).
+ */
+object JsonPretty {
+  @JvmStatic
+  @JvmOverloads
+  fun pretty(json: String, indent: String = "  "): String {
+    val trimmed = json.trim()
+    if (trimmed.isEmpty() || (trimmed[0] != '{' && trimmed[0] != '[')) return json
+    return try {
+      reindent(trimmed, indent)
+    } catch (e: RuntimeException) {
+      json // malformed — best-effort passthrough
+    }
+  }
+
+  private fun reindent(json: String, indent: String): String {
+    val sb = StringBuilder(json.length + json.length / 4)
+    var depth = 0
+    var i = 0
+    val n = json.length
+    while (i < n) {
+      val c = json[i]
+      when (c) {
+        '"' -> {
+          val end = endOfString(json, i)
+          sb.append(json, i, end + 1)
+          i = end + 1
+          continue
+        }
+        '{', '[' -> {
+          val next = nextNonWs(json, i + 1)
+          if (next < n && ((c == '{' && json[next] == '}') || (c == '[' && json[next] == ']'))) {
+            sb.append(c).append(json[next])
+            i = next + 1
+            continue
+          }
+          depth++
+          sb.append(c).append('\n').append(indent.repeat(depth))
+        }
+        '}', ']' -> {
+          depth--
+          sb.append('\n').append(indent.repeat(depth)).append(c)
+        }
+        ',' -> sb.append(",\n").append(indent.repeat(depth))
+        ':' -> sb.append(": ")
+        ' ', '\t', '\n', '\r' -> {} // drop existing insignificant whitespace
+        else -> sb.append(c)
+      }
+      i++
+    }
+    return sb.toString()
+  }
+
+  /** Index of the closing quote of the string literal that starts at `start` ('"'). */
+  private fun endOfString(json: String, start: Int): Int {
+    var i = start + 1
+    while (i < json.length) {
+      when (json[i]) {
+        '\\' -> i += 2 // skip the escaped char
+        '"' -> return i
+        else -> i++
+      }
+    }
+    throw IllegalStateException("unterminated string at $start")
+  }
+
+  private fun nextNonWs(json: String, from: Int): Int {
+    var i = from
+    while (i < json.length && json[i].isWhitespace()) i++
+    return i
+  }
+}

--- a/src/main/kotlin/com/salesforce/revoman/output/log/StepEvent.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/log/StepEvent.kt
@@ -33,6 +33,14 @@ sealed interface StepEvent {
     val consumed: Set<String>,
     val tookMs: Long,
     val outcome: Outcome,
+    /** Full HTTP request as `\n`-normalized wire text, JSON body pretty-printed; null if absent. */
+    val requestMsg: String? = null,
+    /** Full HTTP response as `\n`-normalized wire text, JSON body pretty-printed; null on failure. */
+    val responseMsg: String? = null,
+    /** Produced env keys mapped to their post-step values (`toString()`); empty if none. */
+    val producedValues: Map<String, String?> = emptyMap(),
+    /** Consumed env keys mapped to their post-step values (`toString()`); empty if none. */
+    val consumedValues: Map<String, String?> = emptyMap(),
   ) : StepEvent
 
   data class LedgerSkipped(override val path: String, val reused: Set<String>) : StepEvent

--- a/src/main/kotlin/com/salesforce/revoman/output/log/StepEvent.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/log/StepEvent.kt
@@ -35,7 +35,9 @@ sealed interface StepEvent {
     val outcome: Outcome,
     /** Full HTTP request as `\n`-normalized wire text, JSON body pretty-printed; null if absent. */
     val requestMsg: String? = null,
-    /** Full HTTP response as `\n`-normalized wire text, JSON body pretty-printed; null on failure. */
+    /**
+     * Full HTTP response as `\n`-normalized wire text, JSON body pretty-printed; null on failure.
+     */
     val responseMsg: String? = null,
     /** Produced env keys mapped to their post-step values (`toString()`); empty if none. */
     val producedValues: Map<String, String?> = emptyMap(),

--- a/src/test/kotlin/com/salesforce/revoman/internal/exe/RenderHttpMsgTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/exe/RenderHttpMsgTest.kt
@@ -1,0 +1,46 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.exe
+
+import com.google.common.truth.Truth.assertThat
+import org.http4k.core.Method
+import org.http4k.core.Request
+import org.http4k.core.Response
+import org.http4k.core.Status
+import org.junit.jupiter.api.Test
+
+class RenderHttpMsgTest {
+  @Test
+  fun `normalizes CRLF and pretty-prints a json body`() {
+    val req =
+      Request(Method.POST, "https://localhost:6101/x")
+        .header("Content-Type", "application/json")
+        .body("""{"a":1,"b":[2,3]}""")
+    val rendered = renderHttpMsg(req)
+    assertThat(rendered).doesNotContain("\r")
+    assertThat(rendered).contains("POST https://localhost:6101/x")
+    assertThat(rendered).contains("Content-Type: application/json")
+    assertThat(rendered).contains("\"a\": 1")
+    assertThat(rendered).contains("    2,")
+  }
+
+  @Test
+  fun `leaves a non-json body verbatim`() {
+    val res = Response(Status.OK).body("plain text, not json")
+    val rendered = renderHttpMsg(res)
+    assertThat(rendered).contains("plain text, not json")
+  }
+
+  @Test
+  fun `handles a message with no body`() {
+    val req = Request(Method.GET, "https://localhost:6101/ping")
+    val rendered = renderHttpMsg(req)
+    assertThat(rendered).doesNotContain("\r")
+    assertThat(rendered).contains("GET https://localhost:6101/ping")
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/internal/json/adapters/BigDecimalAdapterTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/json/adapters/BigDecimalAdapterTest.kt
@@ -1,0 +1,51 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.json.adapters
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
+import java.math.BigDecimal
+import org.junit.jupiter.api.Test
+
+class BigDecimalAdapterTest {
+  private val moshi = initMoshi()
+
+  @Test
+  fun `serializes a BigDecimal as an exact json number, not a rounded double`() {
+    val precise = BigDecimal("1234567890123456789.123456789")
+    val json = moshi.toJson(precise, sourceType = BigDecimal::class.java)
+    assertThat(json).isEqualTo("1234567890123456789.123456789")
+  }
+
+  @Test
+  fun `round-trips a BigDecimal without loss`() {
+    val precise = BigDecimal("1234567890123456789.123456789")
+    val json = moshi.toJson(precise, sourceType = BigDecimal::class.java)
+    val back = moshi.fromJson<BigDecimal>(json, BigDecimal::class.java)
+    assertThat(back).isEqualTo(precise)
+  }
+
+  @Test
+  fun `serializes integer-valued BigDecimal without trailing zero`() {
+    // The old toDouble() rendered 5 as 5.0; toString() keeps it 5.
+    assertThat(moshi.toJson(BigDecimal("5"), sourceType = BigDecimal::class.java)).isEqualTo("5")
+  }
+
+  @Test
+  fun `serializes negative high-precision BigDecimal verbatim`() {
+    val negative = BigDecimal("-1234567890123456789.123456789")
+    assertThat(moshi.toJson(negative, sourceType = BigDecimal::class.java))
+      .isEqualTo("-1234567890123456789.123456789")
+  }
+
+  @Test
+  fun `preserves zero scale`() {
+    assertThat(moshi.toJson(BigDecimal("0.00"), sourceType = BigDecimal::class.java)).isEqualTo("0.00")
+    assertThat(moshi.toJson(BigDecimal("0"), sourceType = BigDecimal::class.java)).isEqualTo("0")
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/internal/json/adapters/BigDecimalAdapterTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/json/adapters/BigDecimalAdapterTest.kt
@@ -45,7 +45,8 @@ class BigDecimalAdapterTest {
 
   @Test
   fun `preserves zero scale`() {
-    assertThat(moshi.toJson(BigDecimal("0.00"), sourceType = BigDecimal::class.java)).isEqualTo("0.00")
+    assertThat(moshi.toJson(BigDecimal("0.00"), sourceType = BigDecimal::class.java))
+      .isEqualTo("0.00")
     assertThat(moshi.toJson(BigDecimal("0"), sourceType = BigDecimal::class.java)).isEqualTo("0")
   }
 }

--- a/src/test/kotlin/com/salesforce/revoman/internal/log/RunLogContextActiveSinkTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/log/RunLogContextActiveSinkTest.kt
@@ -31,11 +31,15 @@ class RunLogContextActiveSinkTest {
 
   @Test
   fun `real sink - active`() {
-    RunLogContext.install(object : RunLogSink {
-      override fun line(level: LogLevel, message: String) {}
-      override fun event(event: StepEvent) {}
-      override fun close() {}
-    })
+    RunLogContext.install(
+      object : RunLogSink {
+        override fun line(level: LogLevel, message: String) {}
+
+        override fun event(event: StepEvent) {}
+
+        override fun close() {}
+      }
+    )
     assertThat(RunLogContext.hasActiveSink()).isTrue()
   }
 }

--- a/src/test/kotlin/com/salesforce/revoman/internal/log/RunLogContextActiveSinkTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/log/RunLogContextActiveSinkTest.kt
@@ -1,0 +1,41 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.log
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.output.log.LogLevel
+import com.salesforce.revoman.output.log.RunLogSink
+import com.salesforce.revoman.output.log.StepEvent
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+
+class RunLogContextActiveSinkTest {
+  @AfterEach fun cleanup() = RunLogContext.remove()
+
+  @Test
+  fun `no sink installed - not active`() {
+    RunLogContext.remove()
+    assertThat(RunLogContext.hasActiveSink()).isFalse()
+  }
+
+  @Test
+  fun `NoOp sink - not active`() {
+    RunLogContext.install(RunLogSink.NoOp)
+    assertThat(RunLogContext.hasActiveSink()).isFalse()
+  }
+
+  @Test
+  fun `real sink - active`() {
+    RunLogContext.install(object : RunLogSink {
+      override fun line(level: LogLevel, message: String) {}
+      override fun event(event: StepEvent) {}
+      override fun close() {}
+    })
+    assertThat(RunLogContext.hasActiveSink()).isTrue()
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/output/json/JsonPrettyTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/output/json/JsonPrettyTest.kt
@@ -1,0 +1,71 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.output.json
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class JsonPrettyTest {
+  @Test
+  fun `nests objects and arrays with two-space indent`() {
+    assertThat(JsonPretty.pretty("""{"a":1,"b":[2,3]}"""))
+      .isEqualTo("{\n  \"a\": 1,\n  \"b\": [\n    2,\n    3\n  ]\n}")
+  }
+
+  @Test
+  fun `preserves structural chars inside a string literal`() {
+    assertThat(JsonPretty.pretty("""{"q":"a,b:{c}"}"""))
+      .isEqualTo("{\n  \"q\": \"a,b:{c}\"\n}")
+  }
+
+  @Test
+  fun `respects escaped quote inside a string`() {
+    assertThat(JsonPretty.pretty("""{"q":"he said \"hi\""}"""))
+      .isEqualTo("{\n  \"q\": \"he said \\\"hi\\\"\"\n}")
+  }
+
+  @Test
+  fun `preserves integer and large-id precision verbatim`() {
+    assertThat(JsonPretty.pretty("""{"n":5,"id":1234567890123}"""))
+      .isEqualTo("{\n  \"n\": 5,\n  \"id\": 1234567890123\n}")
+  }
+
+  @Test
+  fun `returns non-json input unchanged`() {
+    assertThat(JsonPretty.pretty("<html>not json</html>")).isEqualTo("<html>not json</html>")
+    assertThat(JsonPretty.pretty("")).isEqualTo("")
+    assertThat(JsonPretty.pretty("   ")).isEqualTo("   ")
+  }
+
+  @Test
+  fun `empty object and array stay compact`() {
+    assertThat(JsonPretty.pretty("""{"a":{},"b":[]}"""))
+      .isEqualTo("{\n  \"a\": {},\n  \"b\": []\n}")
+  }
+
+  @Test
+  fun `handles escaped backslash before closing quote`() {
+    // value is  C:\  — the \\ is an escaped backslash, the next " is the real terminator.
+    assertThat(JsonPretty.pretty("""{"path":"C:\\"}"""))
+      .isEqualTo("{\n  \"path\": \"C:\\\\\"\n}")
+  }
+
+  @Test
+  fun `preserves escape sequences as literal two-char sequences`() {
+    // \n and \t inside the string must stay the two characters backslash-n / backslash-t,
+    // NOT become a real newline/tab.
+    assertThat(JsonPretty.pretty("""{"msg":"line1\nline2\ttab"}"""))
+      .isEqualTo("{\n  \"msg\": \"line1\\nline2\\ttab\"\n}")
+  }
+
+  @Test
+  fun `honors a custom indent`() {
+    assertThat(JsonPretty.pretty("""{"a":1}""", "    "))
+      .isEqualTo("{\n    \"a\": 1\n}")
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/output/json/JsonPrettyTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/output/json/JsonPrettyTest.kt
@@ -19,8 +19,7 @@ class JsonPrettyTest {
 
   @Test
   fun `preserves structural chars inside a string literal`() {
-    assertThat(JsonPretty.pretty("""{"q":"a,b:{c}"}"""))
-      .isEqualTo("{\n  \"q\": \"a,b:{c}\"\n}")
+    assertThat(JsonPretty.pretty("""{"q":"a,b:{c}"}""")).isEqualTo("{\n  \"q\": \"a,b:{c}\"\n}")
   }
 
   @Test
@@ -51,8 +50,7 @@ class JsonPrettyTest {
   @Test
   fun `handles escaped backslash before closing quote`() {
     // value is  C:\  — the \\ is an escaped backslash, the next " is the real terminator.
-    assertThat(JsonPretty.pretty("""{"path":"C:\\"}"""))
-      .isEqualTo("{\n  \"path\": \"C:\\\\\"\n}")
+    assertThat(JsonPretty.pretty("""{"path":"C:\\"}""")).isEqualTo("{\n  \"path\": \"C:\\\\\"\n}")
   }
 
   @Test
@@ -65,7 +63,6 @@ class JsonPrettyTest {
 
   @Test
   fun `honors a custom indent`() {
-    assertThat(JsonPretty.pretty("""{"a":1}""", "    "))
-      .isEqualTo("{\n    \"a\": 1\n}")
+    assertThat(JsonPretty.pretty("""{"a":1}""", "    ")).isEqualTo("{\n    \"a\": 1\n}")
   }
 }

--- a/src/test/kotlin/com/salesforce/revoman/output/log/StepEventTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/output/log/StepEventTest.kt
@@ -1,0 +1,51 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.output.log
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class StepEventTest {
+  @Test
+  fun `StepFinished defaults keep new capture fields empty for back-compat`() {
+    val e =
+      StepEvent.StepFinished(
+        path = "auth/login",
+        httpStatus = 200,
+        produced = setOf("accessToken"),
+        consumed = setOf("baseUrl"),
+        tookMs = 12,
+        outcome = Outcome.SUCCESS,
+      )
+    assertThat(e.requestMsg).isNull()
+    assertThat(e.responseMsg).isNull()
+    assertThat(e.producedValues).isEmpty()
+    assertThat(e.consumedValues).isEmpty()
+  }
+
+  @Test
+  fun `StepFinished carries the rendered exchange and value maps`() {
+    val e =
+      StepEvent.StepFinished(
+        path = "auth/login",
+        httpStatus = 200,
+        produced = setOf("accessToken"),
+        consumed = setOf("baseUrl"),
+        tookMs = 12,
+        outcome = Outcome.SUCCESS,
+        requestMsg = "POST /login\n\n{}",
+        responseMsg = "HTTP/1.1 200 OK\n\n{}",
+        producedValues = mapOf("accessToken" to "tok"),
+        consumedValues = mapOf("baseUrl" to "https://x"),
+      )
+    assertThat(e.requestMsg).isEqualTo("POST /login\n\n{}")
+    assertThat(e.responseMsg).isEqualTo("HTTP/1.1 200 OK\n\n{}")
+    assertThat(e.producedValues).containsEntry("accessToken", "tok")
+    assertThat(e.consumedValues).containsEntry("baseUrl", "https://x")
+  }
+}


### PR DESCRIPTION
## What

Make ReVoman's per-run narration **comprehensive enough for an AI/human to understand an execution from the log alone**, and fix a latent JSON number-precision bug.

### Changes
1. **`fix(json)` — `BigDecimalAdapter.toJson` precision loss (root cause).** It returned `value.toDouble()`, so a `BigDecimal` serialized through a lossy `Double` (`5` → `5.0`, large/high-scale → E-notation). Now writes the exact JSON number via Moshi `JsonWriter.value(Number)` (emits `toString()` verbatim, no `Double` hop). Read side was already exact.
2. **`feat(json)` — new public `JsonPretty`.** A precision-safe **structural** JSON re-indenter (`com.salesforce.revoman.output.json.JsonPretty`): whitespace-only transform driven by `{ } [ ] , :` outside string literals, copies every string/number/literal byte-for-byte (so numbers keep full precision, unlike a Moshi round-trip), passes non-JSON through unchanged. Used internally (HTTP body rendering) and consumable by downstream sinks (Core's per-test run log).
3. **`feat(log)` — `StepEvent.StepFinished` carries the exchange + values.** Four new *defaulted* fields (back-compat): `requestMsg`, `responseMsg` (full http4k wire message, `\r\n`→`\n` normalized, JSON body pretty-printed via `JsonPretty`), and `producedValues`/`consumedValues` (env key→value maps, not just key names).
4. **`feat(exe)` — `renderHttpMsg`** helper that produces those rendered messages; and the redundant `DebuggingFilters.PrintRequestAndResponse()` **stdout dump removed** from `prepareHttpClient` (the structured event now carries the exchange).
5. **Cost guard:** the new fields are populated **only when a non-NoOp `RunLogSink` is installed** (`RunLogContext.hasActiveSink()`), so library consumers that don't attach a sink pay zero per-step `toString()`/`JsonPretty` cost — identical to before.

## Why

The per-test run log (consumed in Salesforce Core) previously had step-boundary JSON + narration but **never the actual HTTP request/response**, and produced/consumed showed only key *names*. An AI reading the log couldn't see what a step sent, what came back, or what values flowed through the env. These changes make the log self-sufficient.

## Tests
- `BigDecimalAdapterTest` (5): exact-digit serialization, lossless round-trip, integer-no-trailing-zero, negative high-precision, zero-scale.
- `JsonPrettyTest` (9): nesting, string-with-structural-chars, escaped quote, escaped-backslash-before-quote, escape-sequence preservation, integer/large-id precision, custom indent, empty containers, non-JSON passthrough.
- `StepEventTest` (2): defaults-empty back-compat + fields-carried.
- `RenderHttpMsgTest` (3): CRLF-normalize + body-pretty, non-JSON verbatim, no-body.
- `RunLogContextActiveSinkTest` (3): no-sink / NoOp / real-sink gating.
- Full suite green (230 tests); end-to-end verified in Salesforce Core against a live org (request/response blocks + value-objects render; numbers exact).

## Notes
All four `StepFinished` fields are defaulted, so this is **purely additive** to the public API — existing consumers compile and behave unchanged.
