### PR TITLE
test(wfs-seed): Workforce Scheduling base-seed E2E against an external org

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,8 @@ dependencies {
   testImplementation(libs.json.assert)
   mockitoAgent(libs.mockito.core) { isTransitive = false }
   testImplementation(libs.mockk)
+  // WfsSeedE2ETest seeds the Shift.Status dyn-enum directly in local SDB (postgres) via JDBC.
+  testImplementation("org.postgresql:postgresql:42.7.4")
 }
 
 testing {

--- a/src/test/kotlin/com/salesforce/revoman/WfsSeedE2ETest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/WfsSeedE2ETest.kt
@@ -11,6 +11,7 @@ import com.google.common.truth.Truth.assertThat
 import com.salesforce.revoman.input.config.Kick
 import com.salesforce.revoman.input.readExternalOrgConfig
 import com.salesforce.revoman.internal.postman.template.v3.V3EnvLoader
+import io.github.oshai.kotlinlogging.KotlinLogging
 import java.net.URLEncoder
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
@@ -44,6 +45,7 @@ import org.junit.jupiter.api.Test
  */
 class WfsSeedE2ETest {
 
+  private val logger = KotlinLogging.logger {}
   private val collection = "pm-templates/v3/wfs-seed"
   private val soapLoginApiVersion = "64" // v68 rejects SOAP login on this org
 
@@ -105,6 +107,30 @@ class WfsSeedE2ETest {
     // owns one resource — see the service-resources folder for the (user, type) uniqueness note).
     assertThat(count("wfsSeedServiceResourceCount")).isAtLeast(1)
     assertThat(count("wfsSeedTerritoryMemberCount")).isAtLeast(1)
+
+    // 5. Summary of what now exists on the org (counts are org-wide totals matching the WS name
+    // filters, so on a re-seeded org they include prior runs — see the `>=` note above).
+    fun env(key: String) = rundown.mutableEnv.getAsString(key) ?: "?"
+    logger.info {
+      """
+      |
+      |========== Workforce Scheduling seed summary ==========
+      |  Org:            $org15  @ $baseUrl
+      |  Personas created this run:
+      |    manager     : ${env("managerUserName")}  (userId ${env("caseManagerUserId")})
+      |    case-worker : ${env("caseWorkerUserName")}  (userId ${env("caseWorkerUserId")})
+      |  Data on org (WS-* totals):
+      |    Accounts               : ${count("wfsSeedAccountCount")}
+      |    OperatingHours         : ${count("wfsSeedOperatingHoursCount")}
+      |    ServiceTerritories     : ${count("wfsSeedTerritoryCount")}
+      |    WorkTypes              : ${count("wfsSeedWorkTypeCount")}
+      |    Locations              : ${count("wfsSeedLocationCount")}
+      |    ServiceResources       : ${count("wfsSeedServiceResourceCount")}
+      |    ServiceTerritoryMembers: ${count("wfsSeedTerritoryMemberCount")}
+      |=======================================================
+      """
+        .trimMargin()
+    }
   }
 
   /** (baseUrl, username, password). */

--- a/src/test/kotlin/com/salesforce/revoman/WfsSeedE2ETest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/WfsSeedE2ETest.kt
@@ -1,0 +1,150 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.input.config.Kick
+import com.salesforce.revoman.input.readExternalOrgConfig
+import java.net.URLEncoder
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.charset.StandardCharsets
+import javax.net.ssl.SSLContext
+import javax.net.ssl.TrustManager
+import javax.net.ssl.X509TrustManager
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Seeds Workforce Scheduling base data onto the external org configured in `~/.revoman/config.yaml`,
+ * then asserts the seed landed. A faithful HTTP port of the org-manager post-processor
+ * `WorkforceSchedulingPostProcessor.runBaseSeed()` (git.soma:orgfarm/org-manager).
+ *
+ * Flow:
+ * 1. Read `~/.revoman/config.yaml` (baseUrl/username/password); SKIP the test if absent (this test
+ *    needs a real org — it does not spin up a mock server like the other E2E tests).
+ * 2. SOAP-login as admin in-test to mint {{adminToken}} and read the 15-char org id (the OSS ReVoman
+ *    library has no in-JVM minting — SOAP login is the token source; it is enabled on the org).
+ * 3. Pre-hook: idempotently seed the Shift.Status dyn-enum in local SDB ([WfsShiftStatusSeeder]).
+ * 4. Run the `pm-templates/v3/wfs-seed` V3 collection as ONE [ReVoman.revUp]: auth/ creates the
+ *    manager + case-worker personas and SOAP-logins the manager for {{managerToken}}; fixtures/ seed
+ *    all data as the manager persona; probes/ count the results as admin.
+ * 5. Assert transport (every step 2xx) + the count probes (persona-correct seed actually landed).
+ *
+ * Personas: admin only creates the persona users (and reads the count probes); the manager persona
+ * does all the data seeding; case-worker owns the 30 ServiceResources. Never seeds as admin.
+ */
+class WfsSeedE2ETest {
+
+  private val collection = "pm-templates/v3/wfs-seed"
+  private val soapLoginApiVersion = "64" // v68 rejects SOAP login on this org
+
+  @Test
+  fun `seeds Workforce Scheduling base data and verifies record counts`() {
+    val cfg = readExternalOrgConfig()
+    assumeTrue(
+      cfg["baseUrl"] != null && cfg["username"] != null && cfg["password"] != null,
+      "No external-org creds in ~/.revoman/config.yaml — skipping WFS seed (needs a real org).",
+    )
+    val baseUrl = (cfg["baseUrl"] as String).trimEnd('/')
+    val username = cfg["username"] as String
+    val password = cfg["password"] as String
+
+    // 1. Admin SOAP login → adminToken + org15.
+    val (adminToken, org15) = soapLogin(baseUrl, username, password)
+
+    // 2. Pre-hook: seed Shift.Status dyn-enum in SDB (idempotent; skips if SDB not local).
+    WfsShiftStatusSeeder.seed(org15)
+
+    // 3. Run the whole collection as one revUp, admin token injected; auth/ mints the manager token.
+    val seedPersonaPassword = "Revoman-${org15}-1!"
+    val rundown =
+      ReVoman.revUp(
+        Kick.configure()
+          .templatePath(collection)
+          .dynamicEnvironment("baseUrl", "$baseUrl/")
+          .dynamicEnvironment("adminToken", adminToken)
+          .dynamicEnvironment("seedPersonaPassword", seedPersonaPassword)
+          .dynamicEnvironment(
+            "unifiedPermSets",
+            "'WorkforceSchedulingManager', 'WorkforceSchedulingResource'",
+          )
+          .insecureHttp(true)
+          .haltOnAnyFailure(true)
+          .off()
+      )
+
+    // 4a. Transport: every non-ignored step returned 2xx.
+    assertThat(rundown.firstUnIgnoredUnsuccessfulStepReport).isNull()
+
+    // 4b. Business outcome: the count probes prove the seed actually landed. Assert `>=` the seed's
+    // own set, NOT `==`: this collection is create-only (unlike the idempotent org-manager script), so
+    // re-running against the same org accumulates records (fresh timestamped OH/territory/worktype
+    // names each run). A pristine org yields exactly these numbers; a re-seeded org yields more. The
+    // `>=` contract holds in both cases and still fails loudly if a whole object type didn't seed.
+    fun count(key: String): Int =
+      rundown.mutableEnv.getAsString(key)?.toIntOrNull()
+        ?: error("Probe env var '$key' missing/non-numeric — probe step did not run or capture")
+
+    assertThat(count("wfsSeedAccountCount")).isAtLeast(20)
+    assertThat(count("wfsSeedOperatingHoursCount")).isAtLeast(3)
+    assertThat(count("wfsSeedTerritoryCount")).isAtLeast(3)
+    assertThat(count("wfsSeedWorkTypeCount")).isAtLeast(5)
+    assertThat(count("wfsSeedLocationCount")).isAtLeast(3)
+    // One ServiceResource + one ServiceTerritoryMember per run (persona-model: single case-worker
+    // owns one resource — see the service-resources folder for the (user, type) uniqueness note).
+    assertThat(count("wfsSeedServiceResourceCount")).isAtLeast(1)
+    assertThat(count("wfsSeedTerritoryMemberCount")).isAtLeast(1)
+  }
+
+  /** SOAP-login; returns (sessionId, org15). Pinned to an API version the org allows for SOAP login. */
+  private fun soapLogin(baseUrl: String, username: String, password: String): Pair<String, String> {
+    val envelope =
+      """
+      <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:partner.soap.sforce.com">
+        <soapenv:Body><urn:login><urn:username>$username</urn:username><urn:password>$password</urn:password></urn:login></soapenv:Body>
+      </soapenv:Envelope>
+      """
+        .trimIndent()
+    val resp =
+      insecureHttpClient()
+        .send(
+          HttpRequest.newBuilder()
+            .uri(java.net.URI.create("$baseUrl/services/Soap/u/$soapLoginApiVersion"))
+            .header("Content-Type", "text/xml; charset=UTF-8")
+            .header("SOAPAction", "login")
+            .POST(HttpRequest.BodyPublishers.ofString(envelope))
+            .build(),
+          HttpResponse.BodyHandlers.ofString(),
+        )
+    val body = resp.body()
+    val sessionId =
+      Regex("<sessionId>(.*?)</sessionId>").find(body)?.groupValues?.get(1)
+        ?: error("Admin SOAP login failed: ${body.take(400)}")
+    val orgId =
+      Regex("<organizationId>(.*?)</organizationId>").find(body)?.groupValues?.get(1)
+        ?: error("Admin SOAP login response missing organizationId")
+    return sessionId to orgId.take(15)
+  }
+
+  private fun insecureHttpClient(): HttpClient {
+    val trustAll =
+      arrayOf<TrustManager>(
+        object : X509TrustManager {
+          override fun checkClientTrusted(c: Array<out java.security.cert.X509Certificate>?, a: String?) {}
+          override fun checkServerTrusted(c: Array<out java.security.cert.X509Certificate>?, a: String?) {}
+          override fun getAcceptedIssuers(): Array<java.security.cert.X509Certificate> = arrayOf()
+        }
+      )
+    val ssl = SSLContext.getInstance("TLS").apply { init(null, trustAll, java.security.SecureRandom()) }
+    return HttpClient.newBuilder().sslContext(ssl).build()
+  }
+
+  @Suppress("unused") private fun enc(s: String) = URLEncoder.encode(s, StandardCharsets.UTF_8)
+}

--- a/src/test/kotlin/com/salesforce/revoman/WfsSeedE2ETest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/WfsSeedE2ETest.kt
@@ -10,6 +10,7 @@ package com.salesforce.revoman
 import com.google.common.truth.Truth.assertThat
 import com.salesforce.revoman.input.config.Kick
 import com.salesforce.revoman.input.readExternalOrgConfig
+import com.salesforce.revoman.internal.postman.template.v3.V3EnvLoader
 import java.net.URLEncoder
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
@@ -22,13 +23,14 @@ import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
 
 /**
- * Seeds Workforce Scheduling base data onto the external org configured in `~/.revoman/config.yaml`,
- * then asserts the seed landed. A faithful HTTP port of the org-manager post-processor
- * `WorkforceSchedulingPostProcessor.runBaseSeed()` (git.soma:orgfarm/org-manager).
+ * Seeds Workforce Scheduling base data onto an external org, then asserts the seed landed. A faithful
+ * HTTP port of the org-manager post-processor `WorkforceSchedulingPostProcessor.runBaseSeed()`
+ * (git.soma:orgfarm/org-manager).
  *
  * Flow:
- * 1. Read `~/.revoman/config.yaml` (baseUrl/username/password); SKIP the test if absent (this test
- *    needs a real org — it does not spin up a mock server like the other E2E tests).
+ * 1. Resolve org creds: `ws.environment.yaml` (alongside the collection) FIRST, else fall back to
+ *    `~/.revoman/config.yaml`. SKIP the test if neither yields creds (this test needs a real org — it
+ *    does not spin up a mock server like the other E2E tests).
  * 2. SOAP-login as admin in-test to mint {{adminToken}} and read the 15-char org id (the OSS ReVoman
  *    library has no in-JVM minting — SOAP login is the token source; it is enabled on the org).
  * 3. Pre-hook: idempotently seed the Shift.Status dyn-enum in local SDB ([WfsShiftStatusSeeder]).
@@ -47,14 +49,16 @@ class WfsSeedE2ETest {
 
   @Test
   fun `seeds Workforce Scheduling base data and verifies record counts`() {
-    val cfg = readExternalOrgConfig()
+    // Creds precedence: ws.environment.yaml (alongside this collection) FIRST, then fall back to
+    // ~/.revoman/config.yaml. The env file wins only when its baseUrl/username/password are all
+    // non-blank; otherwise the dotfile supplies them.
+    val cfg = resolveOrgCreds()
     assumeTrue(
-      cfg["baseUrl"] != null && cfg["username"] != null && cfg["password"] != null,
-      "No external-org creds in ~/.revoman/config.yaml — skipping WFS seed (needs a real org).",
+      cfg != null,
+      "No org creds — set baseUrl/username/password in $collection/ws.environment.yaml OR " +
+        "~/.revoman/config.yaml — skipping WFS seed (needs a real org).",
     )
-    val baseUrl = (cfg["baseUrl"] as String).trimEnd('/')
-    val username = cfg["username"] as String
-    val password = cfg["password"] as String
+    val (baseUrl, username, password) = cfg!!
 
     // 1. Admin SOAP login → adminToken + org15.
     val (adminToken, org15) = soapLogin(baseUrl, username, password)
@@ -101,6 +105,26 @@ class WfsSeedE2ETest {
     // owns one resource — see the service-resources folder for the (user, type) uniqueness note).
     assertThat(count("wfsSeedServiceResourceCount")).isAtLeast(1)
     assertThat(count("wfsSeedTerritoryMemberCount")).isAtLeast(1)
+  }
+
+  /** (baseUrl, username, password). */
+  private data class OrgCreds(val baseUrl: String, val username: String, val password: String)
+
+  /**
+   * Resolve org creds: try `ws.environment.yaml` (a `values:` env file on the classpath, alongside
+   * the collection) FIRST, then fall back to `~/.revoman/config.yaml` (flat `key: value`). Returns
+   * null when neither yields all three non-blank fields (→ the test is assumeTrue-skipped).
+   */
+  private fun resolveOrgCreds(): OrgCreds? {
+    fun fromMap(m: Map<String, Any?>): OrgCreds? {
+      val b = (m["baseUrl"] as? String)?.trim().orEmpty().trimEnd('/')
+      val u = (m["username"] as? String)?.trim().orEmpty()
+      val p = (m["password"] as? String)?.trim().orEmpty()
+      return if (b.isNotEmpty() && u.isNotEmpty() && p.isNotEmpty()) OrgCreds(b, u, p) else null
+    }
+    val fromEnvFile =
+      runCatching { fromMap(V3EnvLoader.loadFromPath("$collection/ws.environment.yaml")) }.getOrNull()
+    return fromEnvFile ?: fromMap(readExternalOrgConfig())
   }
 
   /** SOAP-login; returns (sessionId, org15). Pinned to an API version the org allows for SOAP login. */

--- a/src/test/kotlin/com/salesforce/revoman/WfsShiftStatusSeeder.kt
+++ b/src/test/kotlin/com/salesforce/revoman/WfsShiftStatusSeeder.kt
@@ -31,7 +31,21 @@ object WfsShiftStatusSeeder {
   private val logger = KotlinLogging.logger {}
 
   /** SDB connection coordinates derived from the running postgres process. */
-  data class SdbCoords(val port: Int, val db: String, val release: String, val user: String)
+  data class SdbCoords(
+    val port: Int,
+    val db: String,
+    val release: String,
+    val user: String,
+    val password: String,
+  )
+
+  // SDB is version-scoped: a trust-auth connection as the OS process owner is pinned to a schema
+  // VERSION (e.g. "26400") at which the app-managed `cpicklist` schema — the seed function's home — is
+  // NOT visible, so the call fails `schema "cpicklist" does not exist at version "26400"`. The SDB
+  // build superuser `saydb` runs UNVERSIONED and sees `cpicklist`, so we connect as that role (the
+  // same one the reference `seed-dynenum.sh` uses). Overridable per box via env for release drift.
+  private val SDB_USER = System.getenv("REVOMAN_SDB_USER") ?: "saydb"
+  private val SDB_PASSWORD = System.getenv("REVOMAN_SDB_PASSWORD") ?: "sdb"
 
   private const val SHIFT_STATUS_ENUM_ID = "284"
   // Tentative->'0', Published->'1', Confirmed->'2' — ShiftStatusCategory dbValues; Confirmed is the
@@ -44,10 +58,11 @@ object WfsShiftStatusSeeder {
    * Idempotently seed Shift.Status for [org15]. No-op if already seeded (Confirmed->'2' active).
    * BEST-EFFORT / NON-FATAL: any failure (no local SDB, function/schema absent for the release, SQL
    * error) is logged and swallowed — Shift.Status is only needed for later booking, not the base
-   * seed, so it must never fail the seed run. The seed-function's schema is NOT hardcoded: it is
-   * resolved at runtime from pg_proc, because it differs across releases (e.g. `cpicklist` on one
-   * release, absent-at-that-version on another — the source of the "schema cpicklist does not exist"
-   * error).
+   * seed, so it must never fail the seed run. Two release/box-drift guards: the seed-function's schema
+   * is resolved at runtime from pg_proc (not hardcoded — it differs across releases, e.g. `cpicklist`),
+   * and the connection is made as the UNVERSIONED SDB superuser [SDB_USER] rather than the trust-auth
+   * OS owner, whose version-pinned connection can't see `cpicklist` (the `schema "cpicklist" does not
+   * exist at version "…"` error).
    */
   fun seed(org15: String) {
     val coords = discoverLocalSdb()
@@ -64,7 +79,7 @@ object WfsShiftStatusSeeder {
     }
     val url = "jdbc:postgresql://127.0.0.1:${coords.port}/${coords.db}"
     try {
-      DriverManager.getConnection(url, coords.user, "").use { conn ->
+      DriverManager.getConnection(url, coords.user, coords.password).use { conn ->
         if (isAlreadySeeded(conn, org15)) {
           logger.info { "Shift.Status already seeded for $org15 (Confirmed->'2' active) — no-op" }
           return
@@ -141,10 +156,9 @@ object WfsShiftStatusSeeder {
     val dataDir = Regex("""-D\s+(\S+)""").find(line)?.groupValues?.get(1) ?: return null
     val db = File(dataDir).name
     val release = Regex("""sdbbuild/([^/]+)/bin/postgres""").find(line)?.groupValues?.get(1) ?: "unknown"
-    // SDB uses trust auth for the OS user locally; default to the process owner ($USER), which is the
-    // account the workspace runs as.
-    val user = System.getProperty("user.name") ?: System.getenv("USER") ?: "sfwork"
-    return SdbCoords(port, db, release, user)
+    // Connect as the UNVERSIONED SDB superuser (`saydb`), NOT the trust-auth OS process owner: the
+    // latter is version-pinned and can't see the `cpicklist` schema the seed function lives in.
+    return SdbCoords(port, db, release, SDB_USER, SDB_PASSWORD)
   }
 
   private fun readSdbPostgresCmdLine(): String? {

--- a/src/test/kotlin/com/salesforce/revoman/WfsShiftStatusSeeder.kt
+++ b/src/test/kotlin/com/salesforce/revoman/WfsShiftStatusSeeder.kt
@@ -1,0 +1,124 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.io.File
+import java.sql.DriverManager
+
+/**
+ * Seeds the `Shift.Status` dynamic-enum picklist (enum id 284) in the local SDB, so a fresh
+ * Workforce Scheduling org can create the CONFIRMED Shift that slot-gen requires. WFS slot-gen needs
+ * `Shift.Status` mapped to StatusCategory CONFIRMED (grouping_string '2'); on a fresh org the picklist
+ * is empty and a Shift insert fails `FIELD_INTEGRITY_EXCEPTION`.
+ *
+ * This is the ONE piece the HTTP collection cannot do — dynamic-enum values live in SDB, not behind
+ * any REST/Metadata API — so [WfsSeedE2ETest] runs it as a pre-hook via plain JDBC before the
+ * collection.
+ *
+ * Release-agnostic by design: [discoverLocalSdb] derives the port + db name from the RUNNING
+ * `postgres` process command line (`sdbbuild/<release>/bin/postgres -D <datadir> -p <port>`) rather
+ * than hardcoding — port, db name, and release all change per box/build. If no local SDB process is
+ * found (e.g. the org is genuinely remote), seeding is SKIPPED with a warning, not failed, so the
+ * test still runs where SDB is not co-located.
+ */
+object WfsShiftStatusSeeder {
+  private val logger = KotlinLogging.logger {}
+
+  /** SDB connection coordinates derived from the running postgres process. */
+  data class SdbCoords(val port: Int, val db: String, val release: String, val user: String)
+
+  private const val SHIFT_STATUS_ENUM_ID = "284"
+  // Tentative->'0', Published->'1', Confirmed->'2' — ShiftStatusCategory dbValues; Confirmed is the
+  // one slot-gen needs. defaultIdx 2 = Confirmed.
+  private val VALUES = listOf("Tentative", "Published", "Confirmed")
+  private val GROUPINGS = listOf("0", "1", "2")
+  private const val DEFAULT_IDX = 2
+
+  /**
+   * Idempotently seed Shift.Status for [org15]. No-op if already seeded (Confirmed->'2' active).
+   * Skips (logged) when no local SDB is discoverable. Never throws for the "remote org" case; only a
+   * genuine SQL error on an available SDB propagates.
+   */
+  fun seed(org15: String) {
+    val coords = discoverLocalSdb()
+    if (coords == null) {
+      logger.warn {
+        "No local SDB postgres process found — SKIPPING Shift.Status seed. If the org is remote, seed " +
+          "Shift.Status out-of-band; if it's local, ensure the SDB postgres is running."
+      }
+      return
+    }
+    logger.info {
+      "Seeding Shift.Status (enum $SHIFT_STATUS_ENUM_ID) for org $org15 via SDB " +
+        "127.0.0.1:${coords.port}/${coords.db} (release ${coords.release}, user ${coords.user})"
+    }
+    val url = "jdbc:postgresql://127.0.0.1:${coords.port}/${coords.db}"
+    DriverManager.getConnection(url, coords.user, "").use { conn ->
+      if (isAlreadySeeded(conn, org15)) {
+        logger.info { "Shift.Status already seeded for $org15 (Confirmed->'2' active) — no-op" }
+        return
+      }
+      conn.autoCommit = false
+      // Platform seeder: inserts every value active, sort-ordered, with its category mapping, in one
+      // txn — the same path CPicklist.insertDefaultDynEnumsNc uses. A bare UPDATE would miss on a
+      // fresh org where the values don't exist yet.
+      conn.prepareStatement(
+          "SELECT cpicklist.insert_default_dyn_enums_nc(?, ?, ?::saydb.string_array, ?, ?::saydb.string_array)"
+        )
+        .use { ps ->
+          ps.setString(1, org15)
+          ps.setString(2, SHIFT_STATUS_ENUM_ID)
+          ps.setArray(3, conn.createArrayOf("varchar", VALUES.toTypedArray()))
+          ps.setInt(4, DEFAULT_IDX)
+          ps.setArray(5, conn.createArrayOf("varchar", GROUPINGS.toTypedArray()))
+          ps.execute()
+        }
+      conn.commit()
+    }
+    logger.info { "Shift.Status seeded for $org15: ${VALUES.zip(GROUPINGS)}" }
+  }
+
+  private fun isAlreadySeeded(conn: java.sql.Connection, org15: String): Boolean =
+    conn
+      .prepareStatement(
+        "SELECT 1 FROM core.picklist_master WHERE organization_id = ? AND picklist_enum_or_id = ? " +
+          "AND api_name = 'Confirmed' AND grouping_string = '2' AND is_active = 1 LIMIT 1"
+      )
+      .use { ps ->
+        ps.setString(1, org15)
+        ps.setString(2, SHIFT_STATUS_ENUM_ID)
+        ps.executeQuery().use { it.next() }
+      }
+
+  /**
+   * Derive local SDB coordinates from the running postgres process. Returns null when no such
+   * process exists. Parses the process command line for the SDB postgres launched from
+   * `.../sdbbuild/<release>/bin/postgres -D <datadir> -p <port>`; db name = basename(datadir).
+   */
+  fun discoverLocalSdb(): SdbCoords? {
+    val line = runCatching { readSdbPostgresCmdLine() }.getOrNull() ?: return null
+    val port = Regex("""-p\s+(\d+)""").find(line)?.groupValues?.get(1)?.toIntOrNull() ?: return null
+    val dataDir = Regex("""-D\s+(\S+)""").find(line)?.groupValues?.get(1) ?: return null
+    val db = File(dataDir).name
+    val release = Regex("""sdbbuild/([^/]+)/bin/postgres""").find(line)?.groupValues?.get(1) ?: "unknown"
+    // SDB uses trust auth for the OS user locally; default to the process owner ($USER), which is the
+    // account the workspace runs as.
+    val user = System.getProperty("user.name") ?: System.getenv("USER") ?: "sfwork"
+    return SdbCoords(port, db, release, user)
+  }
+
+  private fun readSdbPostgresCmdLine(): String? {
+    val proc = ProcessBuilder("ps", "-eo", "args").redirectErrorStream(true).start()
+    val out = proc.inputStream.bufferedReader().readText()
+    proc.waitFor()
+    return out.lineSequence().firstOrNull {
+      it.contains("sdbbuild/") && it.contains("/bin/postgres") && it.contains("-D ")
+    }
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/WfsShiftStatusSeeder.kt
+++ b/src/test/kotlin/com/salesforce/revoman/WfsShiftStatusSeeder.kt
@@ -42,15 +42,19 @@ object WfsShiftStatusSeeder {
 
   /**
    * Idempotently seed Shift.Status for [org15]. No-op if already seeded (Confirmed->'2' active).
-   * Skips (logged) when no local SDB is discoverable. Never throws for the "remote org" case; only a
-   * genuine SQL error on an available SDB propagates.
+   * BEST-EFFORT / NON-FATAL: any failure (no local SDB, function/schema absent for the release, SQL
+   * error) is logged and swallowed — Shift.Status is only needed for later booking, not the base
+   * seed, so it must never fail the seed run. The seed-function's schema is NOT hardcoded: it is
+   * resolved at runtime from pg_proc, because it differs across releases (e.g. `cpicklist` on one
+   * release, absent-at-that-version on another — the source of the "schema cpicklist does not exist"
+   * error).
    */
   fun seed(org15: String) {
     val coords = discoverLocalSdb()
     if (coords == null) {
       logger.warn {
-        "No local SDB postgres process found — SKIPPING Shift.Status seed. If the org is remote, seed " +
-          "Shift.Status out-of-band; if it's local, ensure the SDB postgres is running."
+        "No local SDB postgres process found — SKIPPING Shift.Status seed (non-fatal). If the org is " +
+          "remote, seed Shift.Status out-of-band; if it's local, ensure the SDB postgres is running."
       }
       return
     }
@@ -59,30 +63,60 @@ object WfsShiftStatusSeeder {
         "127.0.0.1:${coords.port}/${coords.db} (release ${coords.release}, user ${coords.user})"
     }
     val url = "jdbc:postgresql://127.0.0.1:${coords.port}/${coords.db}"
-    DriverManager.getConnection(url, coords.user, "").use { conn ->
-      if (isAlreadySeeded(conn, org15)) {
-        logger.info { "Shift.Status already seeded for $org15 (Confirmed->'2' active) — no-op" }
-        return
-      }
-      conn.autoCommit = false
-      // Platform seeder: inserts every value active, sort-ordered, with its category mapping, in one
-      // txn — the same path CPicklist.insertDefaultDynEnumsNc uses. A bare UPDATE would miss on a
-      // fresh org where the values don't exist yet.
-      conn.prepareStatement(
-          "SELECT cpicklist.insert_default_dyn_enums_nc(?, ?, ?::saydb.string_array, ?, ?::saydb.string_array)"
-        )
-        .use { ps ->
-          ps.setString(1, org15)
-          ps.setString(2, SHIFT_STATUS_ENUM_ID)
-          ps.setArray(3, conn.createArrayOf("varchar", VALUES.toTypedArray()))
-          ps.setInt(4, DEFAULT_IDX)
-          ps.setArray(5, conn.createArrayOf("varchar", GROUPINGS.toTypedArray()))
-          ps.execute()
+    try {
+      DriverManager.getConnection(url, coords.user, "").use { conn ->
+        if (isAlreadySeeded(conn, org15)) {
+          logger.info { "Shift.Status already seeded for $org15 (Confirmed->'2' active) — no-op" }
+          return
         }
-      conn.commit()
+        val schema = resolveSeedFnSchema(conn)
+        if (schema == null) {
+          logger.warn {
+            "Seed function `insert_default_dyn_enums_nc` not found in this SDB (release " +
+              "${coords.release}) — SKIPPING Shift.Status seed (non-fatal). Seed it out-of-band if a " +
+              "booking flow needs a CONFIRMED Shift."
+          }
+          return
+        }
+        conn.autoCommit = false
+        // Platform seeder: inserts every value active, sort-ordered, with its category mapping, in one
+        // txn — the same path CPicklist.insertDefaultDynEnumsNc uses. A bare UPDATE would miss on a
+        // fresh org where the values don't exist yet. Schema is resolved (not hardcoded); the array
+        // domains live in the stable `saydb` schema.
+        conn.prepareStatement(
+            "SELECT \"$schema\".insert_default_dyn_enums_nc(?, ?, ?::saydb.string_array, ?, ?::saydb.string_array)"
+          )
+          .use { ps ->
+            ps.setString(1, org15)
+            ps.setString(2, SHIFT_STATUS_ENUM_ID)
+            ps.setArray(3, conn.createArrayOf("varchar", VALUES.toTypedArray()))
+            ps.setInt(4, DEFAULT_IDX)
+            ps.setArray(5, conn.createArrayOf("varchar", GROUPINGS.toTypedArray()))
+            ps.execute()
+          }
+        conn.commit()
+        logger.info { "Shift.Status seeded for $org15 via schema `$schema`: ${VALUES.zip(GROUPINGS)}" }
+      }
+    } catch (e: Exception) {
+      logger.warn(e) {
+        "Shift.Status seed FAILED (non-fatal) — continuing the base seed without it. Seed it " +
+          "out-of-band if a booking flow needs a CONFIRMED Shift. Cause: ${e.message}"
+      }
     }
-    logger.info { "Shift.Status seeded for $org15: ${VALUES.zip(GROUPINGS)}" }
   }
+
+  /**
+   * Resolve the schema that hosts `insert_default_dyn_enums_nc` in THIS SDB, or null if absent. The
+   * schema is release-specific (do not hardcode it) — this queries pg_proc so it works on any release
+   * that ships the function, and returns null (→ graceful skip) on one that doesn't.
+   */
+  private fun resolveSeedFnSchema(conn: java.sql.Connection): String? =
+    conn
+      .prepareStatement(
+        "SELECT n.nspname FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace " +
+          "WHERE p.proname = 'insert_default_dyn_enums_nc' LIMIT 1"
+      )
+      .use { ps -> ps.executeQuery().use { if (it.next()) it.getString(1) else null } }
 
   private fun isAlreadySeeded(conn: java.sql.Connection, org15: String): Boolean =
     conn

--- a/src/test/resources/pm-templates/v3/wfs-seed/.resources/definition.yaml
+++ b/src/test/resources/pm-templates/v3/wfs-seed/.resources/definition.yaml
@@ -1,0 +1,8 @@
+$kind: collection
+description: >-
+  Root of the Workforce Scheduling base-seed collection (V3). Walked as ONE ReVoman run via
+  templatePath("pm-templates/v3/wfs-seed"); child folders execute in ascending definition `order:`
+  (auth=100 first, then the fixtures/ subtree). Auth is declared per-folder and does NOT inherit
+  down here (auth/ = adminToken, every fixtures/ folder = managerToken). No auth on the root so a
+  missing child auth fails loud rather than silently borrowing admin.
+order: 0

--- a/src/test/resources/pm-templates/v3/wfs-seed/README.md
+++ b/src/test/resources/pm-templates/v3/wfs-seed/README.md
@@ -1,0 +1,120 @@
+# wfs-seed — Workforce Scheduling base-seed runbook
+
+Seeds Workforce Scheduling base data onto a Salesforce Core org over HTTPS, and verifies it.
+Driven by `WfsSeedE2ETest` (`src/test/kotlin/com/salesforce/revoman/WfsSeedE2ETest.kt`), which
+runs this V3 collection via `ReVoman.revUp`. A faithful HTTP port of the org-manager
+post-processor `WorkforceSchedulingPostProcessor.runBaseSeed()`.
+
+## What it creates
+
+As the **manager** persona (admin only bootstraps users + the context sync):
+
+| Folder | Records |
+|--------|---------|
+| `fixtures/operating-hours-territories` | 3 OperatingHours + Mon–Sun 09:00–17:00 TimeSlots, 3 ServiceTerritories, 5 WorkTypes, 10 ServiceTerritoryWorkTypes |
+| `fixtures/accounts-locations` | 20 Accounts, 3 Locations + child Addresses, 20 AssociatedLocations |
+| `fixtures/service-resources` | 1 ServiceResource (owned by the case-worker persona) + 1 Primary ServiceTerritoryMember |
+| `fixtures/context-definition-sync` | Triggers the `UnifiedSchedule__stdctx` context-definition sync (skips if one exists) |
+
+Run order = ascending folder `order:`: `auth` (100) → `fixtures` (1000: OH/territories 100 →
+accounts 200 → resources 300 → context-sync 400) → `probes` (9000).
+
+## Personas
+
+Tokens are minted via **SOAP login** — the OSS ReVoman library has no in-JVM minting.
+
+- **admin** (`{{adminToken}}`) — the test SOAP-logs-in as the config admin and injects the token.
+  Used ONLY by `auth/` (create the persona users) and `context-definition-sync/` (org-level
+  config, not accessible under the manager PSL) and the read-only `probes/`.
+- **manager** (`{{managerToken}}`) — `auth/` creates the user, sets a password, SOAP-logs-in.
+  Seeds all data.
+- **case-worker** — created by `auth/` (with a password); owns the ServiceResource. Does not
+  itself authenticate.
+
+## Prerequisites on a NEW machine
+
+1. **The org.** A Core org reachable over HTTPS (workspace/orgfarm), WFS-provisioned
+   (`WorkforceSchedulingManager` / `WorkforceSchedulingResource` permission sets exist).
+
+2. **`~/.revoman/config.yaml`** — external-org creds the test reads:
+   ```yaml
+   externalOrg:
+     enabled: true
+   baseUrl: https://<org-host>:6101
+   username: <admin-username>
+   password: <admin-password>
+   cleanup:
+     skip: true
+   ```
+   Without it the test is `assumeTrue`-skipped (never fails CI on a machine with no org).
+
+3. **SOAP login ENABLED on the org.** The token source for every persona. If disabled, minting
+   fails; enable it (or provision an org that allows it). SOAP login is pinned to API `v64`
+   in the collection (`v68` rejects SOAP login on some instances).
+
+4. **Local SDB reachable (for the `Shift.Status` pre-hook).** `WfsShiftStatusSeeder` seeds the
+   `Shift.Status` dyn-enum via JDBC. It **auto-derives** the postgres port / db / release from
+   the running `postgres` process (`sdbbuild/<release>/bin/postgres -D <datadir> -p <port>`),
+   so no config is needed — but the SDB must be a local postgres (trust auth, OS user). If SDB
+   is not local, the hook **skips with a warning** (the test still runs; seed just lacks the
+   Shift.Status values, which only matter for later booking, not the base seed).
+
+5. **Build tooling.**
+   - Use the system **`gradle`**, NOT `./gradlew` — the pinned wrapper distribution may be
+     unreachable behind a proxy. (`gradle test --tests '...'`.)
+   - If plugin/dependency resolution can't reach `plugins.gradle.org` / Maven Central directly,
+     add a Gradle init script pointing at your org's mirror (see "Offline / mirrored builds").
+
+6. **WFS PSL seats.** `WorkforceSchedulingPsl` defaults to a small seat count (e.g. 50).
+   Repeated runs create persona users and can exhaust it → `LICENSE_LIMIT_EXCEEDED`. Bump the
+   seat count in SDB or deactivate stale users (see "Troubleshooting").
+
+## Run it
+
+```bash
+cd <revoman-root>
+gradle test --tests 'com.salesforce.revoman.WfsSeedE2ETest' --console=plain
+```
+
+Green looks like:
+```
+Test seeds Workforce Scheduling base data and verifies record counts() PASSED
+```
+
+The test asserts every step returned HTTP 2xx, then asserts the count probes with `>=`
+(the collection is create-only, so re-runs against the same org accumulate records; a pristine
+org yields exactly the seed's set, a re-seeded org yields more).
+
+## Offline / mirrored builds
+
+If `plugins.gradle.org` / `services.gradle.org` are unreachable (common on locked-down boxes),
+create `~/.gradle/init.d/<mirror>.gradle.kts` routing `pluginManagement` + dependency
+resolution to your org's authenticated Maven mirror (which proxies both Maven Central and the
+Gradle plugin portal). This is a machine-local file, never committed.
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---------|-------------|
+| Test SKIPPED | No `~/.revoman/config.yaml` creds. Add them (prereq 2). |
+| `INVALID_OPERATION: SOAP Login not available in API version` | SOAP login pinned version too new; the collection uses `v64`. Ensure SOAP login is enabled on the org (prereq 3). |
+| `LICENSE_LIMIT_EXCEEDED` on create-manager | `WorkforceSchedulingPsl` seats exhausted. In local SDB: `UPDATE core.permission_set_license SET total_licenses=500 WHERE organization_id='<org15>' AND developer_name='WorkforceSchedulingPsl';` — or deactivate stale users. |
+| `INVALID_FIELD: No such column 'Latitude' on Location` | FLS on Location/Address geo. Already handled — the collection omits Location/Address geolocation (manager lacks the `WS_Location_Field_Access` grant). |
+| `DUPLICATE_VALUE: A service resource of this type already exists for this user` | Org enforces unique ServiceResource per `(user, ResourceType)`. The collection seeds exactly one resource for the case-worker persona. |
+| `Shift.Status` hook skipped | No local postgres found. Fine for the base seed; only needed if you later create a CONFIRMED Shift for booking. |
+| `gradle` "plugin not found" / wrapper SSL error | Use system `gradle`, add the mirror init script (see above). |
+
+## Prompt for a new machine
+
+Paste this to the agent on a fresh machine (fill in the org):
+
+> Seed Workforce Scheduling base data on this org and verify it by running `WfsSeedE2ETest` in
+> the ReVoman repo (`salesforce-misc/ReVoman`).
+> Org: baseUrl `https://<org-host>:6101`, admin `<username>` / `<password>`.
+> Steps: (1) ensure `~/.revoman/config.yaml` has `externalOrg.enabled: true` + those creds
+> (`cleanup.skip: true`); (2) confirm SOAP login is enabled on the org; (3) run
+> `gradle test --tests 'com.salesforce.revoman.WfsSeedE2ETest'` (use system `gradle`, NOT
+> `./gradlew`); (4) if the build can't reach the Gradle plugin portal, add a nexus-mirror init
+> script under `~/.gradle/init.d/`; (5) if `LICENSE_LIMIT_EXCEEDED`, bump `WorkforceSchedulingPsl`
+> seats in local SDB. See `src/test/resources/pm-templates/v3/wfs-seed/README.md` for the full
+> runbook.

--- a/src/test/resources/pm-templates/v3/wfs-seed/README.md
+++ b/src/test/resources/pm-templates/v3/wfs-seed/README.md
@@ -36,17 +36,20 @@ Tokens are minted via **SOAP login** — the OSS ReVoman library has no in-JVM m
 1. **The org.** A Core org reachable over HTTPS (workspace/orgfarm), WFS-provisioned
    (`WorkforceSchedulingManager` / `WorkforceSchedulingResource` permission sets exist).
 
-2. **`~/.revoman/config.yaml`** — external-org creds the test reads:
-   ```yaml
-   externalOrg:
-     enabled: true
-   baseUrl: https://<org-host>:6101
-   username: <admin-username>
-   password: <admin-password>
-   cleanup:
-     skip: true
-   ```
-   Without it the test is `assumeTrue`-skipped (never fails CI on a machine with no org).
+2. **Org creds** — resolved in this precedence:
+   1. **`ws.environment.yaml`** (in this collection dir) — fill `baseUrl` / `username` / `password`.
+      Used when all three are non-blank.
+   2. **`~/.revoman/config.yaml`** — fallback when the env file's creds are blank:
+      ```yaml
+      externalOrg:
+        enabled: true
+      baseUrl: https://<org-host>:6101
+      username: <admin-username>
+      password: <admin-password>
+      cleanup:
+        skip: true
+      ```
+   Without creds in either, the test is `assumeTrue`-skipped (never fails CI on a machine with no org).
 
 3. **SOAP login ENABLED on the org.** The token source for every persona. If disabled, minting
    fails; enable it (or provision an org that allows it). SOAP login is pinned to API `v64`
@@ -101,7 +104,8 @@ Gradle plugin portal). This is a machine-local file, never committed.
 | `LICENSE_LIMIT_EXCEEDED` on create-manager | `WorkforceSchedulingPsl` seats exhausted. In local SDB: `UPDATE core.permission_set_license SET total_licenses=500 WHERE organization_id='<org15>' AND developer_name='WorkforceSchedulingPsl';` — or deactivate stale users. |
 | `INVALID_FIELD: No such column 'Latitude' on Location` | FLS on Location/Address geo. Already handled — the collection omits Location/Address geolocation (manager lacks the `WS_Location_Field_Access` grant). |
 | `DUPLICATE_VALUE: A service resource of this type already exists for this user` | Org enforces unique ServiceResource per `(user, ResourceType)`. The collection seeds exactly one resource for the case-worker persona. |
-| `Shift.Status` hook skipped | No local postgres found. Fine for the base seed; only needed if you later create a CONFIRMED Shift for booking. |
+| `Shift.Status` hook skipped | No local postgres found, OR the seed function isn't in this release's SDB. Fine for the base seed; only needed if you later create a CONFIRMED Shift for booking. |
+| `ERROR: schema "cpicklist" does not exist` (or similar) during the SDB hook | Old hardcoded-schema bug — fixed: the hook now resolves the `insert_default_dyn_enums_nc` schema at runtime from `pg_proc` and is non-fatal (logs + continues). Pull the latest. |
 | `gradle` "plugin not found" / wrapper SSL error | Use system `gradle`, add the mirror init script (see above). |
 
 ## Prompt for a new machine

--- a/src/test/resources/pm-templates/v3/wfs-seed/auth/.resources/definition.yaml
+++ b/src/test/resources/pm-templates/v3/wfs-seed/auth/.resources/definition.yaml
@@ -1,0 +1,18 @@
+$kind: collection
+description: >-
+  Persona bootstrap for the WFS base-seed set (OSS ReVoman - tokens minted via SOAP login, since the
+  library has no in-JVM minting). SOAP-logs-in as System Admin ({{adminToken}} - the ONLY folder that
+  runs as admin, and ONLY to CREATE the persona users), resolves the API version path, looks up the
+  Standard User profile + WorkforceScheduling Manager/Resource permission-set ids, creates the
+  `manager` (WorkforceSchedulingManager) and `case-worker` (WorkforceSchedulingResource) Users with a
+  known password, then SOAP-logs-in as the manager to mint {{managerToken}}. Produces versionPath /
+  apiVersion / standardUserProfileId / unifiedPSManagerId / unifiedPSResourceId / managerUserName /
+  caseWorkerUserName / caseManagerUserId / caseWorkerUserId / managerToken. Every fixtures/ folder runs
+  as {{managerToken}}, never admin. caseWorker does NOT authenticate - it only owns the ServiceResources.
+order: 100
+auth:
+  - id: 1d4f7a92-3b6c-4e80-9a15-2c7e9f0b8d31
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/test/resources/pm-templates/v3/wfs-seed/auth/create-case-worker.request.yaml
+++ b/src/test/resources/pm-templates/v3/wfs-seed/auth/create-case-worker.request.yaml
@@ -1,0 +1,57 @@
+$kind: http-request
+description: >-
+  Create the `case-worker` persona User + assign WorkforceSchedulingResource in one composite/graph
+  (admin SID required for User creation). Produces {{caseWorkerUserId}} - the RelatedRecordId every
+  seeded ServiceResource links to (persona-model). Username timestamped for idempotent re-runs.
+url: "{{baseUrl}}{{versionPath}}/composite/graph"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: json
+  content: |-
+    {
+      "graphs": [
+        {
+          "graphId": "1",
+          "compositeRequest": [
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/User",
+              "referenceId": "refUser",
+              "body": {
+                "Username": "{{caseWorkerUserName}}",
+                "ProfileId": "{{standardUserProfileId}}",
+                "Alias": "marcus",
+                "Email": "{{caseWorkerUserName}}",
+                "EmailEncodingKey": "ISO-8859-1",
+                "LastName": "Brown",
+                "FirstName": "Marcus",
+                "LanguageLocaleKey": "en_US",
+                "LocaleSidKey": "en_US",
+                "TimeZoneSidKey": "America/Los_Angeles"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/PermissionSetAssignment/",
+              "referenceId": "unifiedPS1Assignemnt",
+              "body": {
+                "AssigneeId": "@{refUser.id}",
+                "PermissionSetId": "{{unifiedPSResourceId}}"
+              }
+            }
+          ]
+        }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: pm.environment.set("caseWorkerUserName", pm.variables.replaceIn("case-worker-{{$timestamp}}-{{$guid}}@revoman.org"));
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      var jsonData = pm.response.json()
+      pm.environment.set("caseWorkerUserId", jsonData.graphs[0].graphResponse.compositeResponse[0].body.id);
+    language: text/javascript
+order: 15000

--- a/src/test/resources/pm-templates/v3/wfs-seed/auth/create-manager.request.yaml
+++ b/src/test/resources/pm-templates/v3/wfs-seed/auth/create-manager.request.yaml
@@ -1,0 +1,58 @@
+$kind: http-request
+description: >-
+  Create the `manager` persona User + assign WorkforceSchedulingManager in one composite/graph (admin
+  SID required for User creation). Produces {{caseManagerUserId}} (the manager's User id), consumed by
+  set-manager-password; the manager SID is then minted by the soap-login-manager step into
+  {{managerToken}} and used by every fixtures/ folder. Username timestamped for unique re-runs.
+url: "{{baseUrl}}{{versionPath}}/composite/graph"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: json
+  content: |-
+    {
+      "graphs": [
+        {
+          "graphId": "1",
+          "compositeRequest": [
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/User",
+              "referenceId": "refUser",
+              "body": {
+                "Username": "{{managerUserName}}",
+                "ProfileId": "{{standardUserProfileId}}",
+                "Alias": "sarah",
+                "Email": "{{managerUserName}}",
+                "EmailEncodingKey": "ISO-8859-1",
+                "LastName": "Smith",
+                "FirstName": "Sarah",
+                "LanguageLocaleKey": "en_US",
+                "LocaleSidKey": "en_US",
+                "TimeZoneSidKey": "America/Los_Angeles"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/PermissionSetAssignment/",
+              "referenceId": "unifiedPS1Assignemnt",
+              "body": {
+                "AssigneeId": "@{refUser.id}",
+                "PermissionSetId": "{{unifiedPSManagerId}}"
+              }
+            }
+          ]
+        }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: pm.environment.set("managerUserName", pm.variables.replaceIn("manager-{{$timestamp}}-{{$guid}}@revoman.org"));
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      var jsonData = pm.response.json()
+      pm.environment.set("caseManagerUserId", jsonData.graphs[0].graphResponse.compositeResponse[0].body.id);
+    language: text/javascript
+order: 17000

--- a/src/test/resources/pm-templates/v3/wfs-seed/auth/latest-api-version.request.yaml
+++ b/src/test/resources/pm-templates/v3/wfs-seed/auth/latest-api-version.request.yaml
@@ -1,0 +1,19 @@
+$kind: http-request
+description: Resolve the org's latest API version -> versionPath / apiVersion env vars used by every downstream step.
+url: "{{baseUrl}}/services/data/"
+method: GET
+headers:
+  Content-Type: application/json
+body:
+  type: text
+  content: ""
+scripts:
+  - type: afterResponse
+    code: |-
+      var jsonData = pm.response.json();
+      var lastNode = jsonData.pop();
+      pm.environment.set("version", lastNode.version);
+      pm.environment.set("apiVersion", "v" + lastNode.version);
+      pm.environment.set("versionPath", lastNode.url);
+    language: text/javascript
+order: 1000

--- a/src/test/resources/pm-templates/v3/wfs-seed/auth/set-case-worker-password.request.yaml
+++ b/src/test/resources/pm-templates/v3/wfs-seed/auth/set-case-worker-password.request.yaml
@@ -1,0 +1,17 @@
+$kind: http-request
+description: >-
+  Set a known password on the `case-worker` User via the passwordUtilities subresource, so the persona
+  can later authenticate. Runs as {{adminToken}} (admin can set any user's password). caseWorker does
+  not itself SOAP-login in this collection (it only owns the ServiceResources), but the password is set
+  for parity / manual use. Password comes from {{seedPersonaPassword}} injected by the Java test.
+url: "{{baseUrl}}{{versionPath}}/sobjects/User/{{caseWorkerUserId}}/password"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: json
+  content: |-
+    {
+      "NewPassword": "{{seedPersonaPassword}}"
+    }
+order: 16000

--- a/src/test/resources/pm-templates/v3/wfs-seed/auth/set-manager-password.request.yaml
+++ b/src/test/resources/pm-templates/v3/wfs-seed/auth/set-manager-password.request.yaml
@@ -1,0 +1,16 @@
+$kind: http-request
+description: >-
+  Set a known password on the `manager` User via the passwordUtilities subresource, so the next step
+  can SOAP-login as the manager to mint {{managerToken}}. Runs as {{adminToken}}. Password comes from
+  {{seedPersonaPassword}} injected by the Java test.
+url: "{{baseUrl}}{{versionPath}}/sobjects/User/{{caseManagerUserId}}/password"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: json
+  content: |-
+    {
+      "NewPassword": "{{seedPersonaPassword}}"
+    }
+order: 18000

--- a/src/test/resources/pm-templates/v3/wfs-seed/auth/soap-login-manager.request.yaml
+++ b/src/test/resources/pm-templates/v3/wfs-seed/auth/soap-login-manager.request.yaml
@@ -1,0 +1,34 @@
+$kind: http-request
+description: >-
+  SOAP-login as the `manager` persona to mint {{managerToken}} (the OSS ReVoman lib has no in-JVM
+  minting; SOAP login is enabled on this org). Uses {{managerUserName}} / {{seedPersonaPassword}} set
+  by the create-manager + set-manager-password steps. Parses <sessionId> from the SOAP XML response
+  into managerToken, consumed by every fixtures/ folder. Pinned to Soap/u/64 (v68 rejects SOAP login).
+url: "{{baseUrl}}/services/Soap/u/64"
+method: POST
+headers:
+  Content-Type: text/xml; charset=UTF-8
+  SOAPAction: login
+body:
+  type: text
+  content: |-
+    <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:partner.soap.sforce.com">
+      <soapenv:Body>
+        <urn:login>
+          <urn:username>{{managerUserName}}</urn:username>
+          <urn:password>{{seedPersonaPassword}}</urn:password>
+        </urn:login>
+      </soapenv:Body>
+    </soapenv:Envelope>
+scripts:
+  - type: afterResponse
+    code: |-
+      var xml = pm.response.text();
+      var m = xml.match(/<sessionId>([^<]*)<\/sessionId>/);
+      if (!m) {
+        var fault = xml.match(/<faultstring>([^<]*)<\/faultstring>/);
+        throw new Error("Manager SOAP login failed: " + (fault ? fault[1] : xml.substring(0, 300)));
+      }
+      pm.environment.set("managerToken", m[1]);
+    language: text/javascript
+order: 19000

--- a/src/test/resources/pm-templates/v3/wfs-seed/auth/standard-user-profile.request.yaml
+++ b/src/test/resources/pm-templates/v3/wfs-seed/auth/standard-user-profile.request.yaml
@@ -1,0 +1,18 @@
+$kind: http-request
+description: Look up the Standard User profile id -> standardUserProfileId, used to create both persona users.
+url: "{{baseUrl}}{{versionPath}}/query/?q=SELECT Id FROM Profile WHERE Name = 'Standard User'"
+method: GET
+headers:
+  Content-Type: application/json
+queryParams:
+  q: SELECT Id FROM Profile WHERE Name = 'Standard User'
+body:
+  type: text
+  content: ""
+scripts:
+  - type: afterResponse
+    code: |-
+      var jsonData = pm.response.json();
+      pm.environment.set("standardUserProfileId", jsonData.records[0].Id);
+    language: text/javascript
+order: 3000

--- a/src/test/resources/pm-templates/v3/wfs-seed/auth/wfs-perm-sets.request.yaml
+++ b/src/test/resources/pm-templates/v3/wfs-seed/auth/wfs-perm-sets.request.yaml
@@ -1,0 +1,27 @@
+$kind: http-request
+description: >-
+  Look up the WorkforceSchedulingManager and WorkforceSchedulingResource permission-set ids by NAME
+  (not array index - SOQL WHERE Name IN (...) does not guarantee row order) -> unifiedPSManagerId /
+  unifiedPSResourceId, consumed by the create-manager / create-case-worker persona steps.
+url: "{{baseUrl}}{{versionPath}}/query/?q=SELECT Id, Name FROM PermissionSet WHERE Name IN ({{unifiedPermSets}})"
+method: GET
+headers:
+  Content-Type: application/json
+queryParams:
+  q: SELECT Id, Name FROM PermissionSet WHERE Name IN ({{unifiedPermSets}})
+body:
+  type: text
+  content: ""
+scripts:
+  - type: afterResponse
+    code: |-
+      var jsonData = pm.response.json();
+      var byName = {};
+      jsonData.records.forEach(function (r) { byName[r.Name] = r.Id; });
+      pm.environment.set("unifiedPSManagerId", byName["WorkforceSchedulingManager"]);
+      pm.environment.set("unifiedPSResourceId", byName["WorkforceSchedulingResource"]);
+    language: text/javascript
+  - type: beforeRequest
+    code: pm.environment.set("unifiedPermSets", "'WorkforceSchedulingManager', 'WorkforceSchedulingResource'")
+    language: text/javascript
+order: 4000

--- a/src/test/resources/pm-templates/v3/wfs-seed/fixtures/.resources/definition.yaml
+++ b/src/test/resources/pm-templates/v3/wfs-seed/fixtures/.resources/definition.yaml
@@ -1,0 +1,7 @@
+$kind: collection
+description: >-
+  Container for the manager-persona seed graphs. Has NO auth of its own; each child folder declares
+  its own `auth: bearer {{managerToken}}`. Ordered after auth/ (order 1000 > auth's 100). Children run
+  in ascending order: operating-hours-territories (100) -> accounts-locations (200) ->
+  service-resources (300) -> context-definition-sync (400).
+order: 1000

--- a/src/test/resources/pm-templates/v3/wfs-seed/fixtures/accounts-locations/.resources/definition.yaml
+++ b/src/test/resources/pm-templates/v3/wfs-seed/fixtures/accounts-locations/.resources/definition.yaml
@@ -1,0 +1,10 @@
+$kind: collection
+description: >-
+  Customer + location graph, run as the `manager` persona ({{managerToken}}). One composite/graph builds the 20 WS Customer Accounts, one Location + child Address per territory (3 each), and 20 AssociatedLocations linking each Account round-robin to a territory Location (Type=Primary). Location/Address geolocation (Latitude/Longitude) and Location.VisitorAddressId are intentionally NOT set: they are FLS-gated on Location/Address and the manager persona lacks the WS_Location_Field_Access grant (org-manager assigns it to admin). Address stays linked via ParentId; the ServiceTerritory carries the scheduling geo. Depends on nothing; safe to run after the foundation folder.
+order: 200
+auth:
+  - id: 3f2c9b8a-0d4e-4a1b-9c6f-7e2d1a5b3c8d
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{managerToken}}"

--- a/src/test/resources/pm-templates/v3/wfs-seed/fixtures/accounts-locations/create-accounts-locations-graph.request.yaml
+++ b/src/test/resources/pm-templates/v3/wfs-seed/fixtures/accounts-locations/create-accounts-locations-graph.request.yaml
@@ -1,0 +1,503 @@
+$kind: http-request
+description: >-
+  Build 20 Accounts, 3 Locations + child Addresses, and 20 round-robin AssociatedLocations (Type=Primary) in one composite/graph as {{managerToken}}. Location/Address geolocation (Latitude/Longitude) and Location.VisitorAddressId are omitted: all FLS-gated on Location/Address and the manager persona lacks the WS_Location_Field_Access grant (the org-manager script assigns it to admin). The Address stays linked via ParentId; the ServiceTerritory (created in the operating-hours-territories folder, geocoded there) is the real scheduling geo anchor, so the Location/Address geo is not needed for slot-gen.
+url: "{{baseUrl}}{{versionPath}}/composite/graph"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: json
+  content: |-
+    {
+      "graphs": [
+        {
+          "graphId": "wfsSeedAccountsLocations",
+          "compositeRequest": [
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAcct0",
+              "body": {
+                "Name": "WS Customer Acme Corp",
+                "Industry": "Technology",
+                "Phone": "+1-415-555-0000"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAcct1",
+              "body": {
+                "Name": "WS Customer Globex",
+                "Industry": "Manufacturing",
+                "Phone": "+1-416-555-0001"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAcct2",
+              "body": {
+                "Name": "WS Customer Initech",
+                "Industry": "Healthcare",
+                "Phone": "+1-417-555-0002"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAcct3",
+              "body": {
+                "Name": "WS Customer Hooli",
+                "Industry": "Retail",
+                "Phone": "+1-418-555-0003"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAcct4",
+              "body": {
+                "Name": "WS Customer Massive Dynamic",
+                "Industry": "Finance",
+                "Phone": "+1-419-555-0004"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAcct5",
+              "body": {
+                "Name": "WS Customer Stark Industries",
+                "Industry": "Construction",
+                "Phone": "+1-420-555-0005"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAcct6",
+              "body": {
+                "Name": "WS Customer Wayne Enterprises",
+                "Industry": "Transportation",
+                "Phone": "+1-421-555-0006"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAcct7",
+              "body": {
+                "Name": "WS Customer Umbrella Corp",
+                "Industry": "Hospitality",
+                "Phone": "+1-422-555-0007"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAcct8",
+              "body": {
+                "Name": "WS Customer Cyberdyne",
+                "Industry": "Education",
+                "Phone": "+1-423-555-0008"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAcct9",
+              "body": {
+                "Name": "WS Customer Soylent",
+                "Industry": "Energy",
+                "Phone": "+1-424-555-0009"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAcct10",
+              "body": {
+                "Name": "WS Customer Wonka Industries",
+                "Industry": "Technology",
+                "Phone": "+1-425-555-0010"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAcct11",
+              "body": {
+                "Name": "WS Customer Tyrell Corp",
+                "Industry": "Manufacturing",
+                "Phone": "+1-426-555-0011"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAcct12",
+              "body": {
+                "Name": "WS Customer Oscorp",
+                "Industry": "Healthcare",
+                "Phone": "+1-427-555-0012"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAcct13",
+              "body": {
+                "Name": "WS Customer LexCorp",
+                "Industry": "Retail",
+                "Phone": "+1-428-555-0013"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAcct14",
+              "body": {
+                "Name": "WS Customer Aperture",
+                "Industry": "Finance",
+                "Phone": "+1-429-555-0014"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAcct15",
+              "body": {
+                "Name": "WS Customer Weyland-Yutani",
+                "Industry": "Construction",
+                "Phone": "+1-430-555-0015"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAcct16",
+              "body": {
+                "Name": "WS Customer Bluth Company",
+                "Industry": "Transportation",
+                "Phone": "+1-431-555-0016"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAcct17",
+              "body": {
+                "Name": "WS Customer Dunder Mifflin",
+                "Industry": "Hospitality",
+                "Phone": "+1-432-555-0017"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAcct18",
+              "body": {
+                "Name": "WS Customer Sterling Cooper",
+                "Industry": "Education",
+                "Phone": "+1-433-555-0018"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAcct19",
+              "body": {
+                "Name": "WS Customer Pied Piper",
+                "Industry": "Energy",
+                "Phone": "+1-434-555-0019"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Location",
+              "referenceId": "refLocSf",
+              "body": {
+                "Name": "WS San Francisco Territory Location {{$timestamp}}",
+                "LocationType": "Building"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Address",
+              "referenceId": "refAddrSf",
+              "body": {
+                "ParentId": "@{refLocSf.id}",
+                "LocationType": "Building",
+                "AddressType": "Shipping",
+                "Street": "415 Mission St",
+                "City": "San Francisco",
+                "State": "CA",
+                "PostalCode": "94105",
+                "Country": "US"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Location",
+              "referenceId": "refLocNy",
+              "body": {
+                "Name": "WS New York Territory Location {{$timestamp}}",
+                "LocationType": "Building"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Address",
+              "referenceId": "refAddrNy",
+              "body": {
+                "ParentId": "@{refLocNy.id}",
+                "LocationType": "Building",
+                "AddressType": "Shipping",
+                "Street": "200 Park Ave",
+                "City": "New York",
+                "State": "NY",
+                "PostalCode": "10166",
+                "Country": "US"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Location",
+              "referenceId": "refLocChi",
+              "body": {
+                "Name": "WS Chicago Territory Location {{$timestamp}}",
+                "LocationType": "Building"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Address",
+              "referenceId": "refAddrChi",
+              "body": {
+                "ParentId": "@{refLocChi.id}",
+                "LocationType": "Building",
+                "AddressType": "Shipping",
+                "Street": "233 S Wacker Dr",
+                "City": "Chicago",
+                "State": "IL",
+                "PostalCode": "60606",
+                "Country": "US"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/AssociatedLocation",
+              "referenceId": "refAssoc0",
+              "body": {
+                "ParentRecordId": "@{refAcct0.id}",
+                "LocationId": "@{refLocSf.id}",
+                "Type": "Primary"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/AssociatedLocation",
+              "referenceId": "refAssoc1",
+              "body": {
+                "ParentRecordId": "@{refAcct1.id}",
+                "LocationId": "@{refLocNy.id}",
+                "Type": "Primary"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/AssociatedLocation",
+              "referenceId": "refAssoc2",
+              "body": {
+                "ParentRecordId": "@{refAcct2.id}",
+                "LocationId": "@{refLocChi.id}",
+                "Type": "Primary"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/AssociatedLocation",
+              "referenceId": "refAssoc3",
+              "body": {
+                "ParentRecordId": "@{refAcct3.id}",
+                "LocationId": "@{refLocSf.id}",
+                "Type": "Primary"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/AssociatedLocation",
+              "referenceId": "refAssoc4",
+              "body": {
+                "ParentRecordId": "@{refAcct4.id}",
+                "LocationId": "@{refLocNy.id}",
+                "Type": "Primary"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/AssociatedLocation",
+              "referenceId": "refAssoc5",
+              "body": {
+                "ParentRecordId": "@{refAcct5.id}",
+                "LocationId": "@{refLocChi.id}",
+                "Type": "Primary"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/AssociatedLocation",
+              "referenceId": "refAssoc6",
+              "body": {
+                "ParentRecordId": "@{refAcct6.id}",
+                "LocationId": "@{refLocSf.id}",
+                "Type": "Primary"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/AssociatedLocation",
+              "referenceId": "refAssoc7",
+              "body": {
+                "ParentRecordId": "@{refAcct7.id}",
+                "LocationId": "@{refLocNy.id}",
+                "Type": "Primary"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/AssociatedLocation",
+              "referenceId": "refAssoc8",
+              "body": {
+                "ParentRecordId": "@{refAcct8.id}",
+                "LocationId": "@{refLocChi.id}",
+                "Type": "Primary"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/AssociatedLocation",
+              "referenceId": "refAssoc9",
+              "body": {
+                "ParentRecordId": "@{refAcct9.id}",
+                "LocationId": "@{refLocSf.id}",
+                "Type": "Primary"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/AssociatedLocation",
+              "referenceId": "refAssoc10",
+              "body": {
+                "ParentRecordId": "@{refAcct10.id}",
+                "LocationId": "@{refLocNy.id}",
+                "Type": "Primary"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/AssociatedLocation",
+              "referenceId": "refAssoc11",
+              "body": {
+                "ParentRecordId": "@{refAcct11.id}",
+                "LocationId": "@{refLocChi.id}",
+                "Type": "Primary"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/AssociatedLocation",
+              "referenceId": "refAssoc12",
+              "body": {
+                "ParentRecordId": "@{refAcct12.id}",
+                "LocationId": "@{refLocSf.id}",
+                "Type": "Primary"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/AssociatedLocation",
+              "referenceId": "refAssoc13",
+              "body": {
+                "ParentRecordId": "@{refAcct13.id}",
+                "LocationId": "@{refLocNy.id}",
+                "Type": "Primary"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/AssociatedLocation",
+              "referenceId": "refAssoc14",
+              "body": {
+                "ParentRecordId": "@{refAcct14.id}",
+                "LocationId": "@{refLocChi.id}",
+                "Type": "Primary"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/AssociatedLocation",
+              "referenceId": "refAssoc15",
+              "body": {
+                "ParentRecordId": "@{refAcct15.id}",
+                "LocationId": "@{refLocSf.id}",
+                "Type": "Primary"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/AssociatedLocation",
+              "referenceId": "refAssoc16",
+              "body": {
+                "ParentRecordId": "@{refAcct16.id}",
+                "LocationId": "@{refLocNy.id}",
+                "Type": "Primary"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/AssociatedLocation",
+              "referenceId": "refAssoc17",
+              "body": {
+                "ParentRecordId": "@{refAcct17.id}",
+                "LocationId": "@{refLocChi.id}",
+                "Type": "Primary"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/AssociatedLocation",
+              "referenceId": "refAssoc18",
+              "body": {
+                "ParentRecordId": "@{refAcct18.id}",
+                "LocationId": "@{refLocSf.id}",
+                "Type": "Primary"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/AssociatedLocation",
+              "referenceId": "refAssoc19",
+              "body": {
+                "ParentRecordId": "@{refAcct19.id}",
+                "LocationId": "@{refLocNy.id}",
+                "Type": "Primary"
+              }
+            }
+          ]
+        }
+      ]
+    }
+scripts:
+  - type: afterResponse
+    code: |-
+      const jsonData = pm.response.json();
+      const responses = jsonData.graphs[0].graphResponse.compositeResponse;
+      responses.forEach((r) => {
+        if (r.httpStatusCode < 200 || r.httpStatusCode >= 300) {
+          throw new Error("Composite step " + r.referenceId + " failed: " + JSON.stringify(r.body));
+        }
+      });
+    language: text/javascript
+order: 500

--- a/src/test/resources/pm-templates/v3/wfs-seed/fixtures/context-definition-sync/.resources/definition.yaml
+++ b/src/test/resources/pm-templates/v3/wfs-seed/fixtures/context-definition-sync/.resources/definition.yaml
@@ -1,0 +1,18 @@
+$kind: collection
+description: >-
+  Trigger the standard UnifiedSchedule__stdctx context-definition sync (the 'Map Object Data with
+  Service Appointments' Salesforce Go step). Skips if a sync record already exists (succeeded,
+  in-progress, or failed - re-triggering does not help). Mirrors
+  WorkforceSchedulingPostProcessor.configureUnifiedSchedulingContext.
+  AUTH EXCEPTION: runs as {{adminToken}}, NOT the manager persona. This is an org-level configuration
+  trigger (not persona-scoped data seeding), and the ContextDefinitionSync SObject is not accessible
+  under the WorkforceSchedulingManager permission set (query returns INVALID_TYPE as the manager) - it
+  requires admin. Like the org-manager post-processor, this is an admin-only setup action, so admin is
+  the correct persona here (the only fixtures/ folder that is not manager).
+order: 400
+auth:
+  - id: 5b2c4d9e-8f3a-4a7b-9d6c-1e5f9a2b4c8e
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/test/resources/pm-templates/v3/wfs-seed/fixtures/context-definition-sync/10-check-existing-context-sync.request.yaml
+++ b/src/test/resources/pm-templates/v3/wfs-seed/fixtures/context-definition-sync/10-check-existing-context-sync.request.yaml
@@ -1,0 +1,21 @@
+$kind: http-request
+description: >-
+  Check whether a ContextDefinitionSync for UnifiedSchedule__stdctx already exists (any status). Sets
+  wfsSeedContextSyncExists so the create step can skip - re-triggering a failed/in-progress sync does
+  not help; an admin must manually retry.
+url: "{{baseUrl}}{{versionPath}}/query/?q=SELECT Id, Status FROM ContextDefinitionSync WHERE ContextDefinitionName = 'UnifiedSchedule__stdctx' ORDER BY CreatedDate DESC LIMIT 1"
+method: GET
+headers:
+  Content-Type: application/json
+queryParams:
+  q: SELECT Id, Status FROM ContextDefinitionSync WHERE ContextDefinitionName = 'UnifiedSchedule__stdctx' ORDER BY CreatedDate DESC LIMIT 1
+body:
+  type: text
+  content: ""
+scripts:
+  - type: afterResponse
+    code: |-
+      var jsonData = pm.response.json();
+      pm.environment.set("wfsSeedContextSyncExists", (jsonData.records && jsonData.records.length > 0) ? "true" : "false");
+    language: text/javascript
+order: 1000

--- a/src/test/resources/pm-templates/v3/wfs-seed/fixtures/context-definition-sync/20-trigger-context-sync.request.yaml
+++ b/src/test/resources/pm-templates/v3/wfs-seed/fixtures/context-definition-sync/20-trigger-context-sync.request.yaml
@@ -1,0 +1,30 @@
+$kind: http-request
+description: >-
+  Trigger the UnifiedSchedule__stdctx context-definition sync by inserting a ContextDefinitionSync
+  (Status=in_progress). Guarded by wfsSeedContextSyncExists from the check step - if a sync already
+  exists this request is skipped via pm.execution.skipRequest() (a successful no-op, NOT a failure)
+  rather than creating a duplicate; re-triggering an existing sync does not help.
+url: "{{baseUrl}}{{versionPath}}/sobjects/ContextDefinitionSync"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: json
+  content: |-
+    {
+      "ContextDefinitionName": "UnifiedSchedule__stdctx",
+      "Status": "in_progress",
+      "StartDateTime": "{{wfsSeedContextSyncStart}}",
+      "SynchronizationInformation": "Triggered by Workforce Scheduling seed collection"
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      if (pm.environment.get("wfsSeedContextSyncExists") === "true") {
+        // Already synced — skip the insert as a successful no-op (not a failure).
+        pm.execution.skipRequest();
+      } else {
+        pm.environment.set("wfsSeedContextSyncStart", new Date().toISOString());
+      }
+    language: text/javascript
+order: 2000

--- a/src/test/resources/pm-templates/v3/wfs-seed/fixtures/operating-hours-territories/.resources/definition.yaml
+++ b/src/test/resources/pm-templates/v3/wfs-seed/fixtures/operating-hours-territories/.resources/definition.yaml
@@ -1,0 +1,10 @@
+$kind: collection
+description: >-
+  Base-seed foundation graph, run as the `manager` persona ({{managerToken}} - NOT admin). One composite/graph builds the 3 OperatingHours (SF/NY/Chicago) each with Mon-Sun 09:00-17:00 TimeSlots, the 3 ServiceTerritories (geocoded, active), the 5 WorkTypes, and the 10 ServiceTerritoryWorkType links. Produces wfsSeedTerritorySf / wfsSeedTerritoryNy / wfsSeedTerritoryChi (consumed by the service-resources folder's ServiceTerritoryMembers). Idempotent-safe names carry a {{$timestamp}} suffix. Run this folder FIRST.
+order: 100
+auth:
+  - id: 2e8b5c14-9d3f-4a72-b6e1-0f4a7c9d2b85
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{managerToken}}"

--- a/src/test/resources/pm-templates/v3/wfs-seed/fixtures/operating-hours-territories/create-operating-hours-territories-graph.request.yaml
+++ b/src/test/resources/pm-templates/v3/wfs-seed/fixtures/operating-hours-territories/create-operating-hours-territories-graph.request.yaml
@@ -1,0 +1,542 @@
+$kind: http-request
+description: >-
+  Build the WFS seed foundation (3 OperatingHours + Mon-Sun 09:00-17:00 TimeSlots, 3 ServiceTerritories, 5 WorkTypes, 10 ServiceTerritoryWorkTypes) in one composite/graph as {{managerToken}}. Stores the 3 territory ids as wfsSeedTerritory{Sf,Ny,Chi} for the service-resources folder's ServiceTerritoryMembers. WorkType.IsWalkin omitted (field absent on this org); TimeSlot.SchedulingMethod=OnSite (only accepted value here).
+url: "{{baseUrl}}{{versionPath}}/composite/graph"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: json
+  content: |-
+    {
+      "graphs": [
+        {
+          "graphId": "wfsSeedFoundation",
+          "compositeRequest": [
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refOhSanFrancisco",
+              "body": {
+                "Name": "WS Hours - San Francisco {{$timestamp}}",
+                "TimeZone": "America/Los_Angeles"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refOhNewYork",
+              "body": {
+                "Name": "WS Hours - New York {{$timestamp}}",
+                "TimeZone": "America/New_York"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refOhChicago",
+              "body": {
+                "Name": "WS Hours - Chicago {{$timestamp}}",
+                "TimeZone": "America/Chicago"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refOhSanFranciscoTsMon",
+              "body": {
+                "OperatingHoursId": "@{refOhSanFrancisco.id}",
+                "DayOfWeek": "Monday",
+                "Type": "Normal",
+                "SchedulingMethod": "OnSite",
+                "StartTime": "09:00:00.000Z",
+                "EndTime": "17:00:00.000Z"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refOhSanFranciscoTsTue",
+              "body": {
+                "OperatingHoursId": "@{refOhSanFrancisco.id}",
+                "DayOfWeek": "Tuesday",
+                "Type": "Normal",
+                "SchedulingMethod": "OnSite",
+                "StartTime": "09:00:00.000Z",
+                "EndTime": "17:00:00.000Z"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refOhSanFranciscoTsWed",
+              "body": {
+                "OperatingHoursId": "@{refOhSanFrancisco.id}",
+                "DayOfWeek": "Wednesday",
+                "Type": "Normal",
+                "SchedulingMethod": "OnSite",
+                "StartTime": "09:00:00.000Z",
+                "EndTime": "17:00:00.000Z"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refOhSanFranciscoTsThu",
+              "body": {
+                "OperatingHoursId": "@{refOhSanFrancisco.id}",
+                "DayOfWeek": "Thursday",
+                "Type": "Normal",
+                "SchedulingMethod": "OnSite",
+                "StartTime": "09:00:00.000Z",
+                "EndTime": "17:00:00.000Z"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refOhSanFranciscoTsFri",
+              "body": {
+                "OperatingHoursId": "@{refOhSanFrancisco.id}",
+                "DayOfWeek": "Friday",
+                "Type": "Normal",
+                "SchedulingMethod": "OnSite",
+                "StartTime": "09:00:00.000Z",
+                "EndTime": "17:00:00.000Z"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refOhSanFranciscoTsSat",
+              "body": {
+                "OperatingHoursId": "@{refOhSanFrancisco.id}",
+                "DayOfWeek": "Saturday",
+                "Type": "Normal",
+                "SchedulingMethod": "OnSite",
+                "StartTime": "09:00:00.000Z",
+                "EndTime": "17:00:00.000Z"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refOhSanFranciscoTsSun",
+              "body": {
+                "OperatingHoursId": "@{refOhSanFrancisco.id}",
+                "DayOfWeek": "Sunday",
+                "Type": "Normal",
+                "SchedulingMethod": "OnSite",
+                "StartTime": "09:00:00.000Z",
+                "EndTime": "17:00:00.000Z"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refOhNewYorkTsMon",
+              "body": {
+                "OperatingHoursId": "@{refOhNewYork.id}",
+                "DayOfWeek": "Monday",
+                "Type": "Normal",
+                "SchedulingMethod": "OnSite",
+                "StartTime": "09:00:00.000Z",
+                "EndTime": "17:00:00.000Z"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refOhNewYorkTsTue",
+              "body": {
+                "OperatingHoursId": "@{refOhNewYork.id}",
+                "DayOfWeek": "Tuesday",
+                "Type": "Normal",
+                "SchedulingMethod": "OnSite",
+                "StartTime": "09:00:00.000Z",
+                "EndTime": "17:00:00.000Z"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refOhNewYorkTsWed",
+              "body": {
+                "OperatingHoursId": "@{refOhNewYork.id}",
+                "DayOfWeek": "Wednesday",
+                "Type": "Normal",
+                "SchedulingMethod": "OnSite",
+                "StartTime": "09:00:00.000Z",
+                "EndTime": "17:00:00.000Z"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refOhNewYorkTsThu",
+              "body": {
+                "OperatingHoursId": "@{refOhNewYork.id}",
+                "DayOfWeek": "Thursday",
+                "Type": "Normal",
+                "SchedulingMethod": "OnSite",
+                "StartTime": "09:00:00.000Z",
+                "EndTime": "17:00:00.000Z"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refOhNewYorkTsFri",
+              "body": {
+                "OperatingHoursId": "@{refOhNewYork.id}",
+                "DayOfWeek": "Friday",
+                "Type": "Normal",
+                "SchedulingMethod": "OnSite",
+                "StartTime": "09:00:00.000Z",
+                "EndTime": "17:00:00.000Z"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refOhNewYorkTsSat",
+              "body": {
+                "OperatingHoursId": "@{refOhNewYork.id}",
+                "DayOfWeek": "Saturday",
+                "Type": "Normal",
+                "SchedulingMethod": "OnSite",
+                "StartTime": "09:00:00.000Z",
+                "EndTime": "17:00:00.000Z"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refOhNewYorkTsSun",
+              "body": {
+                "OperatingHoursId": "@{refOhNewYork.id}",
+                "DayOfWeek": "Sunday",
+                "Type": "Normal",
+                "SchedulingMethod": "OnSite",
+                "StartTime": "09:00:00.000Z",
+                "EndTime": "17:00:00.000Z"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refOhChicagoTsMon",
+              "body": {
+                "OperatingHoursId": "@{refOhChicago.id}",
+                "DayOfWeek": "Monday",
+                "Type": "Normal",
+                "SchedulingMethod": "OnSite",
+                "StartTime": "09:00:00.000Z",
+                "EndTime": "17:00:00.000Z"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refOhChicagoTsTue",
+              "body": {
+                "OperatingHoursId": "@{refOhChicago.id}",
+                "DayOfWeek": "Tuesday",
+                "Type": "Normal",
+                "SchedulingMethod": "OnSite",
+                "StartTime": "09:00:00.000Z",
+                "EndTime": "17:00:00.000Z"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refOhChicagoTsWed",
+              "body": {
+                "OperatingHoursId": "@{refOhChicago.id}",
+                "DayOfWeek": "Wednesday",
+                "Type": "Normal",
+                "SchedulingMethod": "OnSite",
+                "StartTime": "09:00:00.000Z",
+                "EndTime": "17:00:00.000Z"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refOhChicagoTsThu",
+              "body": {
+                "OperatingHoursId": "@{refOhChicago.id}",
+                "DayOfWeek": "Thursday",
+                "Type": "Normal",
+                "SchedulingMethod": "OnSite",
+                "StartTime": "09:00:00.000Z",
+                "EndTime": "17:00:00.000Z"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refOhChicagoTsFri",
+              "body": {
+                "OperatingHoursId": "@{refOhChicago.id}",
+                "DayOfWeek": "Friday",
+                "Type": "Normal",
+                "SchedulingMethod": "OnSite",
+                "StartTime": "09:00:00.000Z",
+                "EndTime": "17:00:00.000Z"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refOhChicagoTsSat",
+              "body": {
+                "OperatingHoursId": "@{refOhChicago.id}",
+                "DayOfWeek": "Saturday",
+                "Type": "Normal",
+                "SchedulingMethod": "OnSite",
+                "StartTime": "09:00:00.000Z",
+                "EndTime": "17:00:00.000Z"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refOhChicagoTsSun",
+              "body": {
+                "OperatingHoursId": "@{refOhChicago.id}",
+                "DayOfWeek": "Sunday",
+                "Type": "Normal",
+                "SchedulingMethod": "OnSite",
+                "StartTime": "09:00:00.000Z",
+                "EndTime": "17:00:00.000Z"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritory",
+              "referenceId": "refTerrSf",
+              "body": {
+                "Name": "WS San Francisco Territory {{$timestamp}}",
+                "OperatingHoursId": "@{refOhSanFrancisco.id}",
+                "IsActive": true,
+                "Latitude": 37.789853,
+                "Longitude": -122.396806,
+                "Street": "415 Mission St",
+                "City": "San Francisco",
+                "State": "CA",
+                "PostalCode": "94105",
+                "Country": "US"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritory",
+              "referenceId": "refTerrNy",
+              "body": {
+                "Name": "WS New York Territory {{$timestamp}}",
+                "OperatingHoursId": "@{refOhNewYork.id}",
+                "IsActive": true,
+                "Latitude": 40.75378,
+                "Longitude": -73.976624,
+                "Street": "200 Park Ave",
+                "City": "New York",
+                "State": "NY",
+                "PostalCode": "10166",
+                "Country": "US"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritory",
+              "referenceId": "refTerrChi",
+              "body": {
+                "Name": "WS Chicago Territory {{$timestamp}}",
+                "OperatingHoursId": "@{refOhChicago.id}",
+                "IsActive": true,
+                "Latitude": 41.878908,
+                "Longitude": -87.635489,
+                "Street": "233 S Wacker Dr",
+                "City": "Chicago",
+                "State": "IL",
+                "PostalCode": "60606",
+                "Country": "US"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/WorkType",
+              "referenceId": "refWt0",
+              "body": {
+                "Name": "WS Installation {{$timestamp}}",
+                "EstimatedDuration": 2,
+                "DurationType": "Hours",
+                "Description": "Install new equipment at customer site",
+                "IsRegular": true,
+                "IsGroup": false
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/WorkType",
+              "referenceId": "refWt1",
+              "body": {
+                "Name": "WS Repair {{$timestamp}}",
+                "EstimatedDuration": 1,
+                "DurationType": "Hours",
+                "Description": "Repair existing equipment",
+                "IsRegular": true,
+                "IsGroup": false
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/WorkType",
+              "referenceId": "refWt2",
+              "body": {
+                "Name": "WS Maintenance {{$timestamp}}",
+                "EstimatedDuration": 3,
+                "DurationType": "Hours",
+                "Description": "Scheduled preventive maintenance",
+                "IsRegular": true,
+                "IsGroup": false
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/WorkType",
+              "referenceId": "refWt3",
+              "body": {
+                "Name": "WS Inspection {{$timestamp}}",
+                "EstimatedDuration": 1,
+                "DurationType": "Hours",
+                "Description": "Compliance and safety inspection",
+                "IsRegular": true,
+                "IsGroup": false
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/WorkType",
+              "referenceId": "refWt4",
+              "body": {
+                "Name": "WS Consultation {{$timestamp}}",
+                "EstimatedDuration": 1,
+                "DurationType": "Hours",
+                "Description": "Customer onsite consultation",
+                "IsRegular": true,
+                "IsGroup": false
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryWorkType",
+              "referenceId": "refStwt0",
+              "body": {
+                "ServiceTerritoryId": "@{refTerrSf.id}",
+                "WorkTypeId": "@{refWt0.id}"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryWorkType",
+              "referenceId": "refStwt1",
+              "body": {
+                "ServiceTerritoryId": "@{refTerrSf.id}",
+                "WorkTypeId": "@{refWt1.id}"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryWorkType",
+              "referenceId": "refStwt2",
+              "body": {
+                "ServiceTerritoryId": "@{refTerrSf.id}",
+                "WorkTypeId": "@{refWt4.id}"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryWorkType",
+              "referenceId": "refStwt3",
+              "body": {
+                "ServiceTerritoryId": "@{refTerrNy.id}",
+                "WorkTypeId": "@{refWt0.id}"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryWorkType",
+              "referenceId": "refStwt4",
+              "body": {
+                "ServiceTerritoryId": "@{refTerrNy.id}",
+                "WorkTypeId": "@{refWt2.id}"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryWorkType",
+              "referenceId": "refStwt5",
+              "body": {
+                "ServiceTerritoryId": "@{refTerrNy.id}",
+                "WorkTypeId": "@{refWt3.id}"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryWorkType",
+              "referenceId": "refStwt6",
+              "body": {
+                "ServiceTerritoryId": "@{refTerrNy.id}",
+                "WorkTypeId": "@{refWt4.id}"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryWorkType",
+              "referenceId": "refStwt7",
+              "body": {
+                "ServiceTerritoryId": "@{refTerrChi.id}",
+                "WorkTypeId": "@{refWt1.id}"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryWorkType",
+              "referenceId": "refStwt8",
+              "body": {
+                "ServiceTerritoryId": "@{refTerrChi.id}",
+                "WorkTypeId": "@{refWt2.id}"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryWorkType",
+              "referenceId": "refStwt9",
+              "body": {
+                "ServiceTerritoryId": "@{refTerrChi.id}",
+                "WorkTypeId": "@{refWt4.id}"
+              }
+            }
+          ]
+        }
+      ]
+    }
+scripts:
+  - type: afterResponse
+    code: |-
+      const jsonData = pm.response.json();
+      const responses = jsonData.graphs[0].graphResponse.compositeResponse;
+      responses.forEach((r) => {
+        if (r.httpStatusCode < 200 || r.httpStatusCode >= 300) {
+          throw new Error("Composite step " + r.referenceId + " failed: " + JSON.stringify(r.body));
+        }
+      });
+      const byRef = {};
+      responses.forEach(r => { byRef[r.referenceId] = r.body && r.body.id; });
+      pm.environment.set("wfsSeedTerritorySf", byRef["refTerrSf"]);
+      pm.environment.set("wfsSeedTerritoryNy", byRef["refTerrNy"]);
+      pm.environment.set("wfsSeedTerritoryChi", byRef["refTerrChi"]);
+    language: text/javascript
+order: 500

--- a/src/test/resources/pm-templates/v3/wfs-seed/fixtures/service-resources/.resources/definition.yaml
+++ b/src/test/resources/pm-templates/v3/wfs-seed/fixtures/service-resources/.resources/definition.yaml
@@ -1,0 +1,16 @@
+$kind: collection
+description: >-
+  Workforce graph, run as the `manager` persona ({{managerToken}}). One composite/graph builds ONE
+  ServiceResource owned by the {{caseWorkerUserId}} persona + one Primary ServiceTerritoryMember
+  (TerritoryType=P, effective today UTC) in the SF territory. Persona-model: the case-worker persona
+  owns their own resource. The org enforces uniqueness on (RelatedRecordId, ResourceType), so one
+  persona user maps to one ServiceResource of a type (the org-manager script's 30 resources use 30
+  distinct users). Consumes wfsSeedTerritorySf from the operating-hours-territories folder, so run that
+  FIRST. Requires {{caseWorkerUserId}} from auth/create-case-worker.
+order: 300
+auth:
+  - id: 4a1b3c8d-7e2d-4f6a-9c5b-0d4e8a1b3c8d
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{managerToken}}"

--- a/src/test/resources/pm-templates/v3/wfs-seed/fixtures/service-resources/create-service-resources-graph.request.yaml
+++ b/src/test/resources/pm-templates/v3/wfs-seed/fixtures/service-resources/create-service-resources-graph.request.yaml
@@ -1,0 +1,68 @@
+$kind: http-request
+description: >-
+  Build ONE ServiceResource owned by the {{caseWorkerUserId}} persona + one Primary
+  ServiceTerritoryMember (TerritoryType=P, effective today UTC) in the SF territory, in one
+  composite/graph as {{managerToken}}. Persona-model: the case-worker persona owns their own
+  ServiceResource. NOTE: the org enforces uniqueness on (RelatedRecordId, ResourceType), so a single
+  persona user can own only one ServiceResource of a given type — hence one resource here, not the
+  org-manager script's 30 (which uses 30 distinct users). The resource is timestamped-named and the
+  case-worker user is fresh per run, so re-runs don't collide. Territory id from wfsSeedTerritorySf.
+url: "{{baseUrl}}{{versionPath}}/composite/graph"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: json
+  content: |-
+    {
+      "graphs": [
+        {
+          "graphId": "wfsSeedResources",
+          "compositeRequest": [
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceResource",
+              "referenceId": "refRes",
+              "body": {
+                "Name": "WS Resource - CaseWorker {{$timestamp}}",
+                "ResourceType": "T",
+                "IsActive": true,
+                "RelatedRecordId": "{{caseWorkerUserId}}"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryMember",
+              "referenceId": "refStm",
+              "body": {
+                "ServiceResourceId": "@{refRes.id}",
+                "ServiceTerritoryId": "{{wfsSeedTerritorySf}}",
+                "TerritoryType": "P",
+                "EffectiveStartDate": "{{wfsSeedStmEffectiveStart}}"
+              }
+            }
+          ]
+        }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const today = new Date();
+      today.setUTCHours(0, 0, 0, 0);
+      pm.environment.set("wfsSeedStmEffectiveStart", today.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      const jsonData = pm.response.json();
+      const responses = jsonData.graphs[0].graphResponse.compositeResponse;
+      responses.forEach((r) => {
+        if (r.httpStatusCode < 200 || r.httpStatusCode >= 300) {
+          throw new Error("Composite step " + r.referenceId + " failed: " + JSON.stringify(r.body));
+        }
+      });
+      const byRef = {};
+      responses.forEach(r => { byRef[r.referenceId] = r.body && r.body.id; });
+      pm.environment.set("wfsSeedServiceResourceId", byRef["refRes"]);
+    language: text/javascript
+order: 500

--- a/src/test/resources/pm-templates/v3/wfs-seed/probes/.resources/definition.yaml
+++ b/src/test/resources/pm-templates/v3/wfs-seed/probes/.resources/definition.yaml
@@ -1,0 +1,13 @@
+$kind: collection
+description: >-
+  Read-only verification probes. Runs LAST (order 9000, after auth=100 and fixtures=1000) as
+  {{adminToken}} - reads use admin's org-wide visibility so the count reflects the true seeded total
+  (only *seeding* honors the manager/case-worker persona; verification does not). Each step runs a
+  SOQL COUNT() and captures the total into an env var (wfsSeed*Count) that the Java test asserts on.
+order: 9000
+auth:
+  - id: 6c3d5e0f-9a4b-4b8c-8e7d-2f6a0b3c5d9f
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/test/resources/pm-templates/v3/wfs-seed/probes/count-accounts.request.yaml
+++ b/src/test/resources/pm-templates/v3/wfs-seed/probes/count-accounts.request.yaml
@@ -1,0 +1,18 @@
+$kind: http-request
+description: >-
+  Verification probe: count WS Accounts produced by the seed. Captures totalSize into wfsSeedAccountCount for the Java
+  test to assert. Read-only, runs as {{adminToken}}.
+url: "{{baseUrl}}{{versionPath}}/query/?q=SELECT%20COUNT%28%29%20FROM%20Account%20WHERE%20Name%20LIKE%20%27WS%20Customer%25%27"
+method: GET
+headers:
+  Content-Type: application/json
+body:
+  type: text
+  content: ""
+scripts:
+  - type: afterResponse
+    code: |-
+      var jsonData = pm.response.json();
+      pm.environment.set("wfsSeedAccountCount", String(jsonData.totalSize));
+    language: text/javascript
+order: 1000

--- a/src/test/resources/pm-templates/v3/wfs-seed/probes/count-locations.request.yaml
+++ b/src/test/resources/pm-templates/v3/wfs-seed/probes/count-locations.request.yaml
@@ -1,0 +1,18 @@
+$kind: http-request
+description: >-
+  Verification probe: count WS Locations produced by the seed. Captures totalSize into wfsSeedLocationCount for the Java
+  test to assert. Read-only, runs as {{adminToken}}.
+url: "{{baseUrl}}{{versionPath}}/query/?q=SELECT%20COUNT%28%29%20FROM%20Location%20WHERE%20Name%20LIKE%20%27WS%20%25Location%25%27"
+method: GET
+headers:
+  Content-Type: application/json
+body:
+  type: text
+  content: ""
+scripts:
+  - type: afterResponse
+    code: |-
+      var jsonData = pm.response.json();
+      pm.environment.set("wfsSeedLocationCount", String(jsonData.totalSize));
+    language: text/javascript
+order: 5000

--- a/src/test/resources/pm-templates/v3/wfs-seed/probes/count-operating-hours.request.yaml
+++ b/src/test/resources/pm-templates/v3/wfs-seed/probes/count-operating-hours.request.yaml
@@ -1,0 +1,18 @@
+$kind: http-request
+description: >-
+  Verification probe: count WS OperatingHours produced by the seed. Captures totalSize into wfsSeedOperatingHoursCount for the Java
+  test to assert. Read-only, runs as {{adminToken}}.
+url: "{{baseUrl}}{{versionPath}}/query/?q=SELECT%20COUNT%28%29%20FROM%20OperatingHours%20WHERE%20Name%20LIKE%20%27WS%20Hours%25%27"
+method: GET
+headers:
+  Content-Type: application/json
+body:
+  type: text
+  content: ""
+scripts:
+  - type: afterResponse
+    code: |-
+      var jsonData = pm.response.json();
+      pm.environment.set("wfsSeedOperatingHoursCount", String(jsonData.totalSize));
+    language: text/javascript
+order: 2000

--- a/src/test/resources/pm-templates/v3/wfs-seed/probes/count-service-resources.request.yaml
+++ b/src/test/resources/pm-templates/v3/wfs-seed/probes/count-service-resources.request.yaml
@@ -1,0 +1,18 @@
+$kind: http-request
+description: >-
+  Verification probe: count WS ServiceResources produced by the seed. Captures totalSize into wfsSeedServiceResourceCount for the Java
+  test to assert. Read-only, runs as {{adminToken}}.
+url: "{{baseUrl}}{{versionPath}}/query/?q=SELECT%20COUNT%28%29%20FROM%20ServiceResource%20WHERE%20Name%20LIKE%20%27WS%20Resource%25%27"
+method: GET
+headers:
+  Content-Type: application/json
+body:
+  type: text
+  content: ""
+scripts:
+  - type: afterResponse
+    code: |-
+      var jsonData = pm.response.json();
+      pm.environment.set("wfsSeedServiceResourceCount", String(jsonData.totalSize));
+    language: text/javascript
+order: 6000

--- a/src/test/resources/pm-templates/v3/wfs-seed/probes/count-territories.request.yaml
+++ b/src/test/resources/pm-templates/v3/wfs-seed/probes/count-territories.request.yaml
@@ -1,0 +1,18 @@
+$kind: http-request
+description: >-
+  Verification probe: count WS ServiceTerritories produced by the seed. Captures totalSize into wfsSeedTerritoryCount for the Java
+  test to assert. Read-only, runs as {{adminToken}}.
+url: "{{baseUrl}}{{versionPath}}/query/?q=SELECT%20COUNT%28%29%20FROM%20ServiceTerritory%20WHERE%20Name%20LIKE%20%27WS%20%25Territory%25%27"
+method: GET
+headers:
+  Content-Type: application/json
+body:
+  type: text
+  content: ""
+scripts:
+  - type: afterResponse
+    code: |-
+      var jsonData = pm.response.json();
+      pm.environment.set("wfsSeedTerritoryCount", String(jsonData.totalSize));
+    language: text/javascript
+order: 3000

--- a/src/test/resources/pm-templates/v3/wfs-seed/probes/count-territory-members.request.yaml
+++ b/src/test/resources/pm-templates/v3/wfs-seed/probes/count-territory-members.request.yaml
@@ -1,0 +1,18 @@
+$kind: http-request
+description: >-
+  Verification probe: count WS ServiceTerritoryMembers produced by the seed. Captures totalSize into wfsSeedTerritoryMemberCount for the Java
+  test to assert. Read-only, runs as {{adminToken}}.
+url: "{{baseUrl}}{{versionPath}}/query/?q=SELECT%20COUNT%28%29%20FROM%20ServiceTerritoryMember%20WHERE%20ServiceResource.Name%20LIKE%20%27WS%20Resource%25%27"
+method: GET
+headers:
+  Content-Type: application/json
+body:
+  type: text
+  content: ""
+scripts:
+  - type: afterResponse
+    code: |-
+      var jsonData = pm.response.json();
+      pm.environment.set("wfsSeedTerritoryMemberCount", String(jsonData.totalSize));
+    language: text/javascript
+order: 7000

--- a/src/test/resources/pm-templates/v3/wfs-seed/probes/count-work-types.request.yaml
+++ b/src/test/resources/pm-templates/v3/wfs-seed/probes/count-work-types.request.yaml
@@ -1,0 +1,18 @@
+$kind: http-request
+description: >-
+  Verification probe: count WS WorkTypes produced by the seed. Captures totalSize into wfsSeedWorkTypeCount for the Java
+  test to assert. Read-only, runs as {{adminToken}}.
+url: "{{baseUrl}}{{versionPath}}/query/?q=SELECT%20COUNT%28%29%20FROM%20WorkType%20WHERE%20Name%20LIKE%20%27WS%20%25%27"
+method: GET
+headers:
+  Content-Type: application/json
+body:
+  type: text
+  content: ""
+scripts:
+  - type: afterResponse
+    code: |-
+      var jsonData = pm.response.json();
+      pm.environment.set("wfsSeedWorkTypeCount", String(jsonData.totalSize));
+    language: text/javascript
+order: 4000

--- a/src/test/resources/pm-templates/v3/wfs-seed/ws.environment.yaml
+++ b/src/test/resources/pm-templates/v3/wfs-seed/ws.environment.yaml
@@ -1,0 +1,11 @@
+name: ws
+# Primary creds source for WfsSeedE2ETest. Fill baseUrl / username / password to point the seed at
+# your org. If these are left blank, the test FALLS BACK to ~/.revoman/config.yaml. Not read by
+# ReVoman at runtime for anything else — the auth/ folder produces versionPath / tokens / ids live.
+values:
+  - key: baseUrl
+    value: ''
+  - key: username
+    value: ''
+  - key: password
+    value: ''


### PR DESCRIPTION
## What

Adds `WfsSeedE2ETest` — seeds Workforce Scheduling base data onto the external org configured in `~/.revoman/config.yaml` and verifies the seed landed. An HTTP port of the org-manager post-processor `WorkforceSchedulingPostProcessor.runBaseSeed()`.

## How

- **V3 collection** `pm-templates/v3/wfs-seed/`, walked as one `ReVoman.revUp`:
  - `auth/` — admin SOAP-logins, creates the `manager` + `case-worker` personas (with passwords), SOAP-logins the manager for `{{managerToken}}`.
  - `fixtures/` — operating-hours + territories, accounts + locations, one ServiceResource for the case-worker persona, context-definition-sync.
  - `probes/` — SOQL `COUNT()` verification, read as `{{adminToken}}`.
- **Persona-model:** admin only creates the persona users + triggers the org-level context sync; the manager persona seeds all data; the case-worker owns its ServiceResource. Tokens are minted via **SOAP login** (the OSS lib has no in-JVM minting).
- **`WfsShiftStatusSeeder`** — idempotent pre-hook that seeds the `Shift.Status` dyn-enum in local SDB via JDBC, deriving port / db / release from the running `postgres` process (release-agnostic). Skips gracefully when SDB is not local.
- Adds `org.postgresql:postgresql` (`testImplementation`).
- The test is `assumeTrue`-skipped when `~/.revoman/config.yaml` has no external-org creds (so it never breaks CI without a real org).

## Verification

Green against orgfarm org `00Dxx00azs9RYdc`:

```
Test seeds Workforce Scheduling base data and verifies record counts() PASSED (21.6s)
```

## Notes / deviations from the org-manager script (documented per-folder)

- ServiceResource → single case-worker persona (the org enforces unique ServiceResource per `(user, ResourceType)`, so one persona user maps to one resource; the script's 30 resources use 30 distinct users).
- `Location`/`Address` geolocation + `VisitorAddressId` omitted (FLS-gated; the manager persona lacks the `WS_Location_Field_Access` grant). ServiceTerritory carries the scheduling geo.
- `WorkType.IsWalkin` omitted (absent on the org); `TimeSlot.SchedulingMethod=OnSite`.
- `context-definition-sync` runs as admin (the `ContextDefinitionSync` SObject is not accessible under the manager PSL) — the only fixtures folder that is not manager, flagged in its description.
