### PR TITLE
@W-22813362 - Wire script-only pm APIs (collectionVariables, environment.name, request/response, test/expect, setNextRequest) through ReVoman + coverage tests

### DIFF
--- a/docs/superpowers/plans/2026-06-11-pm-sandbox-api-coverage.md
+++ b/docs/superpowers/plans/2026-06-11-pm-sandbox-api-coverage.md
@@ -1,0 +1,970 @@
+# PM Sandbox — Full Wiring of Script-Only `pm` APIs + Coverage Tests — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `pm.collectionVariables`, `pm.environment.name`, `pm.test`/`pm.expect` results, and `pm.execution.setNextRequest` observable end-to-end through a real `ReVoman.revUp(...)` run (they currently run in the sandbox but are dropped before reaching `Rundown`), and lock every listed script-only `pm` API with unit + a live integration test.
+
+**Architecture:** Thread `collectionVariables` + environment `name` INTO the sandbox via `PmExecutionContext`; read `collectionVariables`, `assertions`, and `nextRequest` back OUT of `PmExecutionResult`; diff collection-vars back into a new `PostmanSDK.collectionVariables` store (mirroring the env path); stash per-step assertions + nextRequest on `PostmanSDK` and surface them as two new read-only `StepReport` fields. `setNextRequest` is captured + warned-on, NOT executed (the jump-capable sequencer is a separate deferred cycle).
+
+**Tech Stack:** Kotlin, GraalJS (real postman-sandbox bootcode), Moshi, Kotest + JUnit5 (unit), JUnit5 + Truth/AssertJ (integration, live HTTP to pokeapi.co + restful-api.dev).
+
+**Spec:** `docs/superpowers/specs/2026-06-11-pm-sandbox-api-coverage-design.md`
+
+---
+
+## Current State (already done this session — do NOT redo)
+
+These are committed/uncommitted WIP and are GREEN; tasks below build on them:
+
+- `PmScope` has an optional `name: String? = null` field (`PmExecutionContext.kt`).
+- `SandboxBridge.scopeToProxy` forwards `name`; `decodeResult` captures `execution.return.nextRequest` into `PmExecutionResult.nextRequest`.
+- `PmSandboxApiCoverageTest` (11 tests) + 2 added tests in `PmSandboxScriptApiTest` — all GREEN. These cover every listed API **at the sandbox layer**.
+
+The work below wires those sandbox-proven APIs through **ReVoman's exe layer** so they reach `Rundown`.
+
+---
+
+## File Structure
+
+**Created (production):**
+- `src/main/kotlin/com/salesforce/revoman/output/report/PmTestAssertion.kt` — public assertion type for `StepReport`.
+
+**Modified (production):**
+- `src/main/kotlin/com/salesforce/revoman/internal/postman/PostmanSDK.kt` — add `collectionVariables` store, `environmentName`, per-step assertion/nextRequest capture.
+- `src/main/kotlin/com/salesforce/revoman/internal/postman/template/Environment.kt` — `mergeEnvs` returns values + env name.
+- `src/main/kotlin/com/salesforce/revoman/internal/exe/PmJsEval.kt` — thread collectionVariables + name in; diff cVars out; map+stash assertions/nextRequest; warn on nextRequest.
+- `src/main/kotlin/com/salesforce/revoman/output/report/StepReport.kt` — two new read-only fields.
+- `src/main/kotlin/com/salesforce/revoman/ReVoman.kt` — unpack `mergeEnvs` result, set `pm.environmentName`, populate new StepReport fields in the fold.
+
+**Created (tests):**
+- `src/test/kotlin/com/salesforce/revoman/internal/postman/PostmanSDKCollectionVariablesTest.kt`
+- `src/test/kotlin/com/salesforce/revoman/internal/postman/template/MergeEnvsNameTest.kt`
+- `src/integrationTest/java/com/salesforce/revoman/integration/pokemon/PokemonSandboxApiTest.java`
+- `src/integrationTest/resources/pm-templates/v2/pokemon-sandbox-api/pokemon-sandbox-api.postman_collection.json`
+- `src/integrationTest/resources/pm-templates/v2/pokemon-sandbox-api/pokemon-sandbox-api.postman_environment.json`
+
+---
+
+## Task 1: Public `PmTestAssertion` type
+
+**Files:**
+- Create: `src/main/kotlin/com/salesforce/revoman/output/report/PmTestAssertion.kt`
+
+**Context:** The bridge's `PmAssertion` is `internal` to the `sandbox` package. We must not leak an internal type onto the public `StepReport` API, so we add a public mirror in `output.report` and map to it in `PmJsEval`.
+
+- [ ] **Step 1: Write the type (no test — pure public data class, exercised by Task 5/6 tests)**
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.output.report
+
+/**
+ * The result of a single `pm.test(name, fn)` assertion block reported by the Postman sandbox.
+ * Attached to [StepReport.pmTestAssertions]. A failing assertion is DATA here (not a thrown error):
+ * [passed] is false and [error] carries the chai/AssertionError message. [skipped] is true for
+ * `pm.test.skip(...)`.
+ */
+data class PmTestAssertion
+@JvmOverloads
+constructor(
+  @JvmField val name: String,
+  @JvmField val passed: Boolean,
+  @JvmField val skipped: Boolean = false,
+  @JvmField val error: String? = null,
+)
+```
+
+- [ ] **Step 2: Compile**
+
+Run: `./gradlew compileKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/kotlin/com/salesforce/revoman/output/report/PmTestAssertion.kt
+git commit -m "feat(report): public PmTestAssertion type for StepReport"
+```
+
+---
+
+## Task 2: `PostmanSDK` — collectionVariables store + environmentName + per-step capture
+
+**Files:**
+- Modify: `src/main/kotlin/com/salesforce/revoman/internal/postman/PostmanSDK.kt`
+- Test: `src/test/kotlin/com/salesforce/revoman/internal/postman/PostmanSDKCollectionVariablesTest.kt`
+
+**Context:** `PostmanSDK` already holds `environment: PostmanEnvironment<Any?>`. We add a parallel `collectionVariables` store (same wrapper type — gives `set`/`unset`/`toMap`-via-`mutableEnv` for free, and its ledger capture stays dormant because we never set its `currentStep`), an `environmentName`, and per-`Step` capture maps for assertions + nextRequest that `PmJsEval` writes and the fold reads.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.postman
+
+import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
+import com.salesforce.revoman.internal.postman.template.Item
+import com.salesforce.revoman.output.report.PmTestAssertion
+import com.salesforce.revoman.output.report.Step
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class PostmanSDKCollectionVariablesTest {
+  private fun sdk() = PostmanSDK(initMoshi())
+
+  private fun step(name: String) = Step(index = "1", rawPMStep = Item(name = name))
+
+  @Test
+  fun `collectionVariables store round-trips set and toMap`() {
+    val pm = sdk()
+    pm.collectionVariables.set("a", "1")
+    pm.collectionVariables.toMap() shouldBe mapOf("a" to "1")
+  }
+
+  @Test
+  fun `environmentName defaults to null and is settable`() {
+    val pm = sdk()
+    pm.environmentName shouldBe null
+    pm.environmentName = "Pokemon"
+    pm.environmentName shouldBe "Pokemon"
+  }
+
+  @Test
+  fun `per-step pmTestAssertions capture is keyed by step`() {
+    val pm = sdk()
+    val s1 = step("s1")
+    val assertions = listOf(PmTestAssertion("t", passed = true))
+    pm.recordPmTestAssertions(s1, assertions)
+    pm.pmTestAssertionsFor(s1) shouldHaveSize 1
+    pm.pmTestAssertionsFor(step("other")) shouldHaveSize 0
+  }
+
+  @Test
+  fun `per-step pmTestAssertions accumulate across pre-req and post-res`() {
+    val pm = sdk()
+    val s1 = step("s1")
+    pm.recordPmTestAssertions(s1, listOf(PmTestAssertion("pre", passed = true)))
+    pm.recordPmTestAssertions(s1, listOf(PmTestAssertion("post", passed = false)))
+    pm.pmTestAssertionsFor(s1) shouldHaveSize 2
+  }
+
+  @Test
+  fun `per-step nextRequest capture is keyed by step and last-write-wins`() {
+    val pm = sdk()
+    val s1 = step("s1")
+    pm.recordNextRequest(s1, "first")
+    pm.recordNextRequest(s1, "second")
+    pm.nextRequestFor(s1) shouldBe "second"
+    pm.nextRequestFor(step("other")) shouldBe null
+  }
+}
+```
+
+> `Step(index, rawPMStep)` + `Item(name=...)` is the existing constructor pattern used across this repo's tests (e.g. `LedgerDecisionTest`, `RegexReplacerConsumedTest`). Two `Step` instances with the same name+index are equal (data class) — fine for keying; the "other" step uses a different name so it won't collide.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew test --tests "com.salesforce.revoman.internal.postman.PostmanSDKCollectionVariablesTest"`
+Expected: FAIL — `collectionVariables` / `environmentName` / `recordPmTestAssertions` unresolved.
+
+- [ ] **Step 3: Write the implementation**
+
+In `PostmanSDK.kt`, add imports near the top:
+
+```kotlin
+import com.salesforce.revoman.output.report.PmTestAssertion
+```
+
+Add fields right after the existing `environment` field (line ~38):
+
+```kotlin
+  @JvmField val environment: PostmanEnvironment<Any?> = PostmanEnvironment(mutableEnv, moshiReVoman)
+
+  /**
+   * Collection-level variables (`pm.collectionVariables`). A plain key→value store reusing
+   * [PostmanEnvironment] for its set/unset/toMap utilities; its per-step ledger capture stays
+   * dormant because [PostmanEnvironment.currentStep] is never set on this instance. Script-seeded
+   * only (ReVoman does not parse collection-root `variable[]`), so it starts empty and is populated
+   * by scripts calling `pm.collectionVariables.set(...)`.
+   */
+  @JvmField
+  val collectionVariables: PostmanEnvironment<Any?> = PostmanEnvironment(mutableMapOf(), moshiReVoman)
+
+  /** The active environment's display name, exposed to scripts via `pm.environment.name`. */
+  @JvmField var environmentName: String? = null
+
+  // Per-step capture written by PmJsEval after each sandbox run, read by the executor fold when it
+  // builds the StepReport. Keyed by Step (a step can run a pre-req AND a post-res script).
+  private val pmTestAssertionsByStep: MutableMap<Step, List<PmTestAssertion>> = mutableMapOf()
+  private val nextRequestByStep: MutableMap<Step, String?> = mutableMapOf()
+```
+
+Add the import for `Step` if not present:
+
+```kotlin
+import com.salesforce.revoman.output.report.Step
+```
+
+Add these methods inside the class (e.g. right after `syncProgress`):
+
+```kotlin
+  /** Accumulates assertions across a step's pre-req + post-res scripts. */
+  internal fun recordPmTestAssertions(step: Step, assertions: List<PmTestAssertion>) {
+    pmTestAssertionsByStep[step] = (pmTestAssertionsByStep[step] ?: emptyList()) + assertions
+  }
+
+  internal fun pmTestAssertionsFor(step: Step): List<PmTestAssertion> =
+    pmTestAssertionsByStep[step] ?: emptyList()
+
+  /** Last-write-wins: a post-res `setNextRequest` overrides a pre-req one (matches Postman). */
+  internal fun recordNextRequest(step: Step, nextRequest: String?) {
+    nextRequestByStep[step] = nextRequest
+  }
+
+  internal fun nextRequestFor(step: Step): String? = nextRequestByStep[step]
+```
+
+> `PostmanEnvironment` already implements `MutableMap` by delegation, so `collectionVariables.toMap()` (Kotlin stdlib on Map) and `.set(k,v)` (its own method) both exist. No extra API needed.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew test --tests "com.salesforce.revoman.internal.postman.PostmanSDKCollectionVariablesTest"`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/kotlin/com/salesforce/revoman/internal/postman/PostmanSDK.kt src/test/kotlin/com/salesforce/revoman/internal/postman/PostmanSDKCollectionVariablesTest.kt
+git commit -m "feat(sdk): collectionVariables store + environmentName + per-step pm-test/nextRequest capture"
+```
+
+---
+
+## Task 3: `mergeEnvs` returns env name
+
+**Files:**
+- Modify: `src/main/kotlin/com/salesforce/revoman/internal/postman/template/Environment.kt`
+- Test: `src/test/kotlin/com/salesforce/revoman/internal/postman/template/MergeEnvsNameTest.kt`
+
+**Context:** `mergeEnvs` returns only the merged value-map; the environment `name` (V3 yaml `name:` / V2 json `"name"`) is discarded. We change it to return both. Streams are consumed once, so the name MUST be captured in the same parse that reads values — hence we parse to `Environment` objects first, then derive values + name. Name precedence = last non-null across sources (yaml → json → streams), consistent with the value-merge order.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.postman.template
+
+import com.salesforce.revoman.internal.postman.template.Environment.Companion.mergeEnvs
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class MergeEnvsNameTest {
+  @Test
+  fun `mergeEnvs reads the environment name from a v2 json env file`() {
+    val merged =
+      mergeEnvs(
+        setOf("pm-templates/v2/pokemon/pokemon.postman_environment.json"),
+        emptyList(),
+        emptyMap(),
+      )
+    merged.name shouldBe "Pokemon"
+    merged.values["baseUrl"] shouldBe "https://pokeapi.co/api/v2"
+  }
+
+  @Test
+  fun `mergeEnvs name is null when there is no env source`() {
+    val merged = mergeEnvs(emptySet(), emptyList(), mapOf("k" to "v"))
+    merged.name shouldBe null
+    merged.values["k"] shouldBe "v"
+  }
+}
+```
+
+> This unit test reads a resource under `src/test` resources path resolution. The pokemon env file lives under `src/integrationTest/resources`. If the test source set can't see it, copy a tiny 2-line env JSON into `src/test/resources/pm-templates/mini-env.postman_environment.json` with `{"name":"Pokemon","values":[{"key":"baseUrl","value":"https://pokeapi.co/api/v2","enabled":true}]}` and point the test at that path. Decide at RED time based on the failure (FileNotFound vs assertion).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew test --tests "com.salesforce.revoman.internal.postman.template.MergeEnvsNameTest"`
+Expected: FAIL — `merged.name` unresolved (mergeEnvs returns `Map`, not a type with `.name`).
+
+- [ ] **Step 3: Write the implementation**
+
+In `Environment.kt`, add the result type above the `companion object` (inside the file, top-level):
+
+```kotlin
+/** The merged environment values plus the chosen environment display name (null if unnamed). */
+internal data class MergedEnv(val values: Map<String, Any?>, val name: String?)
+```
+
+Replace the entire `mergeEnvs` function body with this (preserves value-merge precedence, adds name):
+
+```kotlin
+    @OptIn(ExperimentalStdlibApi::class)
+    internal fun mergeEnvs(
+      pmEnvironmentPaths: Set<String>,
+      pmEnvironmentInputStreams: List<InputStream>,
+      dynamicEnvironment: Map<String, Any?>,
+    ): MergedEnv {
+      val envAdapter = Moshi.Builder().build().adapter<Environment>()
+
+      // V3 yaml paths — read name + values from each.
+      val yamlEnvs: List<V3EnvRead> =
+        pmEnvironmentPaths.filter { isV3EnvFile(it) }.map { V3EnvLoader.readWithName(it) }
+      val envFromYamlPaths: Map<String, Any?> =
+        yamlEnvs.fold(emptyMap()) { acc, e -> acc + e.values }
+
+      // V2 json paths — parse to Environment once, derive values + name.
+      val jsonEnvs: List<Environment> =
+        pmEnvironmentPaths.filterNot { isV3EnvFile(it) }.mapNotNull { envAdapter.fromJson(bufferFile(it)) }
+      val envFromJsonPaths: Map<String, Any?> =
+        jsonEnvs.flatMap { it.values.filter { v -> v.enabled } }.associate { it.key to it.value }
+
+      // Streams — parse to Environment once (single read), derive values + name.
+      val streamEnvs: List<Environment> =
+        pmEnvironmentInputStreams.mapNotNull { envAdapter.fromJson(bufferInputStream(it)) }
+      val envFromStreams: Map<String, Any?> =
+        streamEnvs.flatMap { it.values.filter { v -> v.enabled } }.associate { it.key to it.value }
+
+      // * NOTE 10/09/23 gopala.akshintala: dynamicEnvironment keys replace envFromEnvFiles when
+      // clashed
+      // ! TODO 11 Jun 2025 gopala.akshintala: serialize only during regex replace
+      val values = envFromYamlPaths + envFromJsonPaths + envFromStreams + dynamicEnvironment
+      // Name precedence mirrors value order: last non-null wins (yaml -> json -> streams).
+      val name =
+        (yamlEnvs.map { it.name } + jsonEnvs.map { it.name } + streamEnvs.map { it.name })
+          .lastOrNull { it != null }
+      return MergedEnv(values, name)
+    }
+```
+
+Add the import for `bufferInputStream` is already present; ensure `V3EnvLoader` import is present (it's referenced via fully-qualified name in the original — keep using the fully-qualified `com.salesforce.revoman.internal.postman.template.v3.V3EnvLoader.readWithName(it)` if no import exists).
+
+- [ ] **Step 4: Add `V3EnvLoader.readWithName`**
+
+In `src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3EnvLoader.kt`, add a small read-with-name helper and a tiny carrier (keep the existing `loadFromPath` untouched — other callers use it):
+
+```kotlin
+/** V3 env read carrying both the display name and the flattened key→value map. */
+internal data class V3EnvRead(val name: String?, val values: Map<String, Any?>)
+
+internal object V3EnvLoader {
+  fun loadFromPath(path: String): Map<String, Any?> = readWithName(path).values
+
+  fun readWithName(path: String): V3EnvRead {
+    val yaml = bufferFile(path).readUtf8()
+    val env = V3YamlReader.readEnv(yaml)
+    return V3EnvRead(env.name, env.values.associate { it.key to it.value })
+  }
+}
+```
+
+> Place `V3EnvRead` as a top-level `internal data class` in the same file (above the object) and reference it from `Environment.kt` via import `com.salesforce.revoman.internal.postman.template.v3.V3EnvRead` (or fully-qualified). `loadFromPath` now delegates to `readWithName` — DRY, zero behavior change for its existing callers.
+
+- [ ] **Step 5: Update the `mergeEnvs` call site in `ReVoman.kt`**
+
+In `src/main/kotlin/com/salesforce/revoman/ReVoman.kt`, replace (around line 155-161):
+
+```kotlin
+    val environment =
+      ledgerValues +
+        mergeEnvs(
+          kick.environmentPaths(),
+          kick.environmentInputStreams(),
+          kick.dynamicEnvironment(),
+        )
+```
+
+with:
+
+```kotlin
+    val mergedEnv =
+      mergeEnvs(
+        kick.environmentPaths(),
+        kick.environmentInputStreams(),
+        kick.dynamicEnvironment(),
+      )
+    val environment = ledgerValues + mergedEnv.values
+```
+
+(The heavily-commented ledger-as-floor precedence is preserved: `ledgerValues + mergedEnv.values`.)
+
+- [ ] **Step 6: Run test to verify it passes + full compile**
+
+Run: `./gradlew test --tests "com.salesforce.revoman.internal.postman.template.MergeEnvsNameTest" && ./gradlew compileKotlin`
+Expected: PASS (2 tests), BUILD SUCCESSFUL.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/main/kotlin/com/salesforce/revoman/internal/postman/template/Environment.kt src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3EnvLoader.kt src/main/kotlin/com/salesforce/revoman/ReVoman.kt src/test/kotlin/com/salesforce/revoman/internal/postman/template/MergeEnvsNameTest.kt
+git commit -m "feat(env): mergeEnvs captures environment name (v2 json + v3 yaml + streams)"
+```
+
+---
+
+## Task 4: Set `pm.environmentName` from the merged env in `ReVoman.kt`
+
+**Files:**
+- Modify: `src/main/kotlin/com/salesforce/revoman/ReVoman.kt`
+- Test: covered E2E by the integration test (Task 7); no standalone unit test (pure wiring of a field already unit-tested in Task 2/3).
+
+- [ ] **Step 1: Wire the name onto `pm`**
+
+In `ReVoman.kt`, immediately after the `pm` is constructed (line ~162-163):
+
+```kotlin
+    val pm =
+      PostmanSDK(moshiReVoman, kick.nodeModulesPath(), regexReplacer, environment.toMutableMap())
+```
+
+add:
+
+```kotlin
+    pm.environmentName = mergedEnv.name
+```
+
+- [ ] **Step 2: Compile**
+
+Run: `./gradlew compileKotlin`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/kotlin/com/salesforce/revoman/ReVoman.kt
+git commit -m "feat(env): thread environment name onto PostmanSDK for pm.environment.name"
+```
+
+---
+
+## Task 5: `PmJsEval` — thread collectionVariables + name in, diff out, stash + warn
+
+**Files:**
+- Modify: `src/main/kotlin/com/salesforce/revoman/internal/exe/PmJsEval.kt`
+- Test: covered by Task 2 unit (capture API) + Task 7 integration (E2E behavior). The wiring is exercised end-to-end; a focused unit test would require a full sandbox boot already covered by `PmSandboxApiCoverageTest`.
+
+**Context:** `runSandboxScript` currently threads only `environment`. We add `collectionVariables` + env `name` to the context, diff the returned collection-vars back into `pm.collectionVariables`, map the sandbox assertions to public `PmTestAssertion` and stash them + `nextRequest` per step, and `warn` when a script set `nextRequest` (captured-but-not-executed).
+
+- [ ] **Step 1: Rewrite `runSandboxScript` and its callers to pass the step**
+
+The two callers already receive `currentStep: Step`. Thread it into `runSandboxScript`. Replace the whole `runSandboxScript` function and update both call sites.
+
+In `executePreReqJS`, change the call:
+
+```kotlin
+        runSandboxScript(preReqJS, ScriptTarget.PRE_REQUEST, itemWithRegex.request, pm, sandbox, currentStep)
+```
+
+In `executePostResJS`, change the call:
+
+```kotlin
+        runSandboxScript(postResJs, ScriptTarget.TEST, item.request, pm, sandbox, currentStep)
+```
+
+Replace the `runSandboxScript` body with:
+
+```kotlin
+/**
+ * Runs a pm script in the real Postman sandbox, then applies the returned scopes back onto the
+ * [PostmanSDK] so the rest of ReVoman observes script effects:
+ * - environment: diffed back via [PostmanSDK.environment] set/unset (the ledger path — unchanged).
+ * - collectionVariables: diffed back via [PostmanSDK.collectionVariables] set/unset.
+ * - pm.test assertions + setNextRequest: stashed per [step] for the executor to read onto StepReport.
+ *
+ * Throws on a script error so the surrounding [runCatching] maps it to the right failure type.
+ *
+ * Only sandbox-safe values (String/Number/Boolean/null — real Postman variable semantics) are sent
+ * into and read back from the sandbox. Typed POJOs ReVoman stores in the env (hooks, cross-step
+ * reuse) are NOT pm-script variables and are intentionally left untouched in the Kotlin env.
+ */
+private fun runSandboxScript(
+  script: String,
+  target: ScriptTarget,
+  pmRequest: Request,
+  pm: PostmanSDK,
+  sandbox: PmSandbox,
+  step: Step,
+) {
+  val beforeEnv: Map<String, Any?> = sandboxSafeEnv(pm.environment.mutableEnv)
+  val beforeCVars: Map<String, Any?> = sandboxSafeEnv(pm.collectionVariables.mutableEnv)
+  val context =
+    PmExecutionContext(
+      environment = PmScope("environment", beforeEnv, name = pm.environmentName),
+      collectionVariables = PmScope("collectionVariables", beforeCVars),
+      request = requestAsContextMap(pmRequest),
+      response = if (target == ScriptTarget.TEST) responseAsContextMap(pm) else null,
+    )
+  val result = sandbox.execute(script, target, context)
+  result.error?.let { throw it }
+
+  // Apply env mutations back through the same set()/unset() paths the ledger reads.
+  val envDiff = diffScopes(beforeEnv, result.environment)
+  envDiff.produced.forEach { key -> pm.environment.set(key, result.environment[key]) }
+  envDiff.unset.forEach { key -> pm.environment.unset(key) }
+
+  // Apply collection-variable mutations back (no ledger involvement — separate store).
+  val cVarDiff = diffScopes(beforeCVars, result.collectionVariables)
+  cVarDiff.produced.forEach { key -> pm.collectionVariables.set(key, result.collectionVariables[key]) }
+  cVarDiff.unset.forEach { key -> pm.collectionVariables.unset(key) }
+
+  // Surface pm.test results + setNextRequest onto the StepReport (read by the executor fold).
+  pm.recordPmTestAssertions(
+    step,
+    result.assertions.map { PmTestAssertion(it.name, it.passed, it.skipped, it.error) },
+  )
+  result.nextRequest?.let { next ->
+    pm.recordNextRequest(step, next)
+    RevomanLog.warn {
+      "pm.execution.setNextRequest('$next') was captured but ReVoman does not yet reorder steps " +
+        "(linear execution); directive recorded on StepReport.nextRequest only (Phase 2 will honor it)."
+    }
+  }
+}
+
+/** Filters a scope map to sandbox-safe values (real Postman variable values). */
+private fun sandboxSafeEnv(scope: Map<String, Any?>): Map<String, Any?> =
+  scope.filterValues { it == null || it is String || it is Number || it is Boolean }
+```
+
+> Note: the OLD `sandboxSafeEnv(pm: PostmanSDK)` helper is replaced by `sandboxSafeEnv(scope: Map)` so it can serve both env and collection-vars. Delete the old single-arg version.
+
+- [ ] **Step 2: Add the imports**
+
+At the top of `PmJsEval.kt`, add:
+
+```kotlin
+import com.salesforce.revoman.internal.log.RevomanLog
+import com.salesforce.revoman.output.report.PmTestAssertion
+```
+
+(`Step` is already imported; `diffScopes`, `PmScope`, `PmExecutionContext`, `ScriptTarget` already imported.)
+
+- [ ] **Step 3: Compile + run the existing sandbox suite (no regressions)**
+
+Run: `./gradlew compileKotlin && ./gradlew test --tests "com.salesforce.revoman.internal.postman.sandbox.*"`
+Expected: BUILD SUCCESSFUL; all sandbox tests still GREEN.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/kotlin/com/salesforce/revoman/internal/exe/PmJsEval.kt
+git commit -m "feat(exe): wire collectionVariables + env name into sandbox; stash pm-test/nextRequest; warn on setNextRequest"
+```
+
+---
+
+## Task 6: `StepReport` — two new read-only fields, populated in the fold
+
+**Files:**
+- Modify: `src/main/kotlin/com/salesforce/revoman/output/report/StepReport.kt`
+- Modify: `src/main/kotlin/com/salesforce/revoman/ReVoman.kt`
+- Test: covered E2E by Task 7 (the integration test asserts on both fields). Field defaults keep all existing constructors/tests compiling.
+
+- [ ] **Step 1: Add the fields to `StepReport`'s primary constructor**
+
+In `StepReport.kt`, add to the primary constructor param list (after `envVars`):
+
+```kotlin
+  @JvmField val envVars: StepEnvVars = StepEnvVars(),
+  @JvmField val pmTestAssertions: List<PmTestAssertion> = emptyList(),
+  @JvmField val nextRequest: String? = null,
+) {
+```
+
+Add the import:
+
+```kotlin
+import com.salesforce.revoman.output.report.PmTestAssertion
+```
+
+> `PmTestAssertion` is in the same package (`output.report`), so the import is unnecessary — remove it if the compiler flags a redundant same-package import. The secondary constructor delegates to the primary and need NOT list the new params (they default).
+
+- [ ] **Step 2: Populate them in the executor fold**
+
+In `ReVoman.kt`, in the terminal `.copy(...)` of the step pipeline (the block that sets `exeTimings`, `pmEnvSnapshot`, `envVars` ~line 356-365), add the two fields:
+
+```kotlin
+            .copy(
+              exeTimings = exeTimings,
+              pmEnvSnapshot =
+                pm.environment.copy(mutableEnv = pm.environment.mutableEnv.toMutableMap()),
+              envVars =
+                StepEnvVars(
+                  produced = pm.environment.producedKeysFor(step),
+                  consumed = pm.environment.consumedKeysFor(step),
+                ),
+              pmTestAssertions = pm.pmTestAssertionsFor(step),
+              nextRequest = pm.nextRequestFor(step),
+            )
+```
+
+- [ ] **Step 3: Compile + run full unit suite**
+
+Run: `./gradlew test`
+Expected: BUILD SUCCESSFUL; all unit tests GREEN (existing `StepReport` consumers unaffected by additive defaulted fields).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/kotlin/com/salesforce/revoman/output/report/StepReport.kt src/main/kotlin/com/salesforce/revoman/ReVoman.kt
+git commit -m "feat(report): surface pmTestAssertions + nextRequest on StepReport"
+```
+
+---
+
+## Task 7: Creative live integration test + collection + env
+
+**Files:**
+- Create: `src/integrationTest/resources/pm-templates/v2/pokemon-sandbox-api/pokemon-sandbox-api.postman_collection.json`
+- Create: `src/integrationTest/resources/pm-templates/v2/pokemon-sandbox-api/pokemon-sandbox-api.postman_environment.json`
+- Create: `src/integrationTest/java/com/salesforce/revoman/integration/pokemon/PokemonSandboxApiTest.java`
+
+**Context:** One collection exercising every listed API end-to-end against free live APIs: pokeapi.co (GET) for variables/environment/response/test, restful-api.dev (POST then PUT) for `pm.request.body`. Assertions read the new `StepReport` fields from `Rundown`.
+
+- [ ] **Step 1: Create the environment file**
+
+`src/integrationTest/resources/pm-templates/v2/pokemon-sandbox-api/pokemon-sandbox-api.postman_environment.json`:
+
+```json
+{
+  "id": "a1b2c3d4-0000-0000-0000-pokemonsandbox",
+  "name": "PokemonSandboxApi",
+  "values": [
+    { "key": "baseUrl", "value": "https://pokeapi.co/api/v2", "enabled": true },
+    { "key": "uri", "value": "api.restful-api.dev", "enabled": true },
+    { "key": "limit", "value": "5", "enabled": true }
+  ],
+  "_postman_variable_scope": "environment"
+}
+```
+
+- [ ] **Step 2: Create the collection**
+
+`src/integrationTest/resources/pm-templates/v2/pokemon-sandbox-api/pokemon-sandbox-api.postman_collection.json`:
+
+```json
+{
+  "info": {
+    "name": "pokemon-sandbox-api",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "all-pokemon",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('status is 200', function () { pm.response.to.have.status(200); });",
+              "var json = pm.response.json();",
+              "pm.test('has results array', function () { pm.expect(json.results).to.be.an('array'); });",
+              "pm.test('environment has a name', function () { pm.expect(pm.environment.name).to.be.a('string'); });",
+              "var firstName = json.results[0].name;",
+              "pm.environment.set('pokemonName', firstName);",
+              "pm.collectionVariables.set('firstPokemon', firstName);",
+              "pm.collectionVariables.set('resultCount', json.results.length);"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": { "raw": "{{baseUrl}}/pokemon?limit={{limit}}" }
+      }
+    },
+    {
+      "name": "pokemon-by-name",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('response code is 200', function () { pm.expect(pm.response.code).to.eql(200); });",
+              "pm.test('text body is non-empty', function () { pm.expect(pm.response.text().length).to.be.above(0); });",
+              "pm.test('collection var carried over', function () { pm.expect(pm.collectionVariables.get('firstPokemon')).to.be.a('string'); });",
+              "var allCVars = pm.collectionVariables.toObject();",
+              "pm.test('toObject exposes resultCount', function () { pm.expect(allCVars).to.have.property('resultCount'); });",
+              "var json = pm.response.json();",
+              "pm.collectionVariables.set('pokemonId', json.id);",
+              "pm.execution.setNextRequest('pokemon-species');"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": { "raw": "{{baseUrl}}/pokemon/{{pokemonName}}" }
+      }
+    },
+    {
+      "name": "pokemon-species",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('species status 200', function () { pm.response.to.have.status(200); });",
+              "pm.test('id matches earlier pokemon', function () { pm.expect(pm.response.json().id).to.eql(pm.collectionVariables.get('pokemonId')); });"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": { "raw": "{{baseUrl}}/pokemon-species/{{pokemonName}}" }
+      }
+    },
+    {
+      "name": "add-object",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('object created', function () { pm.expect(pm.response.code).to.be.oneOf([200, 201]); });",
+              "pm.environment.set('objId', pm.response.json().id);"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [{ "key": "Content-Type", "value": "application/json" }],
+        "body": { "mode": "raw", "raw": "{\n  \"name\": \"revoman-{{pokemonName}}\",\n  \"data\": { \"source\": \"revoman-sandbox-test\" }\n}" },
+        "url": { "raw": "https://{{uri}}/objects" }
+      }
+    },
+    {
+      "name": "update-object",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('request body was readable', function () { pm.expect(pm.request.body.raw).to.include('updated-revoman'); });",
+              "pm.test('update echoes new name', function () { pm.expect(pm.response.json().data.name).to.eql('updated-revoman'); });"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "PUT",
+        "header": [{ "key": "Content-Type", "value": "application/json" }],
+        "body": { "mode": "raw", "raw": "{\n  \"name\": \"revoman-{{pokemonName}}\",\n  \"data\": { \"name\": \"updated-revoman\" }\n}" },
+        "url": { "raw": "https://{{uri}}/objects/{{objId}}" }
+      }
+    }
+  ]
+}
+```
+
+> restful-api.dev `PUT /objects/{id}` requires a real id; `add-object` (POST) creates one and stashes `objId` for the PUT. The PUT body sets `data.name='updated-revoman'`, asserted both via `pm.request.body.raw` (the API) AND the echoed response.
+
+- [ ] **Step 3: Write the integration test**
+
+`src/integrationTest/java/com/salesforce/revoman/integration/pokemon/PokemonSandboxApiTest.java`:
+
+```java
+/***************************************************************************************************
+ *  Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier:
+ *           Apache License Version 2.0
+ *  For full license text, see the LICENSE file in the repo root or
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ **************************************************************************************************/
+
+package com.salesforce.revoman.integration.pokemon;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.salesforce.revoman.ReVoman;
+import com.salesforce.revoman.input.config.Kick;
+import com.salesforce.revoman.output.Rundown;
+import com.salesforce.revoman.output.report.PmTestAssertion;
+import com.salesforce.revoman.output.report.StepReport;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end coverage of the script-only `pm` APIs through a real ReVoman run against free live
+ * APIs (pokeapi.co GET + restful-api.dev POST/PUT). Verifies that variables, environment(.name),
+ * request/response, test/expect, collectionVariables, and setNextRequest all surface on the Rundown.
+ */
+class PokemonSandboxApiTest {
+  private static final String PM_COLLECTION_PATH =
+      "pm-templates/v2/pokemon-sandbox-api/pokemon-sandbox-api.postman_collection.json";
+  private static final String PM_ENVIRONMENT_PATH =
+      "pm-templates/v2/pokemon-sandbox-api/pokemon-sandbox-api.postman_environment.json";
+
+  @Test
+  @DisplayName("script-only pm APIs surface end-to-end")
+  void pmSandboxApisEndToEnd() {
+    final Rundown rundown =
+        ReVoman.revUp(
+            Kick.configure()
+                .templatePath(PM_COLLECTION_PATH)
+                .environmentPath(PM_ENVIRONMENT_PATH)
+                .nodeModulesPath("js")
+                .off());
+
+    // No step failed (HTTP + all scripts ran without thrown error).
+    assertThat(rundown.firstUnIgnoredUnsuccessfulStepReport()).isNull();
+    assertThat(rundown.stepReports).hasSize(5);
+
+    // --- pm.environment / pm.test / pm.expect / pm.response.* (all-pokemon) ---
+    final StepReport allPokemon = rundown.reportForStepName("all-pokemon");
+    assertThat(allPokemon).isNotNull();
+    assertThat(allPokemon.pmTestAssertions).isNotEmpty();
+    assertThat(allPokemon.pmTestAssertions.stream().allMatch(a -> a.passed)).isTrue();
+    assertThat(rundown.mutableEnv).containsKey("pokemonName");
+
+    // --- pm.collectionVariables set in step 1, read in steps 2-3 (cross-step) ---
+    final StepReport byName = rundown.reportForStepName("pokemon-by-name");
+    assertThat(byName.pmTestAssertions.stream().allMatch(a -> a.passed)).isTrue();
+
+    // --- pm.execution.setNextRequest: CAPTURED (not executed — Phase 2 reorders) ---
+    // ReVoman still runs steps linearly; we assert only that the directive was surfaced.
+    assertThat(byName.nextRequest).isEqualTo("pokemon-species");
+    // Proof it was NOT executed: pokemon-species still ran in linear order after pokemon-by-name.
+    assertThat(rundown.reportForStepName("pokemon-species")).isNotNull();
+
+    // --- pm.request.body via restful-api.dev PUT ---
+    final StepReport update = rundown.reportForStepName("update-object");
+    assertThat(update.pmTestAssertions.stream().allMatch(a -> a.passed)).isTrue();
+
+    // --- Every assertion across the whole run passed ---
+    final List<PmTestAssertion> all =
+        rundown.stepReports.stream().flatMap(s -> s.pmTestAssertions.stream()).toList();
+    assertThat(all).isNotEmpty();
+    assertThat(all.stream().allMatch(a -> a.passed)).isTrue();
+  }
+}
+```
+
+> `reportForStepName` is the existing `Rundown` accessor. If a live API hiccup makes this flaky in CI, that is an environmental failure, not a logic failure — re-run; do not weaken assertions to mask it.
+
+- [ ] **Step 4: Run the integration test**
+
+Run: `./gradlew integrationTest --tests "com.salesforce.revoman.integration.pokemon.PokemonSandboxApiTest"`
+Expected: PASS (1 test, 5 steps). If `pm.response.json()` / context field-name mismatches surface, align against `PmSandboxApiCoverageTest` (already-green reference for the same calls).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/integrationTest/resources/pm-templates/v2/pokemon-sandbox-api/ src/integrationTest/java/com/salesforce/revoman/integration/pokemon/PokemonSandboxApiTest.java
+git commit -m "test(sandbox): live E2E integration test covering all script-only pm APIs"
+```
+
+---
+
+## Task 8: Full verification + format + handoff
+
+**Files:**
+- Modify: (formatting only) any files spotless touches.
+- Create: `~/work/handoff/2026-06-11-pm-sandbox-phase2-sequencer.md`
+
+- [ ] **Step 1: Spotless + full build**
+
+Run: `./gradlew spotlessApply && ./gradlew build`
+Expected: BUILD SUCCESSFUL (compile, spotless, all `test`; `integrationTest` green — live APIs reachable).
+
+- [ ] **Step 2: Run the complete sandbox unit suite once more**
+
+Run: `./gradlew test --tests "com.salesforce.revoman.internal.postman.sandbox.*" --tests "com.salesforce.revoman.internal.postman.PostmanSDKCollectionVariablesTest" --tests "com.salesforce.revoman.internal.postman.template.MergeEnvsNameTest"`
+Expected: ALL GREEN.
+
+- [ ] **Step 3: Write the Phase 2 handoff note**
+
+Create `~/work/handoff/2026-06-11-pm-sandbox-phase2-sequencer.md` documenting: what's captured today (`StepReport.nextRequest`, the warn), what Phase 2 must build (jump-capable `executeStepsSerially`), the exact landmines (ledger skip/inject reconciliation, `haltOnFailure`, name→index resolution, infinite-loop guard, `setNextRequest(null)`=halt), and the test that should flip from "captured" to "executed" (`PokemonSandboxApiTest` reorder assertion). Full content provided in Step 4.
+
+- [ ] **Step 4: Handoff note content**
+
+Write this into `~/work/handoff/2026-06-11-pm-sandbox-phase2-sequencer.md`:
+
+```markdown
+# Handoff — PM Sandbox Phase 2: setNextRequest executing sequencer
+
+**Date:** 2026-06-11
+**Prereq (done):** API-coverage cycle — all script-only pm APIs wired E2E; setNextRequest is
+CAPTURED on `StepReport.nextRequest` and warned-on, but NOT executed.
+
+## What exists now
+- `SandboxBridge.decodeResult` reads `execution.return.nextRequest` -> `PmExecutionResult.nextRequest`.
+- `PmJsEval.runSandboxScript` stashes it via `pm.recordNextRequest(step, next)` and emits a
+  `RevomanLog.warn` ("captured but ReVoman does not yet reorder...").
+- `StepReport.nextRequest: String?` surfaces it. `PokemonSandboxApiTest` asserts it was CAPTURED
+  (and that linear order was NOT changed).
+
+## What Phase 2 builds
+Turn `ReVoman.executeStepsSerially`'s linear `fold` into an index-driven driver that HONORS
+`setNextRequest`:
+- `setNextRequest("name")` -> jump to the step with that name (forward or backward).
+- `setNextRequest(null)` -> halt the run (Postman semantics).
+- absent -> fall through to the next step.
+
+## Landmines (do NOT skip — each needs a test)
+1. **Ledger skip/inject** (`shadowedPaths`, `ledgerSkipDecision`): a backward jump re-runs a producer
+   step. Decide provenance: does a re-run refresh the ledger entry, or is jump-mode ledger-exempt?
+2. **`haltOnFailureOfTypeExcept`**: jump logic must compose with existing halt logic, not bypass it.
+3. **Name -> index resolution**: `setNextRequest` takes a request NAME; duplicate names across folders
+   need a documented rule (first match? error?). Steps are deep-flattened — names may collide.
+4. **Infinite-loop guard**: `A -> setNextRequest('A')` must cap visited count and fail loud.
+5. **Reports for skipped/repeated steps**: linear `fold` assumes one report per step in order. A jump
+   skips steps (no report?) or repeats them (multiple reports?). Define what `rundown.stepReports`
+   contains after a jump.
+
+## Test to flip
+`PokemonSandboxApiTest` currently asserts `byName.nextRequest == "pokemon-species"` + linear order
+preserved. Phase 2 adds/【flips to】an assertion that execution actually jumped (e.g. an in-between
+step's report is absent, or order differs from declaration). Keep the capture assertion; add the
+execution assertion.
+
+## Files
+- `src/main/kotlin/com/salesforce/revoman/ReVoman.kt` — `executeStepsSerially` (the fold).
+- Spec: `docs/superpowers/specs/2026-06-11-pm-sandbox-api-coverage-design.md` (Non-Goals #1).
+```
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add -A
+git commit -m "chore(sandbox): full verification; Phase 2 sequencer handoff note"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** PmTestAssertion type (T1) ✓; collectionVariables store + environmentName + per-step capture (T2) ✓; mergeEnvs name (T3) ✓; environmentName wiring (T4) ✓; PmJsEval thread-in/diff-out/stash/warn (T5) ✓; StepReport fields + fold population (T6) ✓; live integration test + collection + env covering all listed APIs incl. PUT for request.body (T7) ✓; verification + Phase 2 handoff (T8) ✓. Non-goals respected: setNextRequest captured-not-executed (warn + handoff), no sendRequest, no root-variable parsing.
+- **Type consistency:** `PmTestAssertion(name, passed, skipped, error)` used identically in T1/T2/T5/T6/T7. `MergedEnv(values, name)` in T3 consumed in T3/T4. `recordPmTestAssertions`/`pmTestAssertionsFor`/`recordNextRequest`/`nextRequestFor` defined T2, called T5/T6. `V3EnvRead(name, values)` defined+used T3.
+- **Known soft spots flagged inline:** (a) `Step.fromName` test-factory name — verify against existing tests at RED; (b) `MergeEnvsNameTest` resource visibility across source sets — fallback mini-env provided; (c) same-package redundant `PmTestAssertion` import in StepReport — remove if flagged; (d) live-API flakiness — explicitly an environmental, not logic, failure.
+- **setNextRequest scope:** captured + warned + handoff documented; executing sequencer explicitly deferred per approved design.
+```

--- a/docs/superpowers/specs/2026-06-11-pm-sandbox-api-coverage-design.md
+++ b/docs/superpowers/specs/2026-06-11-pm-sandbox-api-coverage-design.md
@@ -1,0 +1,173 @@
+# PM Sandbox — Full Wiring of Script-Only `pm` APIs + Coverage Tests
+
+**Date:** 2026-06-11
+**Status:** Design — approved, pending spec review
+**Builds on:** `docs/superpowers/specs/2026-06-04-pm-api-sandbox-integration-design.md` (Phase 1 sandbox boot)
+**Related plan:** `docs/superpowers/plans/2026-06-04-pm-sandbox-phase1.md`
+
+## Goal
+
+Make every **script-only** `pm` API the user listed observably work **end-to-end** through a real
+`ReVoman.revUp(...)` run, and lock that behavior with unit + integration tests:
+
+- **Variables:** `pm.collectionVariables` / `.get` / `.set` / `.toObject`
+- **Environment:** `pm.environment`, `pm.environment.name`
+- **Request/Response:** `pm.request.body`, `pm.response.code` / `.json` / `.text` / `.to.have.status`
+- **Testing:** `pm.test`, `pm.expect`
+- **Execution control:** `pm.execution.setNextRequest` (**captured + surfaced this cycle; executing
+  sequencer deferred to its own cycle**)
+
+## Problem / Current State
+
+The real postman-sandbox bootcode already supports all these APIs (proven by
+`PmSandboxApiCoverageTest`, 11 green). The gap is **ReVoman's exe-layer plumbing**: in a real run,
+`PmJsEval.runSandboxScript` only threads `environment` (+ request/response) and reads back only
+`environment`. So four capabilities run inside the sandbox but are **dropped** before reaching the
+caller / `Rundown`:
+
+| Capability | In a real `revUp()` run today |
+| --- | --- |
+| `pm.environment.get/set/unset` | ✅ flows (diffed back into `mutableEnv`) |
+| `pm.request.body`, `pm.response.*` | ✅ fed into context |
+| `pm.collectionVariables.*` | ❌ not threaded in, not read back |
+| `pm.environment.name` | ❌ name discarded by `mergeEnvs` |
+| `pm.test` / `pm.expect` pass/fail | ❌ assertions decoded by the bridge, then dropped |
+| `pm.execution.setNextRequest` | ❌ captured by the bridge, then dropped |
+
+An integration test that "uses" the bottom four today would assert nothing — a failing `pm.test` is
+invisible. Full wiring makes them observable on `StepReport` / `Rundown` so the test is honest.
+
+## Non-Goals (explicit scope guards)
+
+1. **`setNextRequest` execution (the jump-capable sequencer).** Deferred to its own cycle. Reason:
+   honoring the directive rewrites `executeStepsSerially`'s linear `fold` into an index-driven
+   driver that must reconcile with ledger skip/inject (`shadowedPaths`, `ledgerSkipDecision`),
+   `haltOnFailure`, name→index resolution, and an infinite-loop guard. That is a correctness-risky
+   redesign of the hottest loop and deserves a dedicated brainstorm→plan→TDD. **This cycle captures
+   and surfaces the directive (the exact data that future sequencer will consume) and logs a
+   `RevomanLog.warn` when a script sets it**, so a captured-but-unexecuted directive is never a
+   silent failure.
+2. **`pm.sendRequest`.** Unchanged — still the explicit `UnsupportedOperationException` from the
+   bridge. (Separate subsystem; needs an http4k responder on `execution.request`.)
+3. **Collection-root `variable[]` parsing.** `Template` parses only `item` + `auth`; root
+   `variable` is not modeled. `pm.collectionVariables` is therefore **script-seeded only** this
+   cycle — a producer step's script `.set`s a collection variable, a downstream step's script
+   `.get`s it (the common real-world pattern). Seeding from a collection file is out of scope.
+
+## Architecture / Data Flow
+
+```
+Collection scripts ─▶ PmJsEval.runSandboxScript ─▶ PmSandbox ─▶ SandboxBridge ─▶ real bootcode
+                          │  builds PmExecutionContext IN:                │
+                          │   environment(+name), collectionVariables,    │ PmExecutionResult OUT:
+                          │   request, response                           │  environment,
+                          │                                               │  collectionVariables,
+                          ▼                                               │  assertions, nextRequest
+   diff env  ──▶ PostmanSDK.environment.set/unset (ledger path, unchanged)│
+   diff cVars ─▶ PostmanSDK.collectionVariables.set/unset                 ▼
+   stash assertions + nextRequest per step on PostmanSDK ───────────────▶ read at report build
+                          │
+                          ▼
+   StepReport.{pmTestAssertions, nextRequest}  ─▶  Rundown (integration test asserts here)
+```
+
+## Components (each independently testable)
+
+### 1. `PostmanSDK` — collection-variable store, env name, per-step script capture
+- `@JvmField val collectionVariables: PostmanEnvironment<Any?>` — reuse the existing env wrapper as a
+  plain key→value store (gives set/unset/`toMap` for free; ledger capture is env-specific and not
+  triggered here). Seeded empty.
+- `var environmentName: String?` — the environment's display name, exposed via `pm.environment.name`.
+- Per-step capture (keyed by `Step`, mirroring `PostmanEnvironment.producedKeysByStep`):
+  - `pmTestAssertionsByStep: MutableMap<Step, List<PmTestAssertion>>`
+  - `nextRequestByStep: MutableMap<Step, String?>`
+  - accessor `pmTestAssertionsFor(step)` / `nextRequestFor(step)` read at report-build time.
+  - A pre-req and a post-res script are two sandbox executions; assertions **accumulate** across
+    both, `nextRequest` is **last-write-wins** (post-res overrides pre-req — matches Postman).
+
+### 2. Public assertion type — `output.report.PmTestAssertion`
+- The bridge's `PmAssertion` is `internal` in the sandbox package; do not leak it onto the public
+  `StepReport` API. Add a public `data class PmTestAssertion(name, passed, skipped, error)` in
+  `output.report` and map sandbox→public in `PmJsEval`.
+
+### 3. `Environment.mergeEnvs` + `ReVoman.kt` — capture & thread env name
+- `mergeEnvs` currently returns only the merged value-map (name discarded). Change it to also return
+  the chosen environment name (the V3 yaml `name:` / V2 json `"name"`). Precedence when multiple env
+  sources: last non-null wins, consistent with the existing value-merge order
+  (yaml → json → streams → dynamic). Thread the name into `PostmanSDK.environmentName`.
+
+### 4. `PmJsEval.runSandboxScript` — thread the new scopes in, diff the new scope out, stash capture
+- Build `PmExecutionContext` with:
+  - `environment = PmScope("environment", before, name = pm.environmentName)`
+  - `collectionVariables = PmScope("collectionVariables", pm.collectionVariables.toMap())`
+- After `execute`:
+  - env diff back — unchanged.
+  - `diffScopes(beforeCVars, result.collectionVariables)` → apply produced/unset to
+    `pm.collectionVariables`.
+  - stash `result.assertions` (mapped to `PmTestAssertion`) and `result.nextRequest` on `PostmanSDK`
+    for the current step.
+  - if `result.nextRequest != null`: `RevomanLog.warn { "pm.execution.setNextRequest('$next') was
+    captured but ReVoman does not yet reorder steps (linear execution); directive recorded on
+    StepReport.nextRequest only." }`
+
+### 5. `SandboxBridge` — DONE
+- `scopeToProxy` forwards `name`; `decodeResult` captures `execution.return.nextRequest`. ✅ (already
+  TDD'd and green; no change.)
+
+### 6. `StepReport` — two new read-only fields
+- `@JvmField val pmTestAssertions: List<PmTestAssertion> = emptyList()`
+- `@JvmField val nextRequest: String? = null`
+- Populated in the `executeStepsSerially` fold's terminal `.copy(...)` (same site that reads
+  `producedKeysFor(step)`), from the PostmanSDK per-step capture.
+
+### 7. `Rundown` — no change needed
+- `Rundown.reportForStepName(stepName): StepReport?` already exists; the integration test uses it to
+  fetch a step's report by name and read `.nextRequest` / `.pmTestAssertions`.
+
+### 8. Creative integration test — `PokemonSandboxApiTest.java` (live, free APIs)
+- A **new V2 collection** `pm-templates/v2/pokemon-sandbox-api/` whose scripts exercise every listed
+  API end-to-end. Steps (all GET unless noted; pokeapi.co is read-only):
+  1. **all-pokemon** `GET {{baseUrl}}/pokemon?limit={{limit}}` — post-res script:
+     `pm.response.to.have.status(200)`, `pm.test` with `pm.expect(pm.response.json().results)`,
+     `pm.environment.set('pokemonName', json.results[0].name)`,
+     `pm.collectionVariables.set('firstPokemon', name)`,
+     `pm.test('env name', () => pm.expect(pm.environment.name).to.be.a('string'))`.
+  2. **pokemon-by-name** `GET {{baseUrl}}/pokemon/{{pokemonName}}` — post-res:
+     `pm.expect(pm.response.code).to.eql(200)`, `pm.response.text()`,
+     `pm.collectionVariables.get('firstPokemon')` + `toObject()` assertions,
+     `pm.execution.setNextRequest('pokemon-species')`.
+  3. **pokemon-species** `GET {{baseUrl}}/pokemon-species/{{pokemonName}}` — assertions on chained
+     collection variables.
+  4. **PUT step** against `restful-api.dev` (`PUT /objects/{id}`) demonstrating `pm.request.body`:
+     pre-req sets a body var, post-res asserts `pm.response.json().data` echoes it. (pokeapi has no
+     write endpoint; restful-api.dev is the project's existing free write API.)
+- **Assertions on `Rundown`:**
+  - `firstUnIgnoredUnsuccessfulStepReport()` is null (all HTTP + scripts succeeded).
+  - `rundown.mutableEnv` contains the produced env keys (`pokemonName`, …).
+  - collection variables produced by step 1 are visible to steps 2–3 (cross-step `get`).
+  - every `stepReport.pmTestAssertions` entry has `passed == true`.
+  - `rundown.reportForStepName("pokemon-by-name").nextRequest == "pokemon-species"` **with an inline
+    comment that ReVoman does not yet reorder — Phase 2** (the linear order is unchanged; we assert
+    the directive was *captured*, not that it changed execution).
+
+## Testing Strategy (TDD throughout)
+
+- **Unit (extend existing):**
+  - `PmSandboxApiCoverageTest` — already covers all 12 APIs at the sandbox layer (green).
+  - New: `PostmanSDK` collection-variable round-trip; `mergeEnvs` returns env name; `PmJsEval`
+    maps + stashes assertions/nextRequest; `StepReport` carries the new fields.
+- **Integration (live):** `PokemonSandboxApiTest` above. Live HTTP, consistent with `PokemonTest` /
+  `RestfulAPIDevTest`.
+- Every change RED → GREEN → REFACTOR; watch each test fail first.
+
+## Risks / Mitigations
+
+- **Live-API flakiness.** Mitigation: keep assertions structural (status, shape, types) not
+  brittle exact-value (pokeapi data is stable, but assert on `results.length`/`code`/type, not on a
+  specific pokemon attribute that could change).
+- **Ledger interaction with collectionVariables.** Collection vars do NOT feed the ledger (ledger is
+  env-keyed). Confirm `diffScopes` on collection vars never calls the env producer-capture path —
+  it writes a separate `PostmanEnvironment` instance whose `currentStep` is never set, so producer
+  capture is a no-op. Add a unit assertion for this.
+- **Public API surface growth (`StepReport`).** Two additive nullable/empty-default fields; no
+  breaking change to existing constructors used by tests.

--- a/src/integrationTest/java/com/salesforce/revoman/integration/pokemon/PokemonSandboxApiTest.java
+++ b/src/integrationTest/java/com/salesforce/revoman/integration/pokemon/PokemonSandboxApiTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.Test;
 /**
  * End-to-end coverage of the script-only `pm` APIs through a real ReVoman run against free live
  * APIs (pokeapi.co GET + restful-api.dev POST/PUT). Verifies that variables, environment(.name),
- * request/response, test/expect, collectionVariables, and setNextRequest all surface on the Rundown.
+ * request/response, test/expect, collectionVariables, and setNextRequest all surface on the
+ * Rundown.
  */
 class PokemonSandboxApiTest {
   private static final String PM_COLLECTION_PATH =

--- a/src/integrationTest/java/com/salesforce/revoman/integration/pokemon/PokemonSandboxApiTest.java
+++ b/src/integrationTest/java/com/salesforce/revoman/integration/pokemon/PokemonSandboxApiTest.java
@@ -1,0 +1,83 @@
+/***************************************************************************************************
+ *  Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier:
+ *           Apache License Version 2.0
+ *  For full license text, see the LICENSE file in the repo root or
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ **************************************************************************************************/
+
+package com.salesforce.revoman.integration.pokemon;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.salesforce.revoman.ReVoman;
+import com.salesforce.revoman.input.config.Kick;
+import com.salesforce.revoman.output.Rundown;
+import com.salesforce.revoman.output.report.PmTestAssertion;
+import com.salesforce.revoman.output.report.StepReport;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end coverage of the script-only `pm` APIs through a real ReVoman run against free live
+ * APIs (pokeapi.co GET + restful-api.dev POST/PUT). Verifies that variables, environment(.name),
+ * request/response, test/expect, collectionVariables, and setNextRequest all surface on the Rundown.
+ */
+class PokemonSandboxApiTest {
+  private static final String PM_COLLECTION_PATH =
+      "pm-templates/v2/pokemon-sandbox-api/pokemon-sandbox-api.postman_collection.json";
+  private static final String PM_ENVIRONMENT_PATH =
+      "pm-templates/v2/pokemon-sandbox-api/pokemon-sandbox-api.postman_environment.json";
+
+  @Test
+  @DisplayName("script-only pm APIs surface end-to-end")
+  void pmSandboxApisEndToEnd() {
+    final Rundown rundown =
+        ReVoman.revUp(
+            Kick.configure()
+                .templatePath(PM_COLLECTION_PATH)
+                .environmentPath(PM_ENVIRONMENT_PATH)
+                .nodeModulesPath("js")
+                .off());
+
+    // No step failed (HTTP + all scripts ran without thrown error).
+    assertThat(rundown.firstUnIgnoredUnsuccessfulStepReport()).isNull();
+    assertThat(rundown.stepReports).hasSize(5);
+
+    // --- pm.environment / pm.test / pm.expect / pm.response.* (all-pokemon) ---
+    final StepReport allPokemon = rundown.reportForStepName("all-pokemon");
+    assertThat(allPokemon).isNotNull();
+    assertThat(allPokemon.pmTestAssertions).isNotEmpty();
+    assertThat(allPokemon.pmTestAssertions.stream().allMatch(a -> a.passed)).isTrue();
+    assertThat(rundown.mutableEnv).containsKey("pokemonName");
+    assertThat(rundown.mutableEnv).containsKey("objId"); // add-object POST set this for the PUT
+
+    // --- pm.collectionVariables set in step 1, read in steps 2-3 (cross-step) ---
+    final StepReport byName = rundown.reportForStepName("pokemon-by-name");
+    assertThat(byName).isNotNull();
+    assertThat(byName.pmTestAssertions).isNotEmpty();
+    assertThat(byName.pmTestAssertions.stream().allMatch(a -> a.passed)).isTrue();
+
+    // --- pm.execution.setNextRequest: CAPTURED (not executed — Phase 2 reorders) ---
+    // ReVoman still runs steps linearly; we assert only that the directive was surfaced.
+    assertThat(byName.nextRequest).isEqualTo("pokemon-species");
+    // Proof it was NOT executed: pokemon-species still ran in linear order after pokemon-by-name.
+    assertThat(rundown.reportForStepName("pokemon-species")).isNotNull();
+    // Guard the crown-jewel cross-step collectionVariable proof against silently vanishing:
+    // a failing pm.test is DATA (passed=false), and allMatch on an empty list passes vacuously, so
+    // assert this step actually produced assertions.
+    assertThat(rundown.reportForStepName("pokemon-species").pmTestAssertions).isNotEmpty();
+
+    // --- pm.request.body via restful-api.dev PUT ---
+    final StepReport update = rundown.reportForStepName("update-object");
+    assertThat(update).isNotNull();
+    assertThat(update.pmTestAssertions).isNotEmpty();
+    assertThat(update.pmTestAssertions.stream().allMatch(a -> a.passed)).isTrue();
+
+    // --- Every assertion across the whole run passed ---
+    final List<PmTestAssertion> all =
+        rundown.stepReports.stream().flatMap(s -> s.pmTestAssertions.stream()).toList();
+    assertThat(all).isNotEmpty();
+    assertThat(all.stream().allMatch(a -> a.passed)).isTrue();
+  }
+}

--- a/src/integrationTest/resources/pm-templates/v2/pokemon-sandbox-api/pokemon-sandbox-api.postman_collection.json
+++ b/src/integrationTest/resources/pm-templates/v2/pokemon-sandbox-api/pokemon-sandbox-api.postman_collection.json
@@ -1,0 +1,164 @@
+{
+	"info": {
+		"_postman_id": "a1b2c3d4-1111-2222-3333-pokemonsandbox",
+		"name": "pokemon-sandbox-api",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "all-pokemon",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('status is 200', function () { pm.response.to.have.status(200); });",
+							"var json = pm.response.json();",
+							"pm.test('has results array', function () { pm.expect(json.results).to.be.an('array'); });",
+							"pm.test('environment has a name', function () { pm.expect(pm.environment.name).to.be.a('string'); });",
+							"var firstName = json.results[0].name;",
+							"pm.environment.set('pokemonName', firstName);",
+							"pm.collectionVariables.set('firstPokemon', firstName);",
+							"pm.collectionVariables.set('resultCount', json.results.length);"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{baseUrl}}/pokemon?limit={{limit}}"
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "pokemon-by-name",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('response code is 200', function () { pm.expect(pm.response.code).to.eql(200); });",
+							"pm.test('text body is non-empty', function () { pm.expect(pm.response.text().length).to.be.above(0); });",
+							"pm.test('collection var carried over', function () { pm.expect(pm.collectionVariables.get('firstPokemon')).to.be.a('string'); });",
+							"var allCVars = pm.collectionVariables.toObject();",
+							"pm.test('toObject exposes resultCount', function () { pm.expect(allCVars).to.have.property('resultCount'); });",
+							"var json = pm.response.json();",
+							"pm.collectionVariables.set('pokemonId', json.id);",
+							"pm.execution.setNextRequest('pokemon-species');"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{baseUrl}}/pokemon/{{pokemonName}}"
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "pokemon-species",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('species status 200', function () { pm.response.to.have.status(200); });",
+							"pm.test('id matches earlier pokemon', function () { pm.expect(pm.response.json().id).to.eql(pm.collectionVariables.get('pokemonId')); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{baseUrl}}/pokemon-species/{{pokemonName}}"
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "add-object",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('object created', function () { pm.expect(pm.response.code).to.be.oneOf([200, 201]); });",
+							"pm.environment.set('objId', pm.response.json().id);"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"name\": \"revoman-{{pokemonName}}\",\n  \"data\": { \"source\": \"revoman-sandbox-test\" }\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "https://{{uri}}/objects"
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "update-object",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test('request body was readable', function () { pm.expect(pm.request.body.raw).to.include('updated-revoman'); });",
+							"pm.test('update echoes new name', function () { pm.expect(pm.response.json().data.name).to.eql('updated-revoman'); });"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "PUT",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"name\": \"revoman-{{pokemonName}}\",\n  \"data\": { \"name\": \"updated-revoman\" }\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "https://{{uri}}/objects/{{objId}}"
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/src/integrationTest/resources/pm-templates/v2/pokemon-sandbox-api/pokemon-sandbox-api.postman_environment.json
+++ b/src/integrationTest/resources/pm-templates/v2/pokemon-sandbox-api/pokemon-sandbox-api.postman_environment.json
@@ -1,0 +1,10 @@
+{
+  "id": "a1b2c3d4-0000-0000-0000-pokemonsandbox",
+  "name": "PokemonSandboxApi",
+  "values": [
+    { "key": "baseUrl", "value": "https://pokeapi.co/api/v2", "enabled": true },
+    { "key": "uri", "value": "api.restful-api.dev", "enabled": true },
+    { "key": "limit", "value": "5", "enabled": true }
+  ],
+  "_postman_variable_scope": "environment"
+}

--- a/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
+++ b/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
@@ -161,6 +161,7 @@ object ReVoman {
     val environment = ledgerValues + mergedEnv.values
     val pm =
       PostmanSDK(moshiReVoman, kick.nodeModulesPath(), regexReplacer, environment.toMutableMap())
+    pm.environmentName = mergedEnv.name
     val stepNameToReport =
       PmSandbox().use { sandbox ->
         executeStepsSerially(pmStepsDeepFlattened, kick, moshiReVoman, regexReplacer, pm, sandbox)

--- a/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
+++ b/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
@@ -363,6 +363,8 @@ object ReVoman {
                   produced = pm.environment.producedKeysFor(step),
                   consumed = pm.environment.consumedKeysFor(step),
                 ),
+              pmTestAssertions = pm.pmTestAssertionsFor(step),
+              nextRequest = pm.nextRequestFor(step),
             )
         haltExecution = shouldHaltExecution(currentStepReport, kick, pm.rundown)
         val captureForSink = RunLogContext.hasActiveSink()

--- a/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
+++ b/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
@@ -153,11 +153,7 @@ object ReVoman {
     // no-op.
     val ledgerValues: Map<String, Any?> = kick.ledger().values
     val mergedEnv =
-      mergeEnvs(
-        kick.environmentPaths(),
-        kick.environmentInputStreams(),
-        kick.dynamicEnvironment(),
-      )
+      mergeEnvs(kick.environmentPaths(), kick.environmentInputStreams(), kick.dynamicEnvironment())
     val environment = ledgerValues + mergedEnv.values
     val pm =
       PostmanSDK(moshiReVoman, kick.nodeModulesPath(), regexReplacer, environment.toMutableMap())

--- a/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
+++ b/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
@@ -152,13 +152,13 @@ object ReVoman {
     // `kick.ledger().values` is empty (LedgerSnapshot.EMPTY), so this prepends an empty map =
     // no-op.
     val ledgerValues: Map<String, Any?> = kick.ledger().values
-    val environment =
-      ledgerValues +
-        mergeEnvs(
-          kick.environmentPaths(),
-          kick.environmentInputStreams(),
-          kick.dynamicEnvironment(),
-        )
+    val mergedEnv =
+      mergeEnvs(
+        kick.environmentPaths(),
+        kick.environmentInputStreams(),
+        kick.dynamicEnvironment(),
+      )
+    val environment = ledgerValues + mergedEnv.values
     val pm =
       PostmanSDK(moshiReVoman, kick.nodeModulesPath(), regexReplacer, environment.toMutableMap())
     val stepNameToReport =

--- a/src/main/kotlin/com/salesforce/revoman/internal/exe/PmJsEval.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/exe/PmJsEval.kt
@@ -86,7 +86,8 @@ internal fun executePostResJS(
  * [PostmanSDK] so the rest of ReVoman observes script effects:
  * - environment: diffed back via [PostmanSDK.environment] set/unset (the ledger path — unchanged).
  * - collectionVariables: diffed back via [PostmanSDK.collectionVariables] set/unset.
- * - pm.test assertions + setNextRequest: stashed per [step] for the executor to read onto StepReport.
+ * - pm.test assertions + setNextRequest: stashed per [step] for the executor to read onto
+ *   StepReport.
  *
  * Throws on a script error so the surrounding [runCatching] maps it to the right failure type.
  *

--- a/src/main/kotlin/com/salesforce/revoman/internal/exe/PmJsEval.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/exe/PmJsEval.kt
@@ -9,6 +9,7 @@ package com.salesforce.revoman.internal.exe
 
 import arrow.core.Either
 import arrow.core.Either.Right
+import com.salesforce.revoman.internal.log.RevomanLog
 import com.salesforce.revoman.internal.postman.PostmanSDK
 import com.salesforce.revoman.internal.postman.sandbox.PmExecutionContext
 import com.salesforce.revoman.internal.postman.sandbox.PmSandbox
@@ -19,6 +20,7 @@ import com.salesforce.revoman.internal.postman.template.Item
 import com.salesforce.revoman.internal.postman.template.Request
 import com.salesforce.revoman.output.ExeType.POST_RES_JS
 import com.salesforce.revoman.output.ExeType.PRE_REQ_JS
+import com.salesforce.revoman.output.report.PmTestAssertion
 import com.salesforce.revoman.output.report.Step
 import com.salesforce.revoman.output.report.StepReport
 import com.salesforce.revoman.output.report.failure.RequestFailure.PreReqJSFailure
@@ -37,7 +39,14 @@ internal fun executePreReqJS(
   return if (!preReqJS.isNullOrBlank()) {
     runCatching(currentStep, PRE_REQ_JS) {
         pm.request = pm.from(itemWithRegex.request)
-        runSandboxScript(preReqJS, ScriptTarget.PRE_REQUEST, itemWithRegex.request, pm, sandbox)
+        runSandboxScript(
+          preReqJS,
+          ScriptTarget.PRE_REQUEST,
+          itemWithRegex.request,
+          pm,
+          sandbox,
+          currentStep,
+        )
       }
       .mapLeft { PreReqJSFailure(it, currentStepReport.requestInfo!!.get()) }
   } else {
@@ -58,7 +67,7 @@ internal fun executePostResJS(
     runCatching(currentStep, POST_RES_JS) {
         val httpResponse = currentStepReport.responseInfo!!.get().httpMsg
         pm.setRequestAndResponse(pm.from(item.request), httpResponse)
-        runSandboxScript(postResJs, ScriptTarget.TEST, item.request, pm, sandbox)
+        runSandboxScript(postResJs, ScriptTarget.TEST, item.request, pm, sandbox, currentStep)
       }
       .mapLeft {
         PostResJSFailure(
@@ -73,15 +82,17 @@ internal fun executePostResJS(
 }
 
 /**
- * Runs a pm script in the real Postman sandbox, then applies the returned environment scope back
- * onto [PostmanSDK.environment] via a diff so the ledger records produced/unset keys exactly as the
- * old in-JS `pm.environment.set` path did. Throws on a script error so the surrounding
- * [runCatching] maps it to the right failure type.
+ * Runs a pm script in the real Postman sandbox, then applies the returned scopes back onto the
+ * [PostmanSDK] so the rest of ReVoman observes script effects:
+ * - environment: diffed back via [PostmanSDK.environment] set/unset (the ledger path — unchanged).
+ * - collectionVariables: diffed back via [PostmanSDK.collectionVariables] set/unset.
+ * - pm.test assertions + setNextRequest: stashed per [step] for the executor to read onto StepReport.
  *
- * Only sandbox-safe env values (String/Number/Boolean/null — i.e. real Postman variable semantics)
- * are sent into and read back from the sandbox. ReVoman additionally stores typed POJOs in the env
- * (set by hooks for cross-step reuse); those are NOT pm-script variables, would not survive the
- * Flatted round-trip cleanly, and are intentionally left untouched in the Kotlin env.
+ * Throws on a script error so the surrounding [runCatching] maps it to the right failure type.
+ *
+ * Only sandbox-safe values (String/Number/Boolean/null — real Postman variable semantics) are sent
+ * into and read back from the sandbox. Typed POJOs ReVoman stores in the env (hooks, cross-step
+ * reuse) are NOT pm-script variables and are intentionally left untouched in the Kotlin env.
  */
 private fun runSandboxScript(
   script: String,
@@ -89,27 +100,49 @@ private fun runSandboxScript(
   pmRequest: Request,
   pm: PostmanSDK,
   sandbox: PmSandbox,
+  step: Step,
 ) {
-  val before: Map<String, Any?> = sandboxSafeEnv(pm)
+  val beforeEnv: Map<String, Any?> = sandboxSafeEnv(pm.environment.mutableEnv)
+  val beforeCVars: Map<String, Any?> = sandboxSafeEnv(pm.collectionVariables.mutableEnv)
   val context =
     PmExecutionContext(
-      environment = PmScope("environment", before),
+      environment = PmScope("environment", beforeEnv, name = pm.environmentName),
+      collectionVariables = PmScope("collectionVariables", beforeCVars),
       request = requestAsContextMap(pmRequest),
       response = if (target == ScriptTarget.TEST) responseAsContextMap(pm) else null,
     )
   val result = sandbox.execute(script, target, context)
   result.error?.let { throw it }
+
   // Apply env mutations back through the same set()/unset() paths the ledger reads.
-  val diff = diffScopes(before, result.environment)
-  diff.produced.forEach { key -> pm.environment.set(key, result.environment[key]) }
-  diff.unset.forEach { key -> pm.environment.unset(key) }
+  val envDiff = diffScopes(beforeEnv, result.environment)
+  envDiff.produced.forEach { key -> pm.environment.set(key, result.environment[key]) }
+  envDiff.unset.forEach { key -> pm.environment.unset(key) }
+
+  // Apply collection-variable mutations back (no ledger involvement — separate store).
+  val cVarDiff = diffScopes(beforeCVars, result.collectionVariables)
+  cVarDiff.produced.forEach { key ->
+    pm.collectionVariables.set(key, result.collectionVariables[key])
+  }
+  cVarDiff.unset.forEach { key -> pm.collectionVariables.unset(key) }
+
+  // Surface pm.test results + setNextRequest onto the StepReport (read by the executor fold).
+  pm.recordPmTestAssertions(
+    step,
+    result.assertions.map { PmTestAssertion(it.name, it.passed, it.skipped, it.error) },
+  )
+  result.nextRequest?.let { next ->
+    pm.recordNextRequest(step, next)
+    RevomanLog.warn {
+      "pm.execution.setNextRequest('$next') was captured but ReVoman does not yet reorder steps " +
+        "(linear execution); directive recorded on StepReport.nextRequest only (Phase 2 will honor it)."
+    }
+  }
 }
 
-/** Env entries that are real Postman variable values (safe to round-trip through the sandbox). */
-private fun sandboxSafeEnv(pm: PostmanSDK): Map<String, Any?> =
-  pm.environment.mutableEnv.filterValues {
-    it == null || it is String || it is Number || it is Boolean
-  }
+/** Filters a scope map to sandbox-safe values (real Postman variable values). */
+private fun sandboxSafeEnv(scope: Map<String, Any?>): Map<String, Any?> =
+  scope.filterValues { it == null || it is String || it is Number || it is Boolean }
 
 private fun requestAsContextMap(request: Request): Map<String, Any?> =
   linkedMapOf(

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/PostmanSDK.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/PostmanSDK.kt
@@ -15,6 +15,8 @@ import com.salesforce.revoman.internal.postman.template.Header
 import com.salesforce.revoman.internal.postman.template.Url
 import com.salesforce.revoman.output.Rundown
 import com.salesforce.revoman.output.postman.PostmanEnvironment
+import com.salesforce.revoman.output.report.PmTestAssertion
+import com.salesforce.revoman.output.report.Step
 import com.salesforce.revoman.output.report.StepReport
 import io.exoquery.pprint
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -36,6 +38,25 @@ class PostmanSDK(
   mutableEnv: MutableMap<String, Any?> = mutableMapOf(),
 ) {
   @JvmField val environment: PostmanEnvironment<Any?> = PostmanEnvironment(mutableEnv, moshiReVoman)
+
+  /**
+   * Collection-level variables (`pm.collectionVariables`). A plain key→value store reusing
+   * [PostmanEnvironment] for its set/unset/toMap utilities; its per-step ledger capture stays
+   * dormant because [PostmanEnvironment.currentStep] is never set on this instance. Script-seeded
+   * only (ReVoman does not parse collection-root `variable[]`), so it starts empty and is populated
+   * by scripts calling `pm.collectionVariables.set(...)`.
+   */
+  @JvmField
+  val collectionVariables: PostmanEnvironment<Any?> = PostmanEnvironment(mutableMapOf(), moshiReVoman)
+
+  /** The active environment's display name, exposed to scripts via `pm.environment.name`. */
+  @JvmField var environmentName: String? = null
+
+  // Per-step capture written by PmJsEval after each sandbox run, read by the executor fold when it
+  // builds the StepReport. Keyed by Step (a step can run a pre-req AND a post-res script).
+  private val pmTestAssertionsByStep: MutableMap<Step, List<PmTestAssertion>> = mutableMapOf()
+  private val nextRequestByStep: MutableMap<Step, String?> = mutableMapOf()
+
   lateinit var info: Info
   lateinit var request: Request
   lateinit var response: Response
@@ -94,6 +115,25 @@ class PostmanSDK(
     currentStepReport = stepReport
     rundown = rundown.copy(stepReports = rundown.stepReports + stepReport)
   }
+
+  /** Accumulates assertions across a step's pre-req + post-res scripts. */
+  internal fun recordPmTestAssertions(step: Step, assertions: List<PmTestAssertion>) {
+    pmTestAssertionsByStep[step] = (pmTestAssertionsByStep[step] ?: emptyList()) + assertions
+  }
+
+  internal fun pmTestAssertionsFor(step: Step): List<PmTestAssertion> =
+    pmTestAssertionsByStep[step] ?: emptyList()
+
+  /**
+   * Last-write-wins: a post-res `setNextRequest` overrides a pre-req one (matches Postman). A null
+   * (never recorded) and an explicit `setNextRequest(null)` clear are intentionally indistinguishable
+   * — both mean "no jump".
+   */
+  internal fun recordNextRequest(step: Step, nextRequest: String?) {
+    nextRequestByStep[step] = nextRequest
+  }
+
+  internal fun nextRequestFor(step: Step): String? = nextRequestByStep[step]
 
   internal fun setRequestAndResponse(pmRequest: Request, httpResponse: org.http4k.core.Response) {
     request = pmRequest

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/PostmanSDK.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/PostmanSDK.kt
@@ -47,7 +47,8 @@ class PostmanSDK(
    * by scripts calling `pm.collectionVariables.set(...)`.
    */
   @JvmField
-  val collectionVariables: PostmanEnvironment<Any?> = PostmanEnvironment(mutableMapOf(), moshiReVoman)
+  val collectionVariables: PostmanEnvironment<Any?> =
+    PostmanEnvironment(mutableMapOf(), moshiReVoman)
 
   /** The active environment's display name, exposed to scripts via `pm.environment.name`. */
   @JvmField var environmentName: String? = null
@@ -126,8 +127,8 @@ class PostmanSDK(
 
   /**
    * Last-write-wins: a post-res `setNextRequest` overrides a pre-req one (matches Postman). A null
-   * (never recorded) and an explicit `setNextRequest(null)` clear are intentionally indistinguishable
-   * — both mean "no jump".
+   * (never recorded) and an explicit `setNextRequest(null)` clear are intentionally
+   * indistinguishable — both mean "no jump".
    */
   internal fun recordNextRequest(step: Step, nextRequest: String?) {
     nextRequestByStep[step] = nextRequest

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/sandbox/PmExecutionContext.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/sandbox/PmExecutionContext.kt
@@ -13,8 +13,12 @@ internal enum class ScriptTarget(val listen: String) {
   TEST("test"),
 }
 
-/** A single variable scope (environment / globals / collectionVariables) as key→value. */
-internal data class PmScope(val id: String, val values: Map<String, Any?>)
+/**
+ * A single variable scope (environment / globals / collectionVariables) as key→value. [name] is the
+ * scope's display name (e.g. the environment name) — exposed to scripts via `pm.environment.name`;
+ * null when the scope is unnamed.
+ */
+internal data class PmScope(val id: String, val values: Map<String, Any?>, val name: String? = null)
 
 /**
  * Everything the sandbox needs to execute one script. Variable scopes are snapshots taken from

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/sandbox/SandboxBridge.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/sandbox/SandboxBridge.kt
@@ -246,7 +246,8 @@ internal class SandboxBridge {
           environment = scopeValues(execution["environment"])
           globals = scopeValues(execution["globals"])
           collectionVariables = scopeValues(execution["collectionVariables"])
-          // `pm.execution.setNextRequest(name)` writes `execution.return.nextRequest`. Capture it as
+          // `pm.execution.setNextRequest(name)` writes `execution.return.nextRequest`. Capture it
+          // as
           // a control-flow directive; the step sequencer consumes it in Phase 2.
           nextRequest = (execution["return"] as? Map<*, *>)?.get("nextRequest") as? String
         }

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/sandbox/SandboxBridge.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/sandbox/SandboxBridge.kt
@@ -186,14 +186,18 @@ internal class SandboxBridge {
   private fun scopeToProxy(scope: PmScope): ProxyObject =
     ProxyObject.fromMap(
       linkedMapOf<String, Any?>(
-        "id" to scope.id,
-        "values" to
-          ProxyArray.fromList(
-            scope.values.map { (k, v) ->
-              ProxyObject.fromMap(linkedMapOf<String, Any?>("key" to k, "value" to v))
-            }
-          ),
-      )
+          "id" to scope.id,
+          "values" to
+            ProxyArray.fromList(
+              scope.values.map { (k, v) ->
+                ProxyObject.fromMap(linkedMapOf<String, Any?>("key" to k, "value" to v))
+              }
+            ),
+        )
+        // postman-collection's VariableScope carries an optional `name`; forwarding it makes
+        // `pm.environment.name` (and other named scopes) readable from scripts. Omit when null so
+        // unnamed scopes stay unnamed rather than becoming the string "null".
+        .also { m -> scope.name?.let { m["name"] = it } }
     )
 
   private fun decodeResult(id: String): PmExecutionResult {
@@ -202,6 +206,7 @@ internal class SandboxBridge {
     var environment: Map<String, Any?> = emptyMap()
     var globals: Map<String, Any?> = emptyMap()
     var collectionVariables: Map<String, Any?> = emptyMap()
+    var nextRequest: String? = null
 
     for (raw in emits) {
       val parsed = Flatted.parse(raw) as? List<*> ?: continue
@@ -241,10 +246,20 @@ internal class SandboxBridge {
           environment = scopeValues(execution["environment"])
           globals = scopeValues(execution["globals"])
           collectionVariables = scopeValues(execution["collectionVariables"])
+          // `pm.execution.setNextRequest(name)` writes `execution.return.nextRequest`. Capture it as
+          // a control-flow directive; the step sequencer consumes it in Phase 2.
+          nextRequest = (execution["return"] as? Map<*, *>)?.get("nextRequest") as? String
         }
       }
     }
-    return PmExecutionResult(environment, globals, collectionVariables, assertions, error)
+    return PmExecutionResult(
+      environment,
+      globals,
+      collectionVariables,
+      assertions,
+      error,
+      nextRequest,
+    )
   }
 
   /**

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/template/Environment.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/template/Environment.kt
@@ -18,6 +18,9 @@ import com.squareup.moshi.adapter
 import java.io.InputStream
 import kotlin.collections.plus
 
+/** The merged environment values plus the chosen environment display name (null if unnamed). */
+internal data class MergedEnv(val name: String?, val values: Map<String, Any?>)
+
 @JsonClass(generateAdapter = true)
 internal data class Environment(val name: String?, val values: List<EnvValue>) {
   @AlwaysSerializeNulls
@@ -38,33 +41,39 @@ internal data class Environment(val name: String?, val values: List<EnvValue>) {
       pmEnvironmentPaths: Set<String>,
       pmEnvironmentInputStreams: List<InputStream>,
       dynamicEnvironment: Map<String, Any?>,
-    ): Map<String, Any?> {
+    ): MergedEnv {
       val envAdapter = Moshi.Builder().build().adapter<Environment>()
-      val envFromYamlPaths: Map<String, Any?> =
+
+      // V3 yaml paths — read name + values from each.
+      val yamlEnvs: List<com.salesforce.revoman.internal.postman.template.v3.V3EnvRead> =
         pmEnvironmentPaths
           .filter { isV3EnvFile(it) }
-          .fold(emptyMap()) { acc, path ->
-            acc + com.salesforce.revoman.internal.postman.template.v3.V3EnvLoader.loadFromPath(path)
-          }
-      val envFromJsonPaths: Map<String, Any?> =
+          .map { com.salesforce.revoman.internal.postman.template.v3.V3EnvLoader.readWithName(it) }
+      val envFromYamlPaths: Map<String, Any?> = yamlEnvs.fold(emptyMap()) { acc, e -> acc + e.values }
+
+      // V2 json paths — parse to Environment once, derive values + name.
+      val jsonEnvs: List<Environment> =
         pmEnvironmentPaths
           .filterNot { isV3EnvFile(it) }
-          .map { bufferFile(it) }
-          .flatMap { source ->
-            envAdapter.fromJson(source)?.values?.filter { it.enabled } ?: emptyList()
-          }
-          .associate { it.key to it.value }
+          .mapNotNull { envAdapter.fromJson(bufferFile(it)) }
+      val envFromJsonPaths: Map<String, Any?> =
+        jsonEnvs.flatMap { it.values.filter { v -> v.enabled } }.associate { it.key to it.value }
+
+      // Streams — parse to Environment once (single read), derive values + name.
+      val streamEnvs: List<Environment> =
+        pmEnvironmentInputStreams.mapNotNull { envAdapter.fromJson(bufferInputStream(it)) }
       val envFromStreams: Map<String, Any?> =
-        pmEnvironmentInputStreams
-          .map { bufferInputStream(it) }
-          .flatMap { source ->
-            envAdapter.fromJson(source)?.values?.filter { it.enabled } ?: emptyList()
-          }
-          .associate { it.key to it.value }
+        streamEnvs.flatMap { it.values.filter { v -> v.enabled } }.associate { it.key to it.value }
+
       // * NOTE 10/09/23 gopala.akshintala: dynamicEnvironment keys replace envFromEnvFiles when
       // clashed
       // ! TODO 11 Jun 2025 gopala.akshintala: serialize only during regex replace
-      return envFromYamlPaths + envFromJsonPaths + envFromStreams + dynamicEnvironment
+      val values = envFromYamlPaths + envFromJsonPaths + envFromStreams + dynamicEnvironment
+      // Name precedence mirrors value order: last non-null wins (yaml -> json -> streams).
+      val name =
+        (yamlEnvs.map { it.name } + jsonEnvs.map { it.name } + streamEnvs.map { it.name })
+          .lastOrNull { it != null }
+      return MergedEnv(name, values)
     }
   }
 }

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/template/Environment.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/template/Environment.kt
@@ -49,7 +49,8 @@ internal data class Environment(val name: String?, val values: List<EnvValue>) {
         pmEnvironmentPaths
           .filter { isV3EnvFile(it) }
           .map { com.salesforce.revoman.internal.postman.template.v3.V3EnvLoader.readWithName(it) }
-      val envFromYamlPaths: Map<String, Any?> = yamlEnvs.fold(emptyMap()) { acc, e -> acc + e.values }
+      val envFromYamlPaths: Map<String, Any?> =
+        yamlEnvs.fold(emptyMap()) { acc, e -> acc + e.values }
 
       // V2 json paths — parse to Environment once, derive values + name.
       val jsonEnvs: List<Environment> =

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3EnvLoader.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3EnvLoader.kt
@@ -10,11 +10,16 @@ package com.salesforce.revoman.internal.postman.template.v3
 import com.salesforce.revoman.input.bufferFile
 import io.github.oshai.kotlinlogging.KotlinLogging
 
+/** V3 env read carrying both the display name and the flattened key→value map. */
+internal data class V3EnvRead(val name: String?, val values: Map<String, Any?>)
+
 internal object V3EnvLoader {
-  fun loadFromPath(path: String): Map<String, Any?> {
+  fun loadFromPath(path: String): Map<String, Any?> = readWithName(path).values
+
+  fun readWithName(path: String): V3EnvRead {
     val yaml = bufferFile(path).readUtf8()
     val env = V3YamlReader.readEnv(yaml)
-    return env.values.associate { it.key to it.value }
+    return V3EnvRead(env.name, env.values.associate { it.key to it.value })
   }
 }
 

--- a/src/main/kotlin/com/salesforce/revoman/output/postman/PostmanEnvironment.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/postman/PostmanEnvironment.kt
@@ -53,19 +53,23 @@ constructor(
 
   fun set(key: String, value: ValueT) {
     mutableEnv[key] = value
-    if (::currentStep.isInitialized) {
-      producedKeysByStep.getOrPut(currentStep) { mutableSetOf() }.add(key)
-    }
+    // `currentStep` is a lateinit set only on the step-bound `environment` instance; stores like
+    // `collectionVariables` never set it. Read it null-safely so the ledger capture AND the log
+    // line
+    // both no-op on an unstepped instance — interpolating an uninitialized lateinit would throw.
+    val step: Step? = if (::currentStep.isInitialized) currentStep else null
+    if (step != null) producedKeysByStep.getOrPut(step) { mutableSetOf() }.add(key)
     logger.info {
-      "pm environment variable set in Step: $currentStep - key: $key, value: ${pprint(value)}"
+      "pm environment variable set in Step: $step - key: $key, value: ${pprint(value)}"
     }
   }
 
   @Suppress("unused")
   fun unset(key: String) {
     mutableEnv.remove(key)
-    if (::currentStep.isInitialized) producedKeysByStep[currentStep]?.remove(key)
-    logger.info { "pm environment variable unset through JS in Step: $currentStep - key: $key" }
+    val step: Step? = if (::currentStep.isInitialized) currentStep else null
+    if (step != null) producedKeysByStep[step]?.remove(key)
+    logger.info { "pm environment variable unset through JS in Step: $step - key: $key" }
   }
 
   // ! TODO 13/09/23 gopala.akshintala: Refactor code to remove duplication

--- a/src/main/kotlin/com/salesforce/revoman/output/report/PmTestAssertion.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/report/PmTestAssertion.kt
@@ -1,0 +1,23 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.output.report
+
+/**
+ * The result of a single `pm.test(name, fn)` assertion block reported by the Postman sandbox.
+ * Attached to [StepReport.pmTestAssertions]. A failing assertion is DATA here (not a thrown error):
+ * [passed] is false and [error] carries the chai/AssertionError message. [skipped] is true for
+ * `pm.test.skip(...)`.
+ */
+data class PmTestAssertion
+@JvmOverloads
+constructor(
+  @JvmField val name: String,
+  @JvmField val passed: Boolean,
+  @JvmField val skipped: Boolean = false,
+  @JvmField val error: String? = null,
+)

--- a/src/main/kotlin/com/salesforce/revoman/output/report/StepReport.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/report/StepReport.kt
@@ -37,9 +37,7 @@ internal constructor(
   @JvmField val exeTimings: Map<ExeType, Duration> = emptyMap(),
   @JvmField val pmEnvSnapshot: PostmanEnvironment<Any?>,
   @JvmField val envVars: StepEnvVars = StepEnvVars(),
-  /**
-   * `pm.test(...)` results recorded across this step's scripts (pre-request and post-response).
-   */
+  /** `pm.test(...)` results recorded across this step's scripts (pre-request and post-response). */
   @JvmField val pmTestAssertions: List<PmTestAssertion> = emptyList(),
   /**
    * Next request set via `pm.execution.setNextRequest(...)` in this step's scripts, if any.

--- a/src/main/kotlin/com/salesforce/revoman/output/report/StepReport.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/report/StepReport.kt
@@ -37,6 +37,17 @@ internal constructor(
   @JvmField val exeTimings: Map<ExeType, Duration> = emptyMap(),
   @JvmField val pmEnvSnapshot: PostmanEnvironment<Any?>,
   @JvmField val envVars: StepEnvVars = StepEnvVars(),
+  /**
+   * `pm.test(...)` results recorded across this step's scripts (pre-request and post-response).
+   */
+  @JvmField val pmTestAssertions: List<PmTestAssertion> = emptyList(),
+  /**
+   * Next request set via `pm.execution.setNextRequest(...)` in this step's scripts, if any.
+   *
+   * CAPTURED ONLY — ReVoman executes steps linearly and does NOT yet honor this directive to
+   * reorder/skip (Phase 2 will). Treat this as an observed signal, not proof of a jump.
+   */
+  @JvmField val nextRequest: String? = null,
 ) {
   internal constructor(
     step: Step,

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/PostmanSDKCollectionVariablesTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/PostmanSDKCollectionVariablesTest.kt
@@ -1,0 +1,66 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.postman
+
+import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
+import com.salesforce.revoman.internal.postman.template.Item
+import com.salesforce.revoman.output.report.PmTestAssertion
+import com.salesforce.revoman.output.report.Step
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class PostmanSDKCollectionVariablesTest {
+  private fun sdk() = PostmanSDK(initMoshi())
+
+  private fun step(name: String) = Step(index = "1", rawPMStep = Item(name = name))
+
+  @Test
+  fun `collectionVariables store round-trips set and toMap`() {
+    val pm = sdk()
+    pm.collectionVariables.set("a", "1")
+    pm.collectionVariables.toMap() shouldBe mapOf("a" to "1")
+  }
+
+  @Test
+  fun `environmentName defaults to null and is settable`() {
+    val pm = sdk()
+    pm.environmentName shouldBe null
+    pm.environmentName = "Pokemon"
+    pm.environmentName shouldBe "Pokemon"
+  }
+
+  @Test
+  fun `per-step pmTestAssertions capture is keyed by step`() {
+    val pm = sdk()
+    val s1 = step("s1")
+    val assertions = listOf(PmTestAssertion("t", true))
+    pm.recordPmTestAssertions(s1, assertions)
+    pm.pmTestAssertionsFor(s1) shouldHaveSize 1
+    pm.pmTestAssertionsFor(step("other")) shouldHaveSize 0
+  }
+
+  @Test
+  fun `per-step pmTestAssertions accumulate across pre-req and post-res`() {
+    val pm = sdk()
+    val s1 = step("s1")
+    pm.recordPmTestAssertions(s1, listOf(PmTestAssertion("pre", true)))
+    pm.recordPmTestAssertions(s1, listOf(PmTestAssertion("post", false)))
+    pm.pmTestAssertionsFor(s1) shouldHaveSize 2
+  }
+
+  @Test
+  fun `per-step nextRequest capture is keyed by step and last-write-wins`() {
+    val pm = sdk()
+    val s1 = step("s1")
+    pm.recordNextRequest(s1, "first")
+    pm.recordNextRequest(s1, "second")
+    pm.nextRequestFor(s1) shouldBe "second"
+    pm.nextRequestFor(step("other")) shouldBe null
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/RegexReplacerTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/RegexReplacerTest.kt
@@ -30,7 +30,7 @@ class RegexReplacerTest {
     val regexReplacer = RegexReplacer(emptyMap(), dummyDynamicVariableGenerator)
     val pm = PostmanSDK(moshiReVoman, null, regexReplacer)
     pm.environment.putAll(
-      mergeEnvs(setOf("env-with-regex.json"), emptyList(), mutableMapOf("un" to "userName"))
+      mergeEnvs(setOf("env-with-regex.json"), emptyList(), mutableMapOf("un" to "userName")).values
     )
     val envWithVariablesReplaced = regexReplacer.replaceVariablesInEnv(pm)
     envWithVariablesReplaced shouldContain ("userName" to "user-$epoch@xyz.com")

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/sandbox/PmSandboxApiCoverageTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/sandbox/PmSandboxApiCoverageTest.kt
@@ -14,8 +14,8 @@ import org.junit.jupiter.api.TestInstance
 
 /**
  * Per-feature coverage of the script-only `pm` APIs ReVoman commits to supporting in Phase 1,
- * grouped by Postman API area. Each test runs the REAL postman-sandbox bootcode under GraalJS (boots
- * once for the class) so it characterizes the actual behavior, not a shim.
+ * grouped by Postman API area. Each test runs the REAL postman-sandbox bootcode under GraalJS
+ * (boots once for the class) so it characterizes the actual behavior, not a shim.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class PmSandboxApiCoverageTest {

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/sandbox/PmSandboxApiCoverageTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/sandbox/PmSandboxApiCoverageTest.kt
@@ -1,0 +1,175 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.postman.sandbox
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Per-feature coverage of the script-only `pm` APIs ReVoman commits to supporting in Phase 1,
+ * grouped by Postman API area. Each test runs the REAL postman-sandbox bootcode under GraalJS (boots
+ * once for the class) so it characterizes the actual behavior, not a shim.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PmSandboxApiCoverageTest {
+  private val sandbox = PmSandbox()
+
+  @AfterAll fun tearDown() = sandbox.close()
+
+  private fun runTest(
+    script: String,
+    env: Map<String, Any?> = emptyMap(),
+    collectionVariables: Map<String, Any?> = emptyMap(),
+    request: Map<String, Any?>? = null,
+    response: Map<String, Any?>? = null,
+  ): PmExecutionResult =
+    sandbox.execute(
+      script,
+      ScriptTarget.TEST,
+      PmExecutionContext(
+        environment = PmScope("e", env),
+        collectionVariables = PmScope("cv", collectionVariables),
+        request = request,
+        response = response,
+      ),
+    )
+
+  // ---------------------------------------------------------------- Variables
+
+  @Test
+  fun `pm collectionVariables get reads a seeded value`() {
+    val r =
+      runTest(
+        "pm.test('get', () => pm.expect(pm.collectionVariables.get('seed')).to.eql('s1'));",
+        collectionVariables = mapOf("seed" to "s1"),
+      )
+    r.error shouldBe null
+    r.assertions[0].passed shouldBe true
+  }
+
+  @Test
+  fun `pm collectionVariables set round-trips back to host`() {
+    val r = runTest("pm.collectionVariables.set('produced', 'p1');")
+    r.error shouldBe null
+    r.collectionVariables["produced"] shouldBe "p1"
+  }
+
+  @Test
+  fun `pm collectionVariables toObject returns all as a plain object`() {
+    val r =
+      runTest(
+        """
+        pm.collectionVariables.set('b', '2');
+        const all = pm.collectionVariables.toObject();
+        pm.test('toObject has seeded key', () => pm.expect(all.a).to.eql('1'));
+        pm.test('toObject has set key', () => pm.expect(all.b).to.eql('2'));
+        """
+          .trimIndent(),
+        collectionVariables = mapOf("a" to "1"),
+      )
+    r.error shouldBe null
+    r.assertions[0].passed shouldBe true
+    r.assertions[1].passed shouldBe true
+  }
+
+  // ---------------------------------------------------------------- Environment
+
+  @Test
+  fun `pm environment name is exposed to the script`() {
+    val r =
+      sandbox.execute(
+        "pm.test('name', () => pm.expect(pm.environment.name).to.eql('Pokemon Env'));",
+        ScriptTarget.TEST,
+        PmExecutionContext(environment = PmScope("env-id", emptyMap(), name = "Pokemon Env")),
+      )
+    r.error shouldBe null
+    r.assertions[0].passed shouldBe true
+  }
+
+  // ---------------------------------------------------------------- Request / Response
+
+  @Test
+  fun `pm request body raw is readable in a test script`() {
+    val r =
+      runTest(
+        "pm.test('body', () => pm.expect(pm.request.body.raw).to.include('bulbasaur'));",
+        request =
+          mapOf(
+            "method" to "POST",
+            "url" to "https://example.com",
+            "body" to mapOf("mode" to "raw", "raw" to """{"name":"bulbasaur"}"""),
+          ),
+      )
+    r.error shouldBe null
+    r.assertions[0].passed shouldBe true
+  }
+
+  @Test
+  fun `pm response code returns the HTTP status code`() {
+    val r =
+      runTest(
+        "pm.test('code', () => pm.expect(pm.response.code).to.eql(200));",
+        response = mapOf("code" to 200, "status" to "OK", "body" to "{}"),
+      )
+    r.error shouldBe null
+    r.assertions[0].passed shouldBe true
+  }
+
+  @Test
+  fun `pm response json parses the response body`() {
+    val r =
+      runTest(
+        "pm.test('json', () => pm.expect(pm.response.json().x).to.eql(7));",
+        response = mapOf("code" to 200, "status" to "OK", "body" to """{"x":7}"""),
+      )
+    r.error shouldBe null
+    r.assertions[0].passed shouldBe true
+  }
+
+  @Test
+  fun `pm response text returns the raw body string`() {
+    val r =
+      runTest(
+        "pm.test('text', () => pm.expect(pm.response.text()).to.eql('{\"x\":7}'));",
+        response = mapOf("code" to 200, "status" to "OK", "body" to """{"x":7}"""),
+      )
+    r.error shouldBe null
+    r.assertions[0].passed shouldBe true
+  }
+
+  @Test
+  fun `pm response to have status asserts on the status code`() {
+    val r =
+      runTest(
+        "pm.test('status', () => pm.response.to.have.status(200));",
+        response = mapOf("code" to 200, "status" to "OK", "body" to "{}"),
+      )
+    r.error shouldBe null
+    r.assertions[0].passed shouldBe true
+  }
+
+  // ---------------------------------------------------------------- Testing / Assertions
+
+  @Test
+  fun `pm test and pm expect record a passing assertion`() {
+    val r = runTest("pm.test('expect', () => pm.expect(1 + 1).to.eql(2));")
+    r.error shouldBe null
+    r.assertions[0].passed shouldBe true
+  }
+
+  // ---------------------------------------------------------------- Execution Control
+
+  @Test
+  fun `pm execution setNextRequest is captured in the result`() {
+    val r = runTest("pm.execution.setNextRequest('color-step');")
+    r.error shouldBe null
+    r.nextRequest shouldBe "color-step"
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/sandbox/PmSandboxScriptApiTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/sandbox/PmSandboxScriptApiTest.kt
@@ -65,6 +65,53 @@ class PmSandboxScriptApiTest {
   }
 
   @Test
+  fun `pm collectionVariables get set unset round-trips`() {
+    val r =
+      sandbox.execute(
+        """
+        pm.test('reads seeded collectionVariable', () =>
+          pm.expect(pm.collectionVariables.get('seed')).to.eql('seedVal'));
+        pm.collectionVariables.set('produced', 'p1');
+        pm.collectionVariables.unset('toRemove');
+        pm.test('reads back set collectionVariable', () =>
+          pm.expect(pm.collectionVariables.get('produced')).to.eql('p1'));
+        """
+          .trimIndent(),
+        ScriptTarget.TEST,
+        PmExecutionContext(
+          environment = PmScope("e", emptyMap()),
+          collectionVariables = PmScope("cv", mapOf("seed" to "seedVal", "toRemove" to "x")),
+        ),
+      )
+    r.error shouldBe null
+    r.assertions[0].passed shouldBe true // get() reads the seeded value
+    r.assertions[1].passed shouldBe true // set() is visible within the same script
+    r.collectionVariables["produced"] shouldBe "p1" // set() round-trips back to the host
+    (r.collectionVariables.containsKey("toRemove")) shouldBe false // unset() round-trips back
+  }
+
+  @Test
+  fun `console log runs but is not captured in the execution result`() {
+    val r =
+      runTest(
+        """
+        console.log('hello from pm', { a: 1 });
+        console.warn('a warning');
+        console.error('an error');
+        console.info('some info');
+        pm.test('script completed after console calls', () => pm.expect(true).to.be.true);
+        """
+          .trimIndent()
+      )
+    // console.* exist in the sandbox (bootcode provides them) so calling them does NOT throw.
+    r.error shouldBe null
+    r.assertions[0].passed shouldBe true
+    // PmExecutionResult has NO console/log field: the guest dispatches `execution.console` events
+    // but SandboxBridge.decodeResult has no branch for them and boot installs no capture — so the
+    // logged lines are silently dropped, never surfaced to the host or printed by ReVoman.
+  }
+
+  @Test
   fun `pm response json and status assertions`() {
     val r =
       sandbox.execute(

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/template/MergeEnvsNameTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/template/MergeEnvsNameTest.kt
@@ -15,11 +15,7 @@ class MergeEnvsNameTest {
   @Test
   fun `mergeEnvs reads the environment name from a v2 json env file`() {
     val merged =
-      mergeEnvs(
-        setOf("pm-templates/mini-env.postman_environment.json"),
-        emptyList(),
-        emptyMap(),
-      )
+      mergeEnvs(setOf("pm-templates/mini-env.postman_environment.json"), emptyList(), emptyMap())
     merged.name shouldBe "Pokemon"
     merged.values["baseUrl"] shouldBe "https://pokeapi.co/api/v2"
   }

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/template/MergeEnvsNameTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/template/MergeEnvsNameTest.kt
@@ -1,0 +1,33 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.postman.template
+
+import com.salesforce.revoman.internal.postman.template.Environment.Companion.mergeEnvs
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class MergeEnvsNameTest {
+  @Test
+  fun `mergeEnvs reads the environment name from a v2 json env file`() {
+    val merged =
+      mergeEnvs(
+        setOf("pm-templates/mini-env.postman_environment.json"),
+        emptyList(),
+        emptyMap(),
+      )
+    merged.name shouldBe "Pokemon"
+    merged.values["baseUrl"] shouldBe "https://pokeapi.co/api/v2"
+  }
+
+  @Test
+  fun `mergeEnvs name is null when there is no env source`() {
+    val merged = mergeEnvs(emptySet(), emptyList(), mapOf("k" to "v"))
+    merged.name shouldBe null
+    merged.values["k"] shouldBe "v"
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3EnvLoaderTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3EnvLoaderTest.kt
@@ -23,10 +23,11 @@ class V3EnvLoaderTest {
   fun testMergeEnvsAcceptsV3YamlAndDynamicEnv() {
     val merged =
       com.salesforce.revoman.internal.postman.template.Environment.mergeEnvs(
-        pmEnvironmentPaths = setOf("pm-templates/v3/test.environment.yaml"),
-        pmEnvironmentInputStreams = emptyList(),
-        dynamicEnvironment = mapOf("override" to "yes"),
-      )
+          pmEnvironmentPaths = setOf("pm-templates/v3/test.environment.yaml"),
+          pmEnvironmentInputStreams = emptyList(),
+          dynamicEnvironment = mapOf("override" to "yes"),
+        )
+        .values
     assertThat(merged).containsEntry("baseUrl", "https://example.com")
     assertThat(merged).containsEntry("count", "5")
     assertThat(merged).containsEntry("override", "yes")

--- a/src/test/kotlin/com/salesforce/revoman/output/postman/PostmanEnvironmentUnsteppedTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/output/postman/PostmanEnvironmentUnsteppedTest.kt
@@ -1,0 +1,45 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.output.postman
+
+import io.kotest.matchers.maps.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression guard for the `pm.collectionVariables` store — a [PostmanEnvironment] whose
+ * `currentStep` lateinit is intentionally NEVER set (only the step-bound `environment` instance
+ * sets it, to keep per-step ledger capture dormant on the collection-variable store).
+ *
+ * The bug this guards: `set`/`unset` referenced `currentStep` in their `logger.info { }` message
+ * OUTSIDE the `::currentStep.isInitialized` guard, so on an unstepped instance the message lambda
+ * threw `UninitializedPropertyAccessException` whenever INFO logging was enabled (the norm in the
+ * Core embedding). The fix reads `currentStep` into a single null-safe `step` local shared by the
+ * ledger-capture AND the log line, so neither touches the lateinit when it is unset.
+ *
+ * This test pins the observable, logging-independent contract: `set`/`unset` on an unstepped
+ * instance mutate the map and record nothing. (The throw itself is logging-gated; this repo's test
+ * JVM log binding defaults above INFO so it cannot be reproduced here — the guarantee asserted is
+ * that the methods are total on an unstepped instance, which is what the fix makes structurally
+ * true: every `currentStep` read now sits behind the `isInitialized` guard.)
+ */
+class PostmanEnvironmentUnsteppedTest {
+  @Test
+  fun `set then unset on an unstepped instance mutate the map and record no produced keys`() {
+    // Constructed exactly how PostmanSDK.collectionVariables is: no currentStep ever assigned.
+    val store: PostmanEnvironment<Any?> = PostmanEnvironment()
+
+    store.set("a", "1")
+    store.set("b", 2)
+    store.mutableEnv shouldContainExactly mapOf("a" to "1", "b" to 2)
+
+    store.unset("a")
+    store.mutableEnv.containsKey("a") shouldBe false
+    store.mutableEnv shouldContainExactly mapOf("b" to 2)
+  }
+}

--- a/src/test/resources/pm-templates/mini-env.postman_environment.json
+++ b/src/test/resources/pm-templates/mini-env.postman_environment.json
@@ -1,0 +1,1 @@
+{"name":"Pokemon","values":[{"key":"baseUrl","value":"https://pokeapi.co/api/v2","enabled":true}]}


### PR DESCRIPTION
## What

Wires every **script-only `pm` API** through ReVoman so it's observable end-to-end in a real `ReVoman.revUp()` run, and locks each with unit + a live integration test. Builds on the Phase-1 sandbox boot (real `postman-sandbox` bootcode under GraalJS).

| Area | APIs |
|---|---|
| Variables | `pm.collectionVariables.get/set/toObject` |
| Environment | `pm.environment`, `pm.environment.name` |
| Request/Response | `pm.request.body`, `pm.response.code/json/text/to.have.status` |
| Testing | `pm.test`, `pm.expect` |
| Execution control | `pm.execution.setNextRequest` (**captured + surfaced, NOT executed** — sequencer is Phase 2) |

## How

- **`PmTestAssertion`** — public type for `StepReport`.
- **`PostmanSDK`** — adds a `collectionVariables` store (separate `PostmanEnvironment`, ledger-dormant), `environmentName`, and per-step capture of pm.test results + nextRequest.
- **`mergeEnvs`** — now returns `MergedEnv(name, values)`; env name threaded onto `PostmanSDK`.
- **`PmJsEval.runSandboxScript`** — threads `collectionVariables` + env name INTO the sandbox context, diffs `collectionVariables` back OUT (parallel to the env diff), stashes assertions + nextRequest per step, and `warn`s when a script calls `setNextRequest` (captured-not-executed).
- **`StepReport`** — new read-only `pmTestAssertions: List<PmTestAssertion>` and `nextRequest: String?`.
- **`PokemonSandboxApiTest`** — live E2E (pokeapi.co GET chain + restful-api.dev POST/PUT) asserting all the above on the `Rundown`.

### `setNextRequest`: captured, not executed
The directive is decoded (`execution.return.nextRequest`), surfaced on `StepReport.nextRequest`, and `warn`-logged — but ReVoman still runs steps **linearly**. Honoring it (jump-capable sequencer) is deferred to Phase 2 (reconciling ledger skip/inject, haltOnFailure, name→index, loop-guard). The integration test asserts the directive was *captured*, with a comment that reordering is Phase 2.

### Cross-cutting fix (found in final review)
`PostmanEnvironment.set/unset` interpolated `$currentStep` in their `logger.info { }` message **outside** the `::currentStep.isInitialized` guard. The new `collectionVariables` store never sets `currentStep`, so under INFO logging (the norm in the Core embedding) the message lambda would throw `UninitializedPropertyAccessException`, surfaced by `runCatching` as a spurious step failure. Fixed by routing `currentStep` through a single null-safe local.

## Testing

- **Unit: 251/251 green** (incl. `PmSandboxApiCoverageTest` covering all 12 APIs at the sandbox layer, `PostmanSDKCollectionVariablesTest`, `MergeEnvsNameTest`, `PostmanEnvironmentUnsteppedTest`).
- **Integration:** `PokemonSandboxApiTest` passes (live). ⚠️ The pre-existing `restful-api.dev` integration tests (`RestfulAPIDevKtTest` v2+v3, `LedgerRoundTripKtTest`) can fail with **HTTP 405 "daily request limit"** — that free API caps the public tier at **50 requests/24h**, exhausted by repeated local runs. Environmental, not a code regression; the quota resets in ~24h. Verify on a fresh CI quota.

## Out of scope (Phase 2)
- `setNextRequest` executing sequencer.
- `pm.globals` scope (currently threaded neither in nor out — a script's `pm.globals.set` silently vanishes; not a regression, was always unsupported).
- `pm.sendRequest` (unchanged — explicit unsupported error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
