### PR TITLE
test(scheduler-parity): Scheduler ↔ Unified Scheduling parity suite (all 13 decisions)

### DIFF
--- a/docs/superpowers/plans/2026-07-03-scheduler-vs-unified-1x-parity.md
+++ b/docs/superpowers/plans/2026-07-03-scheduler-vs-unified-1x-parity.md
@@ -1,0 +1,905 @@
+# Scheduler ↔ Unified(264) `1.*` Parity — Vertical Slice (1.5) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a two-org differential ReVoman harness and prove the `1.5` (Availability / double-book helper) parity slice: does OLD Salesforce Scheduler and 264-Unified-OnSite (262 proxy) make the SAME include/exclude read decision and book/refuse write outcome for a busy non-required helper?
+
+**Architecture:** A new `com.salesforce.revoman.integration.core.scheduler` package. `SchedulerParityConfig` adds a SECOND external-org creds overlay (`~/.revoman/scheduler-config.yaml`) for the scheduler org, alongside the existing `~/.revoman/config.yaml` (262/Unified side, reused via `ReVomanConfigForWfs`). Each `1.*` test runs the same logical fixture against BOTH orgs — old side over public Scheduler REST (`/scheduling/getAppointmentSlots`, `/connect/scheduling/service-appointments`), Unified side over the existing WFS Connect acts — then diffs normalized verdicts.
+
+**Tech Stack:** ReVoman (`ReVoman.revUp`, `Kick` DSL), JUnit 5, Google Truth, Postman V3 collections (YAML dirs), Kotlin stdlib interop. Java per `/my-java-coding-style` (final var, functional, no bare null).
+
+## Global Constraints
+
+- **Old side = scheduler org** `orgfarm-0c6bcb96c0…crm.dev:6101`; **264 side = 262 org** `orgfarm-4dbef90d6c…crm.dev:6101`. Both local-bound → ReVoman external-org mode.
+- **Never commit creds.** `~/.revoman/config.yaml` and `~/.revoman/scheduler-config.yaml` live in `$HOME`, outside the repo. Committed env yamls stay blank.
+- **Old-side SOAP login uses v64** (`/services/Soap/u/64.0`); v67 rejects SOAP login. REST version comes from `latest-api-version` (`versionPath`).
+- **262-as-264-proxy caveat** stamped in every javadoc: verdicts are 262-observed; a true-264 org may differ on locked-in crashes (1.4/3). The 1.5 slice is crash-free → unaffected.
+- **SchedulingMethod="OnSite"** on TimeSlot/Shift + any Unified schedule body; WorkType carries NO SchedulingMethod. (Old scheduler org value validity is probed in Task 2.)
+- **Verdict equality compares NORMALIZED verdicts only** (`BOOKED/REFUSED/CRASHED`, `INCLUDED/EXCLUDED`) — never raw errorCodes (old REST `isError`/HTTP vs Unified `schedulingStatus`; guide R3).
+- **Control-first discipline:** confirm each control RED for the intended reason before trusting the positive GREEN.
+- Run branch: `wfs/decision-1-9-revoman-tests` in `~/code-clones/work/revoman-root`. Fast loop = external-org mode; the Java lives in the `integrationTest` source set (`gradle :compileIntegrationTestJava`).
+
+---
+
+## File structure
+
+- **Create** `src/integrationTest/java/com/salesforce/revoman/integration/core/scheduler/SchedulerParityConfig.java` — two-org config seam. Old-side Kicks (scheduler org creds overlay) + reuse of `ReVomanConfigForWfs` Unified Kicks + `assumeBothOrgCreds()`.
+- **Create** `src/integrationTest/java/com/salesforce/revoman/integration/core/scheduler/SchedulerVsUnifiedParityE2ETest.java` — the differential test class (slice: one method).
+- **Create** V3 old-Scheduler collection dirs under `src/integrationTest/resources/pm-templates/v3/core/scheduler/`:
+  - `auth/` — SOAP v64 login + latest-api-version (admin session; scheduler org has no manager-persona requirement for the slice).
+  - `fixtures/double-book/` — the double-book data graph (clone of the WFS one, retargeted).
+  - `booking/get-appointment-slots-double-book/` — old READ act (`/scheduling/getAppointmentSlots`), captures `oldReadResourceBIncluded`.
+  - `booking/service-appointments-double-book-non-required/` — old WRITE act (non-required helper), captures `oldWriteHelperOutcome`.
+  - `booking/service-appointments-double-book-required-control/` — old WRITE control (helper→required), captures `oldWriteRequiredControlOutcome`.
+  - `scheduler.environment.yaml` — blank-cred env (baseUrl/username/password) for the old side.
+- **Create** `~/.revoman/scheduler-config.yaml` (in `$HOME`, NOT committed) — scheduler org baseUrl/username/password.
+- **Reuse unchanged:** `ReVomanConfigForWfs` Unified Kicks (`AUTH_CONFIG`, `AVAILABILITY_OP_HOURS_POLICY_CONFIG`, `DOUBLE_BOOK_FIXTURE_CONFIG`, `DOUBLE_BOOK_NON_REQUIRED_SCHEDULE_CONFIG`, `DOUBLE_BOOK_REQUIRED_CONFLICT_SCHEDULE_CONFIG`).
+
+---
+
+### Task 1: Two-org config seam + scheduler-org auth bind
+
+Proves the second org binds and mints a session — the novel harness mechanic — before any fixture work.
+
+**Files:**
+- Create: `src/integrationTest/java/com/salesforce/revoman/integration/core/scheduler/SchedulerParityConfig.java`
+- Create: `src/integrationTest/resources/pm-templates/v3/core/scheduler/scheduler.environment.yaml`
+- Create: `src/integrationTest/resources/pm-templates/v3/core/scheduler/auth/.resources/definition.yaml`
+- Create: `src/integrationTest/resources/pm-templates/v3/core/scheduler/auth/login-as-sysadmin.request.yaml`
+- Create: `src/integrationTest/resources/pm-templates/v3/core/scheduler/auth/latest-api-version.request.yaml`
+- Create (temporary probe test): `src/integrationTest/java/com/salesforce/revoman/integration/core/scheduler/SchedulerVsUnifiedParityE2ETest.java`
+- Create (in `$HOME`, not committed): `~/.revoman/scheduler-config.yaml`
+
+**Interfaces:**
+- Produces:
+  - `SchedulerParityConfig.OLD_AUTH_CONFIG` (`Kick`) — scheduler-org SOAP-login + version.
+  - `SchedulerParityConfig.assumeBothOrgCreds()` (`static void`) — JUnit-skips unless BOTH `~/.revoman/config.yaml` and `~/.revoman/scheduler-config.yaml` carry baseUrl/username/password.
+  - Env keys after `OLD_AUTH_CONFIG`: `adminToken`, `accessToken`, `versionPath`, `apiVersion`, `orgId`.
+
+- [ ] **Step 1: Create the (uncommitted) scheduler creds file**
+
+```bash
+mkdir -p ~/.revoman
+cat > ~/.revoman/scheduler-config.yaml <<'YAML'
+baseUrl: '<scheduler-org-baseUrl>'   # e.g. https://<org>...crm.dev:6101
+username: <scheduler-org-username>
+password: <scheduler-org-password>
+YAML
+```
+Expected: file exists; `grep -c baseUrl ~/.revoman/scheduler-config.yaml` → `1`. (Confirm `~/.revoman/config.yaml` already holds the 262 creds; if not, create it with the 262 org's baseUrl/username/password.)
+
+- [ ] **Step 2: Create the blank old-side env** `…/v3/core/scheduler/scheduler.environment.yaml`
+
+```yaml
+name: scheduler
+values:
+  - key: baseUrl
+    value: ''
+  - key: username
+    value: ''
+  - key: password
+    value: ''
+  - key: adminToken
+    value: ''
+  - key: accessToken
+    value: ''
+```
+
+- [ ] **Step 3: Create the old-side auth collection definition** `…/scheduler/auth/.resources/definition.yaml`
+
+```yaml
+$kind: collection
+description: |-
+  Scheduler-org bootstrap auth for the Scheduler↔Unified 1.* parity slice. SOAP-logs-in as the org
+  admin (v64) to seed {{adminToken}}/{{accessToken}}, then resolves versionPath. The slice's old-side
+  reads/writes run under {{adminToken}} (admin session is sufficient for the read+book parity probe;
+  no manager-persona split is needed here — that is a Decision-9 concern, out of slice).
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000001
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"
+```
+
+- [ ] **Step 4: Create SOAP login** `…/scheduler/auth/login-as-sysadmin.request.yaml`
+
+```yaml
+$kind: http-request
+description: >-
+  SOAP login (v64) to the SCHEDULER org; seeds adminToken/accessToken/orgId. Runs first (order 500) so
+  latest-api-version and every downstream old-side call has a live session.
+url: "{{baseUrl}}/services/Soap/u/64.0"
+method: POST
+headers:
+  Content-Type: text/xml
+  SOAPAction: login
+  charset: UTF-8
+  Accept: text/xml
+body:
+  type: text
+  content: |-
+    <?xml version="1.0" encoding="utf-8" ?>
+    <env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+      <env:Body>
+        <n1:login xmlns:n1="urn:partner.soap.sforce.com">
+          <n1:username><![CDATA[{{username}}]]></n1:username>
+          <n1:password><![CDATA[{{password}}]]></n1:password>
+        </n1:login>
+      </env:Body>
+    </env:Envelope>
+scripts:
+  - type: afterResponse
+    code: |-
+      var xml2js = require('xml2js')
+      xml2js.parseString(pm.response.text(), { explicitArray: false }, (_, jsonResponse) => {
+        let result = jsonResponse['soapenv:Envelope']['soapenv:Body'].loginResponse.result
+        pm.environment.set("accessToken", result.sessionId)
+        pm.environment.set("adminToken", result.sessionId)
+        pm.environment.set("adminUserId", result.userId)
+        pm.environment.set("orgId", result.userInfo.organizationId)
+      })
+    language: text/javascript
+settings:
+  disabledSystemHeaders:
+    - accept
+    - content-type
+    - user-agent
+order: 500
+```
+
+- [ ] **Step 5: Create version resolver** `…/scheduler/auth/latest-api-version.request.yaml`
+
+```yaml
+$kind: http-request
+description: Resolve the scheduler org's latest API version → version / apiVersion / versionPath.
+url: "{{baseUrl}}/services/data/"
+method: GET
+headers:
+  Accept: application/json
+scripts:
+  - type: afterResponse
+    code: |-
+      var jsonData = pm.response.json();
+      var lastNode = jsonData.pop();
+      pm.environment.set("version", lastNode.version);
+      pm.environment.set("apiVersion", "v" + lastNode.version);
+      pm.environment.set("versionPath", lastNode.url);
+    language: text/javascript
+settings:
+  disabledSystemHeaders:
+    - accept
+    - content-type
+order: 1000
+```
+
+- [ ] **Step 6: Write `SchedulerParityConfig`** `…/core/scheduler/SchedulerParityConfig.java`
+
+```java
+/*
+ * Copyright 2026 salesforce.com, inc.
+ * All Rights Reserved
+ * Company Confidential
+ */
+
+package com.salesforce.revoman.integration.core.scheduler;
+
+import static com.salesforce.revoman.input.config.StepPick.PostTxnStepPick.afterStepContainingHeader;
+import static com.salesforce.revoman.integration.core.CoreUtils.ASSERT_COMPOSITE_GRAPH_RESPONSE_SUCCESS;
+import static com.salesforce.revoman.integration.core.CoreUtils.ASSERT_COMPOSITE_RESPONSE_SUCCESS;
+import static com.salesforce.revoman.integration.core.CoreUtils.unmarshallCompositeGraphResponse;
+import static com.salesforce.revoman.integration.core.CoreUtils.unmarshallCompositeResponse;
+import static com.salesforce.revoman.output.ExeType.HTTP_STATUS;
+
+import com.salesforce.revoman.input.ExternalOrgConfig;
+import com.salesforce.revoman.input.config.Kick;
+import com.salesforce.revoman.integration.core.adapters.IDAdapter;
+import com.salesforce.revoman.integration.core.wfs.ReVomanConfigForWfs;
+import java.util.Map;
+import org.junit.jupiter.api.Assumptions;
+
+/**
+ * Two-org config seam for the Salesforce Scheduler ↔ Unified(264) {@code 1.*} helper-fitness parity
+ * tests. The OLD side (scheduler org) is driven over public Scheduler REST; the 264 side reuses the
+ * existing {@link ReVomanConfigForWfs} Unified Kicks against the 262 org (endpoints identical
+ * 262↔264 per the parity effort). The two OnSite engines are SEPARATE re-implementations (old {@code
+ * scheduling-impl.SchedulingServiceImpl} vs {@code unified-scheduling-impl.InBusinessAppointmentSlotCalculator}),
+ * so parity is not guaranteed by construction — these tests assert it.
+ *
+ * <p>The old side reads its creds from {@code ~/.revoman/scheduler-config.yaml} (a SECOND external-org
+ * file, distinct from the {@code ~/.revoman/config.yaml} the Unified side uses). Both files live in
+ * {@code $HOME}, never committed; absent creds → the tests JUnit-skip via {@link #assumeBothOrgCreds}.
+ */
+public final class SchedulerParityConfig {
+
+  private SchedulerParityConfig() {}
+
+  /** OLD scheduler-org creds overlay, read once from {@code ~/.revoman/scheduler-config.yaml}. */
+  static final Map<String, Object> SCHEDULER_ORG_CONFIG =
+      ExternalOrgConfig.readExternalOrgConfig(
+          System.getProperty("user.home") + "/.revoman/scheduler-config.yaml");
+
+  static final String V3_SCHEDULER_PATH = "pm-templates/v3/core/scheduler/";
+  static final String ENV_PATH = V3_SCHEDULER_PATH + "scheduler.environment.yaml";
+  static final String NODE_MODULE_RELATIVE_PATH = "js";
+  static final String IGNORE_HTTP_STATUS_UNSUCCESSFUL = "ignoreHTTPStatusUnsuccessful";
+
+  static final Kick OLD_AUTH_CONFIG = oldKickFor(V3_SCHEDULER_PATH + "auth");
+
+  /**
+   * Skip (JUnit assumption) unless BOTH orgs' creds are present: the Unified side reads {@code
+   * ~/.revoman/config.yaml} (via {@link ReVomanConfigForWfs}) and the old side reads {@code
+   * ~/.revoman/scheduler-config.yaml} (here). Either missing → skip, not fail.
+   */
+  static void assumeBothOrgCreds() {
+    ReVomanConfigForWfs.assumeExternalOrgCreds();
+    Assumptions.assumeTrue(
+        schedulerHasText("baseUrl") && schedulerHasText("username") && schedulerHasText("password"),
+        "Scheduler-org creds absent — set ~/.revoman/scheduler-config.yaml (baseUrl/username/password)."
+            + " Skipping.");
+  }
+
+  private static boolean schedulerHasText(final String key) {
+    final var value = SCHEDULER_ORG_CONFIG.get(key);
+    return value != null && !value.toString().isBlank();
+  }
+
+  /** Old-side Kick: same wiring as {@link ReVomanConfigForWfs} but overlaying the SCHEDULER creds. */
+  private static Kick oldKickFor(final String templatePath) {
+    return Kick.configure()
+        .templatePath(templatePath)
+        .environmentPath(ENV_PATH)
+        .dynamicEnvironment(SCHEDULER_ORG_CONFIG)
+        .responseConfig(unmarshallCompositeGraphResponse(), unmarshallCompositeResponse())
+        .hooks(ASSERT_COMPOSITE_GRAPH_RESPONSE_SUCCESS, ASSERT_COMPOSITE_RESPONSE_SUCCESS)
+        .globalCustomTypeAdapter(IDAdapter.INSTANCE)
+        .nodeModulesPath(NODE_MODULE_RELATIVE_PATH)
+        .haltOnFailureOfTypeExcept(
+            HTTP_STATUS, afterStepContainingHeader(IGNORE_HTTP_STATUS_UNSUCCESSFUL))
+        .insecureHttp(true)
+        .off();
+  }
+}
+```
+
+- [ ] **Step 7: Write the auth-bind probe test** `…/scheduler/SchedulerVsUnifiedParityE2ETest.java`
+
+```java
+/*
+ * Copyright 2026 salesforce.com, inc.
+ * All Rights Reserved
+ * Company Confidential
+ */
+
+package com.salesforce.revoman.integration.core.scheduler;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.salesforce.revoman.integration.core.scheduler.SchedulerParityConfig.OLD_AUTH_CONFIG;
+
+import com.salesforce.revoman.ReVoman;
+import kotlin.collections.CollectionsKt;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Scheduler ↔ Unified(264) {@code 1.*} helper-fitness parity — differential tests. Each scenario diffs
+ * the OLD Salesforce Scheduler decision against the 264-Unified(262-proxy) decision on BOTH the read
+ * (INCLUDED/EXCLUDED) and write (BOOKED/REFUSED/CRASHED) axes.
+ */
+class SchedulerVsUnifiedParityE2ETest {
+
+  @Test
+  void schedulerOrgAuthBindsE2E() {
+    SchedulerParityConfig.assumeBothOrgCreds();
+    final var rundown = ReVoman.revUp(OLD_AUTH_CONFIG);
+    final var env = CollectionsKt.last(rundown).mutableEnv;
+    assertThat(env.getAsString("adminToken")).isNotEmpty();
+    assertThat(env.getAsString("versionPath")).contains("/services/data/v");
+  }
+}
+```
+
+- [ ] **Step 8: Compile**
+
+Run: `cd ~/code-clones/work/revoman-root && gradle :compileIntegrationTestJava`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 9: Run the auth-bind probe**
+
+Run: `cd ~/code-clones/work/revoman-root && gradle :integrationTest --tests '*SchedulerVsUnifiedParityE2ETest.schedulerOrgAuthBindsE2E'`
+Expected: PASS (adminToken minted, versionPath resolved). If the org uses a different SOAP version, adjust `64.0`. If it SKIPS, the creds files are missing/blank — fix Step 1.
+
+- [ ] **Step 10: Commit**
+
+```bash
+cd ~/code-clones/work/revoman-root
+git add src/integrationTest/java/com/salesforce/revoman/integration/core/scheduler \
+        src/integrationTest/resources/pm-templates/v3/core/scheduler
+git commit -m "test(scheduler-parity): two-org config seam + scheduler-org auth bind"
+```
+
+---
+
+### Task 2: Old-side double-book fixture graph
+
+Clone the proven WFS double-book graph onto the scheduler org (standard objects, so the graph transfers). This task's deliverable is: the graph inserts clean on the scheduler org and exposes the same resource/territory/workType/account ids.
+
+**Files:**
+- Create: `…/v3/core/scheduler/fixtures/double-book/.resources/definition.yaml`
+- Create: `…/v3/core/scheduler/fixtures/double-book/create-double-book-graph.request.yaml`
+- Modify: `SchedulerParityConfig.java` (add the fixture Kick)
+
+**Interfaces:**
+- Produces `SchedulerParityConfig.OLD_DOUBLE_BOOK_FIXTURE_CONFIG` (`Kick`); env keys after it: `schedTerritoryId`, `schedWorkTypeId`, `schedAccountId`, `schedResourceAId`, `schedResourceBId`.
+- Consumes from Task 1: a live `{{adminToken}}` + `{{versionPath}}`.
+
+- [ ] **Step 1: Copy the WFS graph as the starting point**
+
+```bash
+cd ~/code-clones/work/revoman-root/src/integrationTest/resources/pm-templates/v3/core/scheduler
+mkdir -p fixtures/double-book/.resources
+cp ../wfs/fixtures/double-book-non-required/create-double-book-non-required-graph.request.yaml \
+   fixtures/double-book/create-double-book-graph.request.yaml
+```
+
+- [ ] **Step 2: Retarget the copied graph.** In `fixtures/double-book/create-double-book-graph.request.yaml`, make exactly these edits (the graph body of OperatingHours/TimeSlot/ServiceTerritory/WorkType/STWT/ServiceResource/STM/Shift/Account is unchanged — standard objects book on either org):
+  - The two `RelatedRecordId` values `{{caseWorkerUserId}}` / `{{caseManagerUserId}}` → `{{adminUserId}}` for resourceA and, for resourceB, a second scheduler-org user id. **If the scheduler org has only the admin user available**, create a second ServiceResource on an Asset instead (`ResourceType": "T"` → keep, but point `RelatedRecordId` at a second user; if none, add a `User` insert node to the graph, mirroring the WFS `auth/create-case-worker` body, under `{{adminToken}}`). Decide during the run from what the org exposes; log the choice.
+  - In the `afterResponse` script, rename the captured env keys to the `sched*` names: `doubleBookTerritoryId`→`schedTerritoryId`, `doubleBookWorkTypeId`→`schedWorkTypeId`, `doubleBookAccountId`→`schedAccountId`, `doubleBookResourceAId`→`schedResourceAId`, `doubleBookResourceBId`→`schedResourceBId`. Keep the `beforeRequest` time-window script (shift A 10-14, shift B 12-14, STM effective a month ago) verbatim — the 11:00-11:30 booking window and B's noon-start gap are the mechanism.
+  - Keep `SchedulingMethod": "OnSite"` on TimeSlot/Shift for now; **if the scheduler org rejects it** with `INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST`, drop the `SchedulingMethod` field from TimeSlot/Shift entirely (old Scheduler doesn't require it) and record that in the file's top comment.
+
+- [ ] **Step 3: Create the fixture definition** `fixtures/double-book/.resources/definition.yaml`
+
+```yaml
+$kind: collection
+description: |-
+  OLD Scheduler-org double-book data graph (clone of the WFS Unified fixture, retargeted to the scheduler
+  org and admin session). Territory OH 08-16; resourceA member OH + Shift 10-14 (covers 11:00-11:30);
+  resourceB member OH + Shift 12-14 (does NOT cover 11:00 → busy at the window). Standard objects, so the
+  same graph books on the scheduler org. Sets sched{Territory,WorkType,Account,ResourceA,ResourceB}Id.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000010
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"
+```
+
+- [ ] **Step 4: Add the fixture Kick to `SchedulerParityConfig`** (after `OLD_AUTH_CONFIG`)
+
+```java
+  static final Kick OLD_DOUBLE_BOOK_FIXTURE_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "fixtures/double-book");
+```
+
+- [ ] **Step 5: Add a fixture-only probe test method** to `SchedulerVsUnifiedParityE2ETest`
+
+```java
+  @Test
+  void oldDoubleBookFixtureInsertsE2E() {
+    SchedulerParityConfig.assumeBothOrgCreds();
+    final var rundown =
+        ReVoman.revUp(
+            SchedulerParityConfig.OLD_AUTH_CONFIG,
+            SchedulerParityConfig.OLD_DOUBLE_BOOK_FIXTURE_CONFIG);
+    final var env = CollectionsKt.last(rundown).mutableEnv;
+    assertThat(env.getAsString("schedResourceAId")).isNotEmpty();
+    assertThat(env.getAsString("schedResourceBId")).isNotEmpty();
+    assertThat(env.getAsString("schedTerritoryId")).isNotEmpty();
+  }
+```
+
+- [ ] **Step 6: Compile + run the fixture probe**
+
+Run: `cd ~/code-clones/work/revoman-root && gradle :compileIntegrationTestJava && gradle :integrationTest --tests '*SchedulerVsUnifiedParityE2ETest.oldDoubleBookFixtureInsertsE2E'`
+Expected: PASS; all five ids non-empty. If a composite step fails, the thrown message names the `referenceId` — fix that node (likely the SchedulingMethod picklist per Step 2, or the second-user requirement).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd ~/code-clones/work/revoman-root
+git add src/integrationTest
+git commit -m "test(scheduler-parity): old-side double-book fixture graph"
+```
+
+---
+
+### Task 3: Old-side READ act — getAppointmentSlots include/exclude decision
+
+Capture whether resourceB is INCLUDED in old-Scheduler's returned slots when named as a required resource vs excluded — the read half of the 1.5 diff.
+
+**Files:**
+- Create: `…/scheduler/booking/get-appointment-slots-double-book/.resources/definition.yaml`
+- Create: `…/scheduler/booking/get-appointment-slots-double-book/10-get-appointment-slots-double-book.request.yaml`
+- Modify: `SchedulerParityConfig.java` (add the read Kick)
+
+**Interfaces:**
+- Produces `SchedulerParityConfig.OLD_GET_SLOTS_DOUBLE_BOOK_CONFIG` (`Kick`); env keys: `oldReadWithBSlotCount` (slots when A+B both required), `oldReadAOnlySlotCount` (slots when only A required). Old read INCLUDES B ⟺ naming B as required does NOT drop the count to 0 relative to A-only… but per research the old path AND-intersects required resources, so B-as-required (busy) → 0; the "helper" (non-required) has no read-input representation on the old side. So the read decision we capture is: **does adding busy B as a required id zero out the slots** (proving old read applies availability to required resources) — the old-side analog of "would a helper be checked?".
+- Consumes: `schedResourceAId`, `schedResourceBId`, `schedTerritoryId`, `schedWorkTypeId` (Task 2), `versionPath`.
+
+- [ ] **Step 1: Create the read act** `…/get-appointment-slots-double-book/10-get-appointment-slots-double-book.request.yaml`
+
+```yaml
+$kind: http-request
+description: >-
+  OLD Salesforce Scheduler read: POST /scheduling/getAppointmentSlots twice over the double-book fixture,
+  tomorrow 11:00-11:30 UTC. Call 1 names BOTH resourceA (free) and resourceB (busy at 11:00) as
+  requiredResourceIds → the old engine AND-intersects required-resource availability, so B being busy
+  zeroes the slots. Call 2 names ONLY resourceA → slots > 0. This captures the old-side read decision
+  (a busy REQUIRED resource is availability-checked and excludes the slot) that the 1.5 parity diff
+  compares against the Unified read. NOTE: the old read has NO non-required "helper" input — every named
+  id is required — so the read-side probe is "required-and-busy zeroes vs A-only offers", per research.
+url: "{{baseUrl}}{{versionPath}}/scheduling/getAppointmentSlots"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "workType": { "id": "{{schedWorkTypeId}}" },
+      "territoryIds": ["{{schedTerritoryId}}"],
+      "requiredResourceIds": ["{{schedResourceAId}}", "{{schedResourceBId}}"],
+      "primaryResourceId": "{{schedResourceAId}}",
+      "startTime": "{{schedReadStart}}",
+      "endTime": "{{schedReadEnd}}"
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 0, 0, 0);
+      const e = new Date(s.getTime() + 30 * 60 * 1000);
+      pm.environment.set("schedReadStart", s.toISOString());
+      pm.environment.set("schedReadEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      const data = pm.response.json() || {};
+      const slots = (data.timeSlots || data.slots || []);
+      pm.environment.set("oldReadWithBSlotCount", String(slots.length));
+      console.log("OLD read A+B http=" + pm.response.code + " slots=" + slots.length);
+    language: text/javascript
+order: 1000
+```
+
+- [ ] **Step 2: Create the A-only control read** in the same folder, `20-get-appointment-slots-a-only.request.yaml`
+
+```yaml
+$kind: http-request
+description: >-
+  Control: OLD getAppointmentSlots naming ONLY resourceA (free) as required, same window. Proves the
+  fixture is bookable on the old side (slots > 0), so the A+B zero in step 10 is resourceB's busyness,
+  not a dead fixture. Captures oldReadAOnlySlotCount.
+url: "{{baseUrl}}{{versionPath}}/scheduling/getAppointmentSlots"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "workType": { "id": "{{schedWorkTypeId}}" },
+      "territoryIds": ["{{schedTerritoryId}}"],
+      "requiredResourceIds": ["{{schedResourceAId}}"],
+      "primaryResourceId": "{{schedResourceAId}}",
+      "startTime": "{{schedReadStart}}",
+      "endTime": "{{schedReadEnd}}"
+    }
+scripts:
+  - type: afterResponse
+    code: |-
+      const data = pm.response.json() || {};
+      const slots = (data.timeSlots || data.slots || []);
+      pm.environment.set("oldReadAOnlySlotCount", String(slots.length));
+      console.log("OLD read A-only http=" + pm.response.code + " slots=" + slots.length);
+    language: text/javascript
+order: 2000
+```
+
+- [ ] **Step 3: Create the read definition** `…/get-appointment-slots-double-book/.resources/definition.yaml`
+
+```yaml
+$kind: collection
+description: |-
+  OLD Scheduler getAppointmentSlots over the double-book fixture: A+B (B busy → 0 slots) vs A-only
+  (> 0 slots). Captures oldReadWithBSlotCount + oldReadAOnlySlotCount for the 1.5 read-decision diff.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000020
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"
+```
+
+- [ ] **Step 4: Add the read Kick to `SchedulerParityConfig`**
+
+```java
+  static final Kick OLD_GET_SLOTS_DOUBLE_BOOK_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/get-appointment-slots-double-book");
+```
+
+- [ ] **Step 5: Add a read-probe test method** to `SchedulerVsUnifiedParityE2ETest`
+
+```java
+  @Test
+  void oldReadDoubleBookDecisionE2E() {
+    SchedulerParityConfig.assumeBothOrgCreds();
+    final var rundown =
+        ReVoman.revUp(
+            SchedulerParityConfig.OLD_AUTH_CONFIG,
+            SchedulerParityConfig.OLD_DOUBLE_BOOK_FIXTURE_CONFIG,
+            SchedulerParityConfig.OLD_GET_SLOTS_DOUBLE_BOOK_CONFIG);
+    final var env = CollectionsKt.last(rundown).mutableEnv;
+    // Control proves the fixture is live; A+B zero proves the busy required resource is availability-checked.
+    assertThat(Integer.parseInt(env.getAsString("oldReadAOnlySlotCount"))).isGreaterThan(0);
+    assertThat(env.getAsString("oldReadWithBSlotCount")).isEqualTo("0");
+  }
+```
+
+- [ ] **Step 6: Compile + run**
+
+Run: `cd ~/code-clones/work/revoman-root && gradle :compileIntegrationTestJava && gradle :integrationTest --tests '*SchedulerVsUnifiedParityE2ETest.oldReadDoubleBookDecisionE2E'`
+Expected: PASS. If the A+B count is NOT 0, the old engine may union rather than intersect (the §1 open item in the spec) — record the observed count and switch the read assertion to characterize the observed old behavior (this is a finding, not a failure). If the endpoint 404s, confirm the `/scheduling/` path + version on the org (Task 1 `versionPath`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd ~/code-clones/work/revoman-root
+git add src/integrationTest
+git commit -m "test(scheduler-parity): old-side getAppointmentSlots read decision"
+```
+
+---
+
+### Task 4: Old-side WRITE acts — book non-required helper + required control
+
+Capture the old-Scheduler book outcome for a non-required busy helper (expected BOOKED) and its required control (expected REFUSED) — the write half of the 1.5 diff.
+
+**Files:**
+- Create: `…/scheduler/booking/service-appointments-double-book-non-required/{.resources/definition.yaml,10-book.request.yaml}`
+- Create: `…/scheduler/booking/service-appointments-double-book-required-control/{.resources/definition.yaml,10-book.request.yaml}`
+- Modify: `SchedulerParityConfig.java`
+
+**Interfaces:**
+- Produces `SchedulerParityConfig.OLD_BOOK_NON_REQUIRED_CONFIG`, `OLD_BOOK_REQUIRED_CONTROL_CONFIG` (`Kick`); env keys `oldWriteHelperHttp`, `oldWriteHelperSaId`, `oldWriteRequiredControlHttp`, `oldWriteRequiredControlSaId`.
+- Consumes: fixture ids (Task 2), `versionPath`, `adminToken`.
+
+- [ ] **Step 1: Create the non-required book act** `…/service-appointments-double-book-non-required/10-book.request.yaml`
+
+```yaml
+$kind: http-request
+description: >-
+  OLD Salesforce Scheduler book: POST /connect/scheduling/service-appointments, tomorrow 11:00-11:30 UTC,
+  with TWO assignedResources — resourceA (isRequiredResource=true, isPrimaryResource=true, free) and
+  resourceB (isRequiredResource=false, busy at 11:00). Per the object reference, a non-required resource
+  is "considered available for other appointments" — so the old engine should NOT availability-check B →
+  the SA books (HTTP 2xx, serviceAppointmentId returned). Captures oldWriteHelperHttp + oldWriteHelperSaId.
+url: "{{baseUrl}}{{versionPath}}/connect/scheduling/service-appointments"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  x-revoman-ledger: "off"
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "serviceAppointment": {
+        "serviceTerritoryId": "{{schedTerritoryId}}",
+        "parentRecordId": "{{schedAccountId}}",
+        "workTypeId": "{{schedWorkTypeId}}",
+        "schedStartTime": "{{schedBookStart}}",
+        "schedEndTime": "{{schedBookEnd}}",
+        "extendedFields": [ { "name": "Status", "value": "Scheduled" } ]
+      },
+      "assignedResources": [
+        { "serviceResourceId": "{{schedResourceAId}}", "isRequiredResource": true, "isPrimaryResource": true },
+        { "serviceResourceId": "{{schedResourceBId}}", "isRequiredResource": false, "isPrimaryResource": false }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 0, 0, 0);
+      const e = new Date(s.getTime() + 30 * 60 * 1000);
+      pm.environment.set("schedBookStart", s.toISOString());
+      pm.environment.set("schedBookEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      const data = pm.response.json() || {};
+      pm.environment.set("oldWriteHelperHttp", String(pm.response.code));
+      pm.environment.set("oldWriteHelperSaId", data.serviceAppointmentId || (data.serviceAppointment && data.serviceAppointment.id) || "");
+      console.log("OLD book helper http=" + pm.response.code + " body=" + JSON.stringify(data).slice(0,300));
+    language: text/javascript
+order: 1000
+```
+
+- [ ] **Step 2: Create the required-control book act** `…/service-appointments-double-book-required-control/10-book.request.yaml` — byte-identical to Step 1 EXCEPT resourceB's `isRequiredResource` flips to `true`, and the capture keys are `oldWriteRequiredControlHttp` / `oldWriteRequiredControlSaId`. The description states: "Control — resourceB flipped to isRequiredResource=true; a required busy resource IS availability-checked → the book is REFUSED (non-2xx / no serviceAppointmentId), proving the helper Success above is the non-required flag's effect."
+
+```yaml
+$kind: http-request
+description: >-
+  Control: OLD book with resourceB isRequiredResource=true (still busy at 11:00). A REQUIRED busy resource
+  IS availability-checked → the book is refused (non-2xx, no serviceAppointmentId). Isolates the helper
+  Success to the non-required flag. Captures oldWriteRequiredControlHttp + oldWriteRequiredControlSaId.
+url: "{{baseUrl}}{{versionPath}}/connect/scheduling/service-appointments"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  x-revoman-ledger: "off"
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "serviceAppointment": {
+        "serviceTerritoryId": "{{schedTerritoryId}}",
+        "parentRecordId": "{{schedAccountId}}",
+        "workTypeId": "{{schedWorkTypeId}}",
+        "schedStartTime": "{{schedBookStart}}",
+        "schedEndTime": "{{schedBookEnd}}",
+        "extendedFields": [ { "name": "Status", "value": "Scheduled" } ]
+      },
+      "assignedResources": [
+        { "serviceResourceId": "{{schedResourceAId}}", "isRequiredResource": true, "isPrimaryResource": true },
+        { "serviceResourceId": "{{schedResourceBId}}", "isRequiredResource": true, "isPrimaryResource": false }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 0, 0, 0);
+      const e = new Date(s.getTime() + 30 * 60 * 1000);
+      pm.environment.set("schedBookStart", s.toISOString());
+      pm.environment.set("schedBookEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      const data = pm.response.json() || {};
+      pm.environment.set("oldWriteRequiredControlHttp", String(pm.response.code));
+      pm.environment.set("oldWriteRequiredControlSaId", data.serviceAppointmentId || (data.serviceAppointment && data.serviceAppointment.id) || "");
+      console.log("OLD book required-control http=" + pm.response.code + " body=" + JSON.stringify(data).slice(0,300));
+    language: text/javascript
+order: 1000
+```
+
+- [ ] **Step 3: Create both definitions** (`…-non-required/.resources/definition.yaml` and `…-required-control/.resources/definition.yaml`), each:
+
+```yaml
+$kind: collection
+description: |-
+  OLD Scheduler book of the double-book fixture (see the request file). Runs under {{adminToken}}.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000030
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"
+```
+(Use id `…031` for the control folder.)
+
+- [ ] **Step 4: Add both Kicks to `SchedulerParityConfig`**
+
+```java
+  static final Kick OLD_BOOK_NON_REQUIRED_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/service-appointments-double-book-non-required");
+  static final Kick OLD_BOOK_REQUIRED_CONTROL_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/service-appointments-double-book-required-control");
+```
+
+- [ ] **Step 5: Add a write-probe test method** to `SchedulerVsUnifiedParityE2ETest` (fresh revUp per arm → no ServiceResource collision)
+
+```java
+  @Test
+  void oldWriteDoubleBookDecisionE2E() {
+    SchedulerParityConfig.assumeBothOrgCreds();
+    final var helperRundown =
+        ReVoman.revUp(
+            SchedulerParityConfig.OLD_AUTH_CONFIG,
+            SchedulerParityConfig.OLD_DOUBLE_BOOK_FIXTURE_CONFIG,
+            SchedulerParityConfig.OLD_BOOK_NON_REQUIRED_CONFIG);
+    final var helperEnv = CollectionsKt.last(helperRundown).mutableEnv;
+    // Non-required busy helper books (2xx + SA id).
+    assertThat(helperEnv.getAsString("oldWriteHelperSaId")).isNotEmpty();
+    final var controlRundown =
+        ReVoman.revUp(
+            SchedulerParityConfig.OLD_AUTH_CONFIG,
+            SchedulerParityConfig.OLD_DOUBLE_BOOK_FIXTURE_CONFIG,
+            SchedulerParityConfig.OLD_BOOK_REQUIRED_CONTROL_CONFIG);
+    final var controlEnv = CollectionsKt.last(controlRundown).mutableEnv;
+    // Required busy control is refused (no SA id).
+    assertThat(controlEnv.getAsString("oldWriteRequiredControlSaId")).isEmpty();
+  }
+```
+
+- [ ] **Step 6: Compile + run**
+
+Run: `cd ~/code-clones/work/revoman-root && gradle :compileIntegrationTestJava && gradle :integrationTest --tests '*SchedulerVsUnifiedParityE2ETest.oldWriteDoubleBookDecisionE2E'`
+Expected: PASS (helper books, control refused). If the control ALSO books (SA id non-empty), old Scheduler does NOT availability-check even required multi-resources on this path — record it; that is itself a divergence-vs-Unified finding. If the book endpoint needs `MultiResourceScheduling` enabled, confirm the org pref (spec §7 open item 3) — a `FIELD_INTEGRITY`/`INVALID_FIELD` on `isPrimaryResource` means the pref is off.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd ~/code-clones/work/revoman-root
+git add src/integrationTest
+git commit -m "test(scheduler-parity): old-side service-appointments book + control"
+```
+
+---
+
+### Task 5: The differential parity test — diff old vs 264, normalized verdicts
+
+Combine both orgs into one method: run the 264 double-book (reusing WFS Kicks), run the old-side read+write, normalize each side to `{readIncluded, writeOutcome}`, assert equal (or characterize divergence). Delete the temporary probe methods. Register in the ftest inventory if run via ftest-console.
+
+**Files:**
+- Modify: `SchedulerVsUnifiedParityE2ETest.java` (add the slice method; remove the 4 probe methods from Tasks 1-4, keeping `schedulerOrgAuthBindsE2E` optional as a smoke test)
+- Modify: `SchedulerParityConfig.java` (add a `Verdict` helper + normalizers)
+- Modify (if ftest-console is used): the module `ftest-inventory.xml`
+
+**Interfaces:**
+- Consumes: all old-side Kicks (Tasks 1-4) + `ReVomanConfigForWfs.{AUTH_CONFIG, AVAILABILITY_OP_HOURS_POLICY_CONFIG, DOUBLE_BOOK_FIXTURE_CONFIG, DOUBLE_BOOK_NON_REQUIRED_SCHEDULE_CONFIG, DOUBLE_BOOK_REQUIRED_CONFLICT_SCHEDULE_CONFIG}`.
+- Produces: `testHelperDoubleBookParity_1_5_E2E` (the slice gate).
+
+- [ ] **Step 1: Add verdict normalizers to `SchedulerParityConfig`**
+
+```java
+  /** Normalized read decision for a resource: was it offered/kept in the availability result? */
+  enum ReadDecision {
+    INCLUDED,
+    EXCLUDED
+  }
+
+  /** Normalized write outcome, comparable across old-REST and Unified error envelopes (guide R3). */
+  enum WriteOutcome {
+    BOOKED,
+    REFUSED,
+    CRASHED
+  }
+
+  /** Old side: a busy resource is INCLUDED iff naming it required did NOT zero the slot count. */
+  static ReadDecision oldReadDecision(final String withBusyCount) {
+    return "0".equals(withBusyCount) ? ReadDecision.EXCLUDED : ReadDecision.INCLUDED;
+  }
+
+  /** Old side: BOOKED iff an SA id came back; CRASHED on HTTP 500; else REFUSED. */
+  static WriteOutcome oldWriteOutcome(final String saId, final String http) {
+    if (saId != null && !saId.isBlank()) {
+      return WriteOutcome.BOOKED;
+    }
+    return "500".equals(http) ? WriteOutcome.CRASHED : WriteOutcome.REFUSED;
+  }
+
+  /** Unified side: schedulingStatus=="Success" → BOOKED; ScheduleError/PersistError → REFUSED; 500 → CRASHED. */
+  static WriteOutcome unifiedWriteOutcome(final String schedulingStatus, final String http) {
+    if ("Success".equals(schedulingStatus)) {
+      return WriteOutcome.BOOKED;
+    }
+    return "500".equals(http) ? WriteOutcome.CRASHED : WriteOutcome.REFUSED;
+  }
+```
+
+- [ ] **Step 2: Write the failing slice test** in `SchedulerVsUnifiedParityE2ETest`
+
+```java
+  /**
+   * Decision 1.5 parity — a busy NON-required helper. OLD Salesforce Scheduler vs 264 Unified OnSite
+   * (262 proxy) must agree on both axes: the busy helper BOOKS (not availability-checked) while a
+   * required busy control is REFUSED; and the read offers the fixture's slots only when the busy
+   * resource is not a hard required constraint. Old side: public Scheduler REST
+   * (/scheduling/getAppointmentSlots + /connect/scheduling/service-appointments). Unified side: the
+   * existing WFS double-book Connect acts. 262-proxy caveat: verdicts are 262-observed; a true-264 org
+   * may differ on locked-in crashes (1.4/3) — 1.5 is crash-free so unaffected. Divergence is a finding,
+   * asserted faithfully rather than forced.
+   */
+  @Test
+  void testHelperDoubleBookParity_1_5_E2E() {
+    SchedulerParityConfig.assumeBothOrgCreds();
+
+    // --- OLD side: read decision + write (helper) + write (required control), fresh revUps ---
+    final var oldReadEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_DOUBLE_BOOK_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_GET_SLOTS_DOUBLE_BOOK_CONFIG))
+            .mutableEnv;
+    final var oldReadDecision =
+        SchedulerParityConfig.oldReadDecision(oldReadEnv.getAsString("oldReadWithBSlotCount"));
+
+    final var oldHelperEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_DOUBLE_BOOK_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_BOOK_NON_REQUIRED_CONFIG))
+            .mutableEnv;
+    final var oldHelperOutcome =
+        SchedulerParityConfig.oldWriteOutcome(
+            oldHelperEnv.getAsString("oldWriteHelperSaId"),
+            oldHelperEnv.getAsString("oldWriteHelperHttp"));
+
+    // --- 264 side (262 proxy): reuse the proven WFS double-book acts, one revUp ---
+    final var unifiedEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    ReVomanConfigForWfs.AUTH_CONFIG,
+                    ReVomanConfigForWfs.AVAILABILITY_OP_HOURS_POLICY_CONFIG,
+                    ReVomanConfigForWfs.DOUBLE_BOOK_FIXTURE_CONFIG,
+                    ReVomanConfigForWfs.DOUBLE_BOOK_NON_REQUIRED_SCHEDULE_CONFIG,
+                    ReVomanConfigForWfs.DOUBLE_BOOK_REQUIRED_CONFLICT_SCHEDULE_CONFIG))
+            .mutableEnv;
+    final var unifiedHelperOutcome =
+        SchedulerParityConfig.unifiedWriteOutcome(
+            unifiedEnv.getAsString("doubleBookNonRequiredSchedulingStatus"), "201");
+
+    // --- PARITY: both products book the non-required busy helper (helper is NOT availability-checked) ---
+    assertThat(oldHelperOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.BOOKED);
+    assertThat(unifiedHelperOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.BOOKED);
+    assertThat(oldHelperOutcome).isEqualTo(unifiedHelperOutcome);
+    // Old read excludes the busy resource when it is a hard required id (the old-side availability proof).
+    assertThat(oldReadDecision).isEqualTo(SchedulerParityConfig.ReadDecision.EXCLUDED);
+    // Unified control (busy resource as required) is refused → the Unified availability proof.
+    assertThat(unifiedEnv.getAsString("doubleBookRequiredControlSchedulingStatus"))
+        .isNotEqualTo("Success");
+  }
+```
+
+- [ ] **Step 3: Run to verify it fails first for the RIGHT reason**
+
+Run: `cd ~/code-clones/work/revoman-root && gradle :compileIntegrationTestJava && gradle :integrationTest --tests '*SchedulerVsUnifiedParityE2ETest.testHelperDoubleBookParity_1_5_E2E'`
+Expected: initially may FAIL on a live-observed value differing from the hypothesis (e.g. old read union not intersect, or old control books). Per the control-first rule, inspect the captured env values in the run log BEFORE adjusting. If the observed old behavior is a genuine divergence from Unified, re-characterize the assertion to the observed verdicts and document the divergence in the method javadoc + the report — that is the deliverable, not a forced green.
+
+- [ ] **Step 4: Make it pass (agreement) or characterize (divergence)**
+
+If both sides BOOK the helper and the controls/read behave as hypothesized → the assertions above pass; parity confirmed. If they diverge, replace the equality assertion with the observed pair and add a `<p>DIVERGENCE:` javadoc paragraph naming which side does what and the captured verdicts.
+
+- [ ] **Step 5: Remove the temporary probe methods**
+
+Delete `oldDoubleBookFixtureInsertsE2E`, `oldReadDoubleBookDecisionE2E`, `oldWriteDoubleBookDecisionE2E` from `SchedulerVsUnifiedParityE2ETest` (their coverage is now inside the slice). Keep `schedulerOrgAuthBindsE2E` as a lightweight smoke test.
+
+- [ ] **Step 6: Re-run the full class green**
+
+Run: `cd ~/code-clones/work/revoman-root && gradle :integrationTest --tests '*SchedulerVsUnifiedParityE2ETest'`
+Expected: both methods PASS (or the slice faithfully characterizes a divergence, still green).
+
+- [ ] **Step 7: Register in ftest-inventory (only if run via ftest-console)**
+
+If this suite is discovered via a module `ftest-inventory.xml` (as the WFS suite is), add `SchedulerVsUnifiedParityE2ETest` there. If it runs purely as a gradle `integrationTest` JUnit class (like its WFS siblings), skip — no inventory entry needed.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd ~/code-clones/work/revoman-root
+git add src/integrationTest
+git commit -m "test(scheduler-parity): 1.5 double-book helper parity slice (old vs 264)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Two-org differential harness → Task 1 (`SchedulerParityConfig`, second creds overlay, `assumeBothOrgCreds`). ✓
+- Old side = public Scheduler REST (reads `/scheduling/getAppointmentSlots`, write `/connect/scheduling/service-appointments`) → Tasks 3, 4. ✓
+- 264 side = 262 proxy, reuse WFS Kicks → Task 5. ✓
+- Verdict contract (INCLUDED/EXCLUDED, BOOKED/REFUSED/CRASHED), normalized-not-raw (R3) → Task 5 Step 1. ✓
+- Control per scenario (non-vacuous) → Tasks 3 (A-only), 4 (required control), 5. ✓
+- Vertical slice = 1.5 → Tasks 2-5. ✓
+- Divergence handled as first-class characterization → Task 5 Steps 3-4. ✓
+- Creds-absent skip, license/collision hygiene (fresh revUp per write arm) → Tasks 1, 4, 5. ✓
+- 262-proxy caveat stamped in javadoc → Task 5 Step 2. ✓
+- Spec §7 open items surfaced as run-time decision points → Task 2 Step 2 (SchedulingMethod/second user), Task 3 Step 6 (AND-vs-union), Task 4 Step 6 (MultiResourceScheduling pref). ✓
+
+**Placeholder scan:** No TBD/TODO. Each code step carries complete file content or an exact clone+edit recipe (Task 2 clones an in-repo 300-line graph — the edits are enumerated exactly rather than re-pasting, since the engineer copies a real file). Endpoint bodies grounded in the authoritative dev-guide shapes from research.
+
+**Type consistency:** `ReadDecision`/`WriteOutcome` enums + `oldReadDecision`/`oldWriteOutcome`/`unifiedWriteOutcome` signatures defined in Task 5 Step 1 match their uses in Step 2. Env keys are consistent across producer (yaml `pm.environment.set`) and consumer (Java `getAsString`): `oldReadWithBSlotCount`, `oldReadAOnlySlotCount`, `oldWriteHelperSaId`, `oldWriteHelperHttp`, `oldWriteRequiredControlSaId`, `sched{Territory,WorkType,Account,ResourceA,ResourceB}Id`, and the reused WFS `doubleBookNonRequiredSchedulingStatus`/`doubleBookRequiredControlSchedulingStatus`. Kick field names match `SchedulerParityConfig` declarations.
+
+**Known residual unknowns (resolve live, all flagged in-task):** (a) old getAppointmentSlots AND-vs-union semantics; (b) SchedulingMethod picklist validity + second-user availability on the scheduler org; (c) MultiResourceScheduling org pref on the scheduler org; (d) exact old response field names (`timeSlots` vs `slots`, `serviceAppointmentId` vs nested) — the scripts defensively read both.

--- a/docs/superpowers/specs/2026-07-03-scheduler-vs-unified-1x-parity-design.md
+++ b/docs/superpowers/specs/2026-07-03-scheduler-vs-unified-1x-parity-design.md
@@ -1,0 +1,150 @@
+# Salesforce Scheduler ↔ Unified (264) — `1.*` Helper-Fitness Parity: Design
+
+**Date:** 2026-07-03
+**Author:** Gopal S Akshintala (with Claude, brainstorming session)
+**Branch:** `wfs/decision-1-9-revoman-tests` (revoman-root)
+**Status:** DESIGN — approved through Sections 1–3; vertical slice (1.5) to be built first.
+
+**Relates to:**
+- `docs/superpowers/2026-06-30-wfs-parity-test-report.md` — the 262↔264 Unified read/write parity report; source of the `1.*` scenario catalogue.
+- `~/work/docs/scheduler-to-unified-parity-guide.md` — the plain-language Scheduler→Unified mapping guide (risks R1–R8, §6 recipe).
+- `src/integrationTest/java/com/salesforce/revoman/integration/core/wfs/WfsWritePathParityE2ETest.java` — existing single-org WFS suite whose fixtures/personas the 264 side reuses.
+
+---
+
+## 0. Problem & scope
+
+The 262↔264 report characterized the `1.*` "helper-fitness" family **on the Unified write path only** (single org, one shared engine). The new goal: compare the **older Salesforce Scheduler** (a.k.a. Lightning Scheduler) product against **264 Unified OnSite** for the same `1.*` scenarios — the first cut of a broader Scheduler↔Unified parity effort.
+
+`1.*` scenarios (from the report):
+- **1a** Excluded — helper on the account's block-list.
+- **1b** Territory — helper's territory doesn't cover the window.
+- **1c** Skills — helper lacks a required skill.
+- **1d** Working-locations — helper is a Secondary territory member under a primary-only policy.
+- **1.4** Required-resources — account demands a resource, met only by a helper.
+- **1.5** Availability / double-book — helper is busy at the window.
+
+The single question underneath all six: **does the scheduling engine fitness-check / availability-check a NON-required "helper" resource?** The lever is `AssignedResource.isRequiredResource` (± `isPrimaryResource`).
+
+**In scope (this design):** the two-org differential harness + the `1.5` vertical slice end-to-end. **Out of scope (next steps):** the other five `1.*` scenarios (fan out from the slice template) and the read-only guide risks R1/R6/R7.
+
+---
+
+## 1. Research findings that shaped this design (do NOT re-litigate)
+
+Three code-grounded + docs-grounded research passes established:
+
+1. **Old Salesforce Scheduler HAS the non-required "helper" concept.** Authoritative public object reference on `AssignedResource.IsRequiredResource`: *"If this field is set to false, Salesforce Scheduler considers the resource as available for other appointments."* Plus `IsPrimaryResource` (v47+), "primary must be required," max 5 required (1 primary + 4). Confirmed internally (CSGPAK "required or optional attendee"). *(An earlier read-input-only analysis wrongly concluded the concept was absent; the helper model lives on the write/persist side — AssignedResource rows.)*
+
+2. **Old Salesforce Scheduler HAS a booking path.** `POST /connect/scheduling/service-appointments` (Connect API) with an `assignedResources[]` array carrying `isRequiredResource`/`isPrimaryResource`; also Apex `ConnectApi.createServiceAppointment` and raw DML. Canonical flow: work-type-groups → territories → `getAppointmentCandidates` → `getAppointmentSlots` → POST service-appointments.
+
+3. **The OnSite engines are SEPARATE re-implementations.** Old `scheduling-impl.SchedulingServiceImpl` (serves both the `appointmentbooking` connect API and the public Scheduler `/scheduling/*` REST) vs Unified `unified-scheduling-impl.InBusinessAppointmentSlotCalculator` — near-twin algorithms, **zero shared engine code**, independent feature gates. So parity is **NOT** guaranteed by construction and can drift. *(This inverts the report's "read==write because one shared engine" thesis — here divergence is genuinely possible, which is exactly what makes the test valuable.)*
+
+4. **Old save-time fitness is minimal.** `LightningSchedulerAssignedResourceValidator` (fieldservice-impl) enforces only *primary⇒required* and *one-primary*; **no** skills/territory/availability check at write. Fitness is read-time only. So structurally the old side, like Unified 262, books a non-required helper regardless of fitness.
+
+**Open item to pin during authoring (not blocking):** old `getAppointmentSlots` intersects (AND) all named resources (`containsAll` gate, `SchedulingServiceImpl:517-522`), whereas an internal IAM spike describes multi-resource "any-available" (union). Likely different operations (slots-for-a-crew vs candidates). Resolve when building the read act; pick the operation whose semantics let the helper-vs-required distinction surface.
+
+---
+
+## 2. Architecture
+
+**Thesis.** Because the two OnSite engines are independent re-implementations, `1.*` parity is a real, un-guaranteed surface. Each test diffs the **old-Scheduler** decision against the **264-Unified** decision on BOTH the read (include/exclude) and write (book/refuse) axes, per scenario.
+
+**Parity hypothesis (H0).** Both products treat a non-required helper as non-reserved and non-fitness-checked (helper books regardless of the rule; a required resource is checked). Each test asserts old-decision == 264-decision; a mismatch is the finding.
+
+**Sides:**
+- **Old side = scheduler org** (`orgfarm-0c6bcb96c0…crm.dev:6101`), driven via **public Scheduler REST**.
+- **264 side = 262 org** (`orgfarm-4dbef90d6c…crm.dev:6101`) as the Unified proxy — endpoints identical 262↔264, reusing the proven `WfsWritePathParityE2ETest` harness.
+
+**Both orgs are local-bound** (verified: both 200 from the same workspace frontdoor host; localhost:6101 up), so ReVoman external-org mode (in-JVM SDB bind) works for both — same harness family as the existing WFS suite. (psql client not currently on PATH — a resolve-at-impl detail, not a blocker.)
+
+```
+                 ┌─────────────────── ONE scenario ───────────────────┐
+ scheduler org ─▶│ OLD Scheduler REST          │ 262 org ─▶ Unified    │
+ (old side)      │  read:  /scheduling/         │  read: get-appointment-slots/-candidates
+                 │    getAppointmentSlots        │  write:/unified-scheduling/actions/schedule
+                 │    getAppointmentCandidates   │                       │
+                 │  write:/connect/scheduling/   │                       │
+                 │    service-appointments       │                       │
+                 └──────┬───────────────────────┴──────────┬────────────┘
+                        ▼                                    ▼
+              old {readDecision, writeOutcome}    264 {readDecision, writeOutcome}
+                        └──────── assert equal / record divergence ───────┘
+```
+
+---
+
+## 3. Components
+
+New package `com.salesforce.revoman.integration.core.scheduler` (sibling to `…/core/wfs`). Four units:
+
+1. **`SchedulerParityConfig`** — the ONLY unit aware of two orgs. Exposes `OLD_SCHEDULER_AUTH` + `UNIFIED_AUTH` credential/baseURL sets, each resolved from `~/.revoman/config.yaml` via the existing `ExternalOrgConfig` overlay; `assumeExternalOrgCreds()` JUnit-skips when creds absent. Mirrors `ReVomanConfigForWfs`.
+
+2. **Old-Scheduler fixtures + acts** (Postman V3 dirs) — the genuinely new content. Per scenario: policy fixture, resource/territory/skill fixture, read act (`getAppointmentSlots`/`getAppointmentCandidates`), write act (`service-appointments`). Modeled on the existing `wfs/booking/*` + `wfs/policies/*` layout.
+
+3. **264-side fixtures + acts** — REUSE existing `WfsWritePathParityE2ETest` fixtures unchanged (for the slice: `DOUBLE_BOOK_*` configs). No new 264 content for the slice.
+
+4. **`SchedulerVsUnifiedParityE2ETest`** — the differential test class. Per scenario: `revUp` old-side + `revUp` 264-side, capture normalized verdicts, assert equal (or characterize divergence).
+
+**Verdict contract (uniform across scenarios):**
+- **readDecision** = is resourceB present in returned slots/candidates? `INCLUDED` / `EXCLUDED` (absence-among-a-live-set, stronger than empty).
+- **writeOutcome** = `BOOKED` / `REFUSED` / `CRASHED` (+ errorCode captured to env for the report, but excluded from the equality assertion).
+- Every scenario carries a **control** (resourceB flipped to required) proving the fixture is live — non-vacuous guardrail.
+
+---
+
+## 4. Vertical slice — `1.5` (Availability / double-book)
+
+**Why 1.5 first:** cleanly constructible on the old read path (per-resource unavailability applies to every pooled resource — research-confirmed) AND the 264 half already has a proven fixture (`DOUBLE_BOOK_*` in `testNonRequiredHelperDoubleBooksE2E`). Only the old-Scheduler half + the two-org diff mechanics are new. Its A/B (flip only `isRequiredResource` on a busy resourceB) is the report's clearest helper-vs-required demonstration — highest-signal slice.
+
+**Method:** `testHelperDoubleBookParity_1_5_E2E`.
+
+```
+OLD-SCHEDULER revUp (scheduler org)              264 revUp (262 org)
+1. OLD_SCHEDULER_AUTH (SOAP v64 login)           1. UNIFIED_AUTH (AUTH_CONFIG)
+2. seed policy + territory/OH/shift              2. AVAILABILITY_OP_HOURS_POLICY_CONFIG
+3. resourceA required+primary (free);            3. DOUBLE_BOOK_FIXTURE_CONFIG (reuse)
+   resourceB busy at window
+4. READ getAppointmentSlots[reqIds=A,B]          4. READ get-appointment-slots → unifiedReadIncluded
+   → oldReadIncluded (B present?)
+5. WRITE service-appointments, B non-required    5. WRITE schedule B non-req (DOUBLE_BOOK_NON_REQUIRED)
+   → oldWriteStatus                                 → unifiedWriteStatus
+6. control: B required                           6. control: B required (DOUBLE_BOOK_REQUIRED_CONFLICT)
+```
+
+**Assertion:** `oldReadIncluded == unifiedReadIncluded` AND `oldWriteStatus ≈ unifiedWriteStatus` (normalized verdicts). Expected under H0: both {helper busy → BOOKED + INCLUDED; required busy → REFUSED + EXCLUDED}. Agreement → parity confirmed for 1.5; divergence → the finding, characterized faithfully.
+
+**Slice gate:** green `testHelperDoubleBookParity_1_5_E2E` = the both-orgs harness is proven; the remaining five fan out from this exact template.
+
+---
+
+## 5. Data flow, divergence handling, error handling
+
+**Verdict normalization (load-bearing).** Old REST reports `isError`/`errorMessage` + HTTP; Unified reports `schedulingStatus` + per-item `errors[]`. The equality assertion compares NORMALIZED verdicts (`BOOKED/REFUSED/CRASHED`, `INCLUDED/EXCLUDED`), never raw codes (guide R3). Raw codes captured to env for the report only.
+
+**Divergence — three first-class outcomes:**
+1. **Agree** → parity confirmed; assert equality.
+2. **Diverge, reproducible** → the finding. Assert observed verdicts on each side faithfully (characterization), document in javadoc + report.
+3. **Old side un-constructible** for a scenario (e.g. candidates-path-only account preference, primary-only skill matching) → mark `PARTIAL`, assert what IS constructible, log the gap explicitly. No silent skips.
+
+**Error / edge handling:**
+- Creds absent → `assumeExternalOrgCreds()` JUnit-skips (both orgs).
+- License churn (timestamped users → `LICENSE_LIMIT_EXCEEDED`) → fresh-per-scenario personas + documented deactivate-stale-`@revoman.org` recovery; now applies to BOTH orgs.
+- 262-as-264-proxy caveat → stamped in every javadoc: verdicts are 262-observed; a true-264 org may differ on the locked-in crashes (1.4/3). Slice (1.5) is crash-free → unaffected.
+- Old-side crash (if old engine NPEs) → captured as `CRASHED`, itself a parity data point.
+
+## 6. Testing
+
+- **Slice gate:** `testHelperDoubleBookParity_1_5_E2E` green in external-org mode (fast loop), confirmed once with both orgs live.
+- **Control-first discipline:** verify each control RED for the intended reason before trusting the positive GREEN (vacuous-proof lesson: the required-busy control MUST actually be refused).
+- **Registration:** new class → `ftest-inventory.xml` if run via ftest-console; ReVoman JUnit otherwise.
+- **Scope honesty:** only the slice ships first; the other five `1.*` + read-only guide risks (R1/R6/R7) are explicit next steps, not silently dropped.
+
+---
+
+## 7. Open questions / next steps
+
+1. Pin the old read operation (slots-AND vs candidates-any-available) so the helper-vs-required distinction surfaces cleanly (§1 open item).
+2. Confirm the public Scheduler REST version on the scheduler org (v66 in the appointmentbooking spec `info.version`; verify the live org accepts it; SOAP login uses v64 per prior WFS work).
+3. Confirm `MultiResourceScheduling` org pref is enabled on the scheduler org (gates `IsPrimaryResource`; required for the multi-resource book) and `WorkforceSchdMulResSchdPref` on the 262 org.
+4. After the slice proves the harness: fan out 1b, 1d (clean), then 1a, 1c, 1.4 (path-dependent partials).

--- a/src/integrationTest/java/com/salesforce/revoman/integration/core/scheduler/SchedulerParityConfig.java
+++ b/src/integrationTest/java/com/salesforce/revoman/integration/core/scheduler/SchedulerParityConfig.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026 salesforce.com, inc.
+ * All Rights Reserved
+ * Company Confidential
+ */
+
+package com.salesforce.revoman.integration.core.scheduler;
+
+import static com.salesforce.revoman.input.config.StepPick.PostTxnStepPick.afterStepContainingHeader;
+import static com.salesforce.revoman.integration.core.CoreUtils.ASSERT_COMPOSITE_GRAPH_RESPONSE_SUCCESS;
+import static com.salesforce.revoman.integration.core.CoreUtils.ASSERT_COMPOSITE_RESPONSE_SUCCESS;
+import static com.salesforce.revoman.integration.core.CoreUtils.unmarshallCompositeGraphResponse;
+import static com.salesforce.revoman.integration.core.CoreUtils.unmarshallCompositeResponse;
+import static com.salesforce.revoman.output.ExeType.HTTP_STATUS;
+
+import com.salesforce.revoman.input.ExternalOrgConfig;
+import com.salesforce.revoman.input.config.Kick;
+import com.salesforce.revoman.integration.core.adapters.IDAdapter;
+import com.salesforce.revoman.integration.core.wfs.ReVomanConfigForWfs;
+import java.util.Map;
+import org.junit.jupiter.api.Assumptions;
+
+/**
+ * Two-org config seam for the Salesforce Scheduler ↔ Unified(264) {@code 1.*} helper-fitness parity
+ * tests. The OLD side (scheduler org) is driven over public Scheduler REST; the 264 side reuses the
+ * existing {@link ReVomanConfigForWfs} Unified Kicks against the 262 org (endpoints identical 262↔264 per the parity effort).
+ * The two OnSite engines are SEPARATE re-implementations (old {@code
+ * scheduling-impl.SchedulingServiceImpl} vs {@code unified-scheduling-impl.InBusinessAppointmentSlotCalculator}),
+ * so parity is not guaranteed by construction — these tests assert it.
+ *
+ * <p>The old side reads its creds from {@code ~/.revoman/scheduler-config.yaml} (a SECOND external-org
+ * file, distinct from the {@code ~/.revoman/config.yaml} the Unified side uses). Both files live in
+ * {@code $HOME}, never committed; absent creds → the tests JUnit-skip via {@link #assumeBothOrgCreds}.
+ */
+public final class SchedulerParityConfig {
+
+  private SchedulerParityConfig() {}
+
+  /** OLD scheduler-org creds overlay, read once from {@code ~/.revoman/scheduler-config.yaml}. */
+  static final Map<String, Object> SCHEDULER_ORG_CONFIG =
+      ExternalOrgConfig.readExternalOrgConfig(
+          System.getProperty("user.home") + "/.revoman/scheduler-config.yaml");
+
+  static final String V3_SCHEDULER_PATH = "pm-templates/v3/core/scheduler/";
+  static final String ENV_PATH = V3_SCHEDULER_PATH + "scheduler.environment.yaml";
+  static final String NODE_MODULE_RELATIVE_PATH = "js";
+  static final String IGNORE_HTTP_STATUS_UNSUCCESSFUL = "ignoreHTTPStatusUnsuccessful";
+
+  static final Kick OLD_AUTH_CONFIG = oldKickFor(V3_SCHEDULER_PATH + "auth");
+  static final Kick OLD_DOUBLE_BOOK_FIXTURE_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "fixtures/double-book");
+
+  /**
+   * Shared Lightning-Scheduler user-access grant, DRY-consolidated out of the read and write booking
+   * collections into its own Kick. The classic engine ({@code SchedulingServiceImpl
+   * .removeResourcesWithoutPerm}) prunes every ServiceResource whose backing User lacks the {@code
+   * lightningSchedulerUserAccess} user-perm on the REST path, so BOTH the read and the write revUp this
+   * Kick right after {@link #OLD_DOUBLE_BOOK_FIXTURE_CONFIG} to keep the fixture resources alive.
+   */
+  static final Kick OLD_GRANT_LS_ACCESS_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/grant-ls-user-access");
+  static final Kick OLD_GET_SLOTS_DOUBLE_BOOK_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/get-appointment-slots-double-book");
+  static final Kick OLD_BOOK_NON_REQUIRED_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/service-appointments-double-book-non-required");
+  static final Kick OLD_BOOK_REQUIRED_CONTROL_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/service-appointments-double-book-required-control");
+
+  /**
+   * Skip (JUnit assumption) unless BOTH orgs' creds are present: the Unified side reads {@code
+   * ~/.revoman/config.yaml} and the old side reads {@code ~/.revoman/scheduler-config.yaml} (here).
+   * Either missing → skip, not fail.
+   */
+  static void assumeBothOrgCreds() {
+    // Check WFS creds (262 org) — read directly since EXTERNAL_ORG_CONFIG is package-private in
+    // ReVomanConfigForWfs (cross-package not visible).
+    final var wfsConfig = ExternalOrgConfig.readExternalOrgConfig();
+    Assumptions.assumeTrue(
+        hasText(wfsConfig, "baseUrl") && hasText(wfsConfig, "username") && hasText(wfsConfig, "password"),
+        "WFS external-org creds absent — set ~/.revoman/config.yaml (baseUrl/username/password)."
+            + " Skipping.");
+    // Check scheduler creds
+    Assumptions.assumeTrue(
+        schedulerHasText("baseUrl") && schedulerHasText("username") && schedulerHasText("password"),
+        "Scheduler-org creds absent — set ~/.revoman/scheduler-config.yaml (baseUrl/username/password)."
+            + " Skipping.");
+  }
+
+  private static boolean hasText(final Map<String, Object> config, final String key) {
+    final var value = config.get(key);
+    return value != null && !value.toString().isBlank();
+  }
+
+  private static boolean schedulerHasText(final String key) {
+    return hasText(SCHEDULER_ORG_CONFIG, key);
+  }
+
+  /** Normalized read decision for a resource: was it offered/kept in the availability result? */
+  enum ReadDecision {
+    INCLUDED,
+    EXCLUDED
+  }
+
+  /** Normalized write outcome, comparable across old-REST and Unified error envelopes (guide R3). */
+  enum WriteOutcome {
+    BOOKED,
+    REFUSED,
+    CRASHED
+  }
+
+  /** Old side: a busy resource is INCLUDED iff naming it required did NOT zero the slot count. */
+  static ReadDecision oldReadDecision(final String withBusyCount) {
+    return "0".equals(withBusyCount) ? ReadDecision.EXCLUDED : ReadDecision.INCLUDED;
+  }
+
+  /** Old side: BOOKED iff an SA id came back; CRASHED on HTTP 500; else REFUSED. */
+  static WriteOutcome oldWriteOutcome(final String saId, final String http) {
+    if (saId != null && !saId.isBlank()) {
+      return WriteOutcome.BOOKED;
+    }
+    return "500".equals(http) ? WriteOutcome.CRASHED : WriteOutcome.REFUSED;
+  }
+
+  /** Unified side: schedulingStatus=="Success" → BOOKED; ScheduleError/PersistError → REFUSED; 500 → CRASHED. */
+  static WriteOutcome unifiedWriteOutcome(final String schedulingStatus, final String http) {
+    if ("Success".equals(schedulingStatus)) {
+      return WriteOutcome.BOOKED;
+    }
+    return "500".equals(http) ? WriteOutcome.CRASHED : WriteOutcome.REFUSED;
+  }
+
+  /** Old-side Kick: same wiring as {@link ReVomanConfigForWfs} but overlaying the SCHEDULER creds. */
+  private static Kick oldKickFor(final String templatePath) {
+    return Kick.configure()
+        .templatePath(templatePath)
+        .environmentPath(ENV_PATH)
+        .dynamicEnvironment(SCHEDULER_ORG_CONFIG)
+        .responseConfig(unmarshallCompositeGraphResponse(), unmarshallCompositeResponse())
+        .hooks(ASSERT_COMPOSITE_GRAPH_RESPONSE_SUCCESS, ASSERT_COMPOSITE_RESPONSE_SUCCESS)
+        .globalCustomTypeAdapter(IDAdapter.INSTANCE)
+        .nodeModulesPath(NODE_MODULE_RELATIVE_PATH)
+        .haltOnFailureOfTypeExcept(
+            HTTP_STATUS, afterStepContainingHeader(IGNORE_HTTP_STATUS_UNSUCCESSFUL))
+        .insecureHttp(true)
+        .off();
+  }
+}

--- a/src/integrationTest/java/com/salesforce/revoman/integration/core/scheduler/SchedulerParityConfig.java
+++ b/src/integrationTest/java/com/salesforce/revoman/integration/core/scheduler/SchedulerParityConfig.java
@@ -135,6 +135,135 @@ public final class SchedulerParityConfig {
   static final Kick OLD_BOOK_REQUIRED_NON_REQUIRED_CONFIG =
       oldKickFor(V3_SCHEDULER_PATH + "booking/service-appointments-required-non-required");
 
+  // ======================================================================================
+  // Fan-out Decisions 2 / 3 / 4 / 4z / 5 / 8 / 9 — old-side Kick declarations.
+  // ======================================================================================
+
+  // ## Decision 2 (slot promise) — is a SHOWN time-slot a real promise? An intra-product read↔write
+  // consistency check over a SINGLE resource: an AVAILABLE window (inside member OH ∪ Shift 08-16 →
+  // read offers slots ⟺ book Succeeds) vs an UNAVAILABLE window (outside those hours → read 0 slots ⟺
+  // book Refused). The fixture is single-resource; the read is single-resource getAppointmentSlots
+  // (requiredResourceIds=[A], NO primaryResourceId — the classic engine rejects a primary that also
+  // appears required); the two book acts book resourceA (required+primary) into each window. The
+  // fixture sets schedResourceBId = schedResourceAId so the shared grant-ls-user-access Kick (grants
+  // BOTH resource users) runs unchanged. See {@link
+  // SchedulerVsUnifiedParityE2ETest#testSlotPromiseParity_2_E2E}.
+  static final Kick OLD_PROMISE_FIXTURE_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "fixtures/promise-helper");
+  static final Kick OLD_GET_SLOTS_PROMISE_AVAILABLE_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/get-appointment-slots-promise-available");
+  static final Kick OLD_GET_SLOTS_PROMISE_UNAVAILABLE_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/get-appointment-slots-promise-unavailable");
+  static final Kick OLD_BOOK_PROMISE_AVAILABLE_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/service-appointments-promise-available");
+  static final Kick OLD_BOOK_PROMISE_UNAVAILABLE_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/service-appointments-promise-unavailable");
+
+  // ## Decision 3 — a single AssignedResource sent OMITTING isRequiredResource entirely. On 264 the
+  // missing-flag payload CRASHES (Boolean.booleanValue() NPE, HTTP 500 INTERNAL_SERVER_ERROR). The OLD
+  // probe reuses the double-book fixture (fresh users + grant chain, resourceA FREE at the 11:00 window
+  // so availability does not confound) and books a SINGLE resourceA: Act A OMITS isRequiredResource (the
+  // parity question — does OLD also crash, or degrade gracefully?), and Act B (doc L142 control) sends a
+  // single isRequiredResource=true with NO isPrimaryResource → must BOOK (proves the fixture is live).
+  static final Kick OLD_BOOK_MISSING_REQUIRED_FLAG_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/service-appointments-missing-required-flag");
+  static final Kick OLD_BOOK_SINGLE_REQUIRED_NO_PRIMARY_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/service-appointments-single-required-no-primary");
+
+  // ## Decision 4 — two "primary" workers on ONE appointment are rejected. Multi-resource scheduling
+  // requires EXACTLY one primary. The fixture seeds TWO clean, fully-available PRIMARY-eligible resources
+  // (both member OH + Confirmed Shift 10-14, covering the 11:00-11:30 window) so availability is NOT the
+  // discriminator — only the primary-count rule is. The two-primary book act sends both AssignedResources
+  // isPrimaryResource=true → REFUSED. LIVE-OBSERVED: the OLD connect API rejects at INPUT validation with
+  // errorCode INVALID_API_INPUT / HTTP 400, "Only one assignedResource can have isPrimaryResource set to
+  // true…" (no booking). The one-primary control (A primary + B non-primary, both free) BOOKS (non-vacuity).
+  // Both engines reject at connect-API INPUT validation (pre-persist) at HTTP 400 — 264 with INVALID_INPUT,
+  // OLD with INVALID_API_INPUT — so the WHERE coincides and only the errorCode + message text differ; the
+  // OUTCOME is parity: both refuse two primaries, no booking. See {@link
+  // SchedulerVsUnifiedParityE2ETest#testTwoPrimaryParity_4_E2E}.
+  static final Kick OLD_TWO_PRIMARY_FIXTURE_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "fixtures/two-primary-helper");
+  static final Kick OLD_BOOK_TWO_PRIMARY_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/service-appointments-two-primary");
+  static final Kick OLD_BOOK_ONE_PRIMARY_CONTROL_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/service-appointments-one-primary-control");
+
+  // ## Decision 4z — a reschedule can leave an appointment with NO primary worker. The classic
+  // Scheduler exposes NO reschedule connect API; "rescheduling" on the old side is direct DML/REST on
+  // the SA's AssignedResource rows. So the OLD analog is: (fixture) a CLEAN two-resource SA where BOTH
+  // resources are available at the window, (book) create it with resourceA primary+required + resourceB
+  // required and capture the AR ids, then (delete-primary) DELETE the primary AssignedResource and
+  // (demote-primary) PATCH it to IsPrimaryResource=false — each attempting to leave the SA with no
+  // primary. The old-side enforcement is the SAVE-TIME LightningSchedulerAssignedResourceValidator:
+  // validatePrimaryAssignedResourceOnDelete BLOCKS deleting a primary AR (FIELD_INTEGRITY_EXCEPTION
+  // "AssignedResourceDelete"), while validateAssignedResourceOnSave guards only primary-must-be-required
+  // and at-most-one-primary (no "must keep a primary" rule). The 264 side reuses the proven WFS
+  // reschedule-no-primary acts (validation ALLOWS zero primaries; validatePrimaryResourceCount throws
+  // only when primaryCount > 1). See {@link
+  // SchedulerVsUnifiedParityE2ETest#testRescheduleNoPrimaryParity_4z_E2E}.
+  static final Kick OLD_RESCHEDULE_HELPER_FIXTURE_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "fixtures/reschedule-helper");
+  static final Kick OLD_BOOK_CLEAN_TWO_RESOURCE_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/service-appointments-clean-two-resource");
+  static final Kick OLD_AR_DELETE_PRIMARY_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/assignedresource-delete-primary");
+  static final Kick OLD_AR_DEMOTE_PRIMARY_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/assignedresource-demote-primary");
+
+  // * NOTE 2026-07-03 gopal.akshintala: Decision 5 (primary-not-required) — a single AssignedResource
+  // * marked isPrimaryResource=true BUT isRequiredResource=false is a contradiction. The window is FREE
+  // * (availability passes), so the classic book path inserts the AssignedResource row and the SAVE-TIME
+  // * LightningSchedulerAssignedResourceValidator (fieldservice-impl — the SAME validator 264 hits on
+  // * this API/Apex/DML) rejects it ("Only an required service resource can be set as a primary service
+  // * resource."). Probe: single primary + NOT required → REFUSED. Control: flip isRequiredResource=true
+  // * → BOOKED (isolates the reject to the not-required flag). Single-resource fixture, so only resourceA
+  // * is needed and it is fully available over the 11:00-11:30 window.
+  static final Kick OLD_PRIMARY_NOT_REQUIRED_FIXTURE_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "fixtures/primary-not-required-helper");
+  static final Kick OLD_BOOK_PRIMARY_NOT_REQUIRED_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/service-appointments-primary-not-required");
+  static final Kick OLD_BOOK_PRIMARY_REQUIRED_CONTROL_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/service-appointments-primary-required-control");
+
+  // ## Decision 8 — resourceLimitApptDistribution cap on the load-balancing candidates read path
+  // (read-only). The OLD classic engine has NO SchedulingObjective/SchedulingPolicyObjective (those are
+  // Unified-only); its load-balancing cap instead lives behind an AppointmentAssignmentPolicy(loadBalancing)
+  // SETUP record whose FK on the AppointmentSchedulingPolicy flips
+  // SchedulingServiceImpl.getAppointmentCandidatesForTerritoryWorkTypes onto the smart-scheduling path
+  // (SmartSchedulerServiceImpl.getServiceResourceByResourceLimitApptDistribution → getLeastUtilizedResources
+  // → subList(0, N)). The cap engages ONLY when filterByResources is EMPTY, the policy carries that FK, AND
+  // the org has smart scheduling enabled (SsAppointmentDistribution pref + AppointmentDistribution perm) — so
+  // the fixture seeds the assignment policy + policy FK, and the reads omit filterByResources. limit=0 →
+  // subList(0,0) → empty (a literal cap-of-0, matching 264's Stream.limit(0)); limit=50 (> 2 seeded
+  // resources) → no trim → pool returned. See
+  // {@link SchedulerVsUnifiedParityE2ETest#testResourceLimitCapParity_8_E2E}.
+  static final Kick OLD_LIMIT_FIXTURE_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "fixtures/limit-helper");
+  static final Kick OLD_GET_CANDIDATES_LIMIT_ZERO_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/get-candidates-limit-zero");
+  static final Kick OLD_GET_CANDIDATES_LIMIT_POSITIVE_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/get-candidates-limit-positive");
+
+  // * NOTE 2026-07-03 gopal.akshintala: Decision 9 (Shift sharing-mode split) — the classic-engine
+  // * mirror of the WFS auth-personas-dec9 machinery. Unlike the 1.* helper-fitness scenarios (single
+  // * admin session), Decision 9 is a CROSS-PERSONA sharing question, so the old side mints TWO real
+  // * personas with their OWN SOAP sessions (a MANAGER who OWNS the Private fixture rows + a sharing-
+  // * deprived CASE-WORKER) plus an admin-created resource-owner User, then runs the SAME classic
+  // * getAppointmentSlots read as each persona over the manager-owned fixture. The parity crux (source-
+  // * confirmed, scheduling-impl): the classic engine reads SHIFTS in FULL-access mode
+  // * (SoqlUtil.runSoqlWithoutMruUpdate single-arg → SFDC_FULL, ShiftsDbUtil.getShiftEntities) while its
+  // * STM/ServiceResource read is the user-mode gate (SystemMode.NONE, gated by orgHasDepriveSoqlAccess)
+  // * — the INVERSE of 264, whose SHIFT read is the user-mode gate. So old never gates on the shift; the
+  // * observable slot-count split (if any) comes from the STM/ServiceResource sharing gate instead.
+  static final Kick OLD_AUTH_PERSONAS_DEC9_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "auth-personas-old");
+  static final Kick OLD_SHARING_SPLIT_FIXTURE_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "fixtures/sharing-split-helper");
+  static final Kick OLD_GET_SLOTS_SHARING_AS_MANAGER_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/get-appointment-slots-sharing-as-manager");
+  static final Kick OLD_GET_SLOTS_SHARING_AS_CASEWORKER_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/get-appointment-slots-sharing-as-caseworker");
+
   /**
    * Skip (JUnit assumption) unless BOTH orgs' creds are present: the Unified side reads {@code
    * ~/.revoman/config.yaml} and the old side reads {@code ~/.revoman/scheduler-config.yaml} (here).
@@ -177,9 +306,93 @@ public final class SchedulerParityConfig {
     CRASHED
   }
 
+  /**
+   * Decision 4z normalized outcome for a "leave the appointment with no primary" attempt, comparable
+   * across the OLD sObject DELETE/PATCH probes and the 264 reschedule API: LEFT_NO_PRIMARY means the
+   * appointment ended with zero primary workers (the state the doc says should be impossible), BLOCKED
+   * means a rule refused the change (2xx never happened, or the primary survived), CRASHED means an
+   * HTTP 500 / INTERNAL_SERVER_ERROR.
+   */
+  enum NoPrimaryOutcome {
+    LEFT_NO_PRIMARY,
+    BLOCKED,
+    CRASHED
+  }
+
+  /**
+   * Decision-9 sharing-gate verdict, shared by both engines: does a sharing-DEPRIVED reader (the
+   * case-worker, no sharing on the private fixture rows) get GATED (zero slots, HTTP 200, no error) or
+   * does it read the SAME availability as the privileged reader (OPEN)? On 264 this gate is the SHIFT
+   * user-mode read; on OLD classic it is the STM/ServiceResource user-mode read (the shift read is
+   * full-access) — same observable (zero slots) via an INVERTED axis.
+   */
+  enum SharingGate {
+    GATED,
+    OPEN
+  }
+
   /** Old side: a busy resource is INCLUDED iff naming it required did NOT zero the slot count. */
   static ReadDecision oldReadDecision(final String withBusyCount) {
     return "0".equals(withBusyCount) ? ReadDecision.EXCLUDED : ReadDecision.INCLUDED;
+  }
+
+  /**
+   * Old side (Decision 8): did the load-balancing {@code resourceLimitApptDistribution} cap actually
+   * engage? It engaged iff the limit=0 probe returned an EMPTY resource pool ({@code "0"}) WHILE the
+   * positive-limit control still returned resources (&gt; 0). If the org lacks smart scheduling the
+   * classic engine never takes the load-balancing branch, so limit=0 does NOT empty the pool (both counts
+   * &gt; 0) → cap did not engage (a configuration nuance, not a divergence in the cap semantics).
+   */
+  static boolean oldLimitCapEngaged(final String limitZeroCount, final String limitPositiveCount) {
+    final var positiveOffered =
+        limitPositiveCount != null
+            && !limitPositiveCount.isBlank()
+            && !"0".equals(limitPositiveCount);
+    return "0".equals(limitZeroCount) && positiveOffered;
+  }
+
+  /**
+   * A sharing-deprived reader is GATED iff its slot count is "0" on an HTTP-200 (no-error) read — the
+   * silent empty-availability contract. A non-zero count is OPEN (sees availability despite lacking
+   * sharing). A non-200 is neither (it is an access/perm error, not the silent sharing gate) →
+   * reported as OPEN=false via GATED only on the clean-empty case.
+   */
+  static SharingGate sharingGate(final String slotCount, final String http) {
+    return "0".equals(slotCount) && "200".equals(http) ? SharingGate.GATED : SharingGate.OPEN;
+  }
+
+  /**
+   * Old side (sObject DELETE/PATCH probe): LEFT_NO_PRIMARY iff the mutation succeeded (HTTP 2xx, no
+   * errorCode) AND the post-mutation state confirms no surviving primary ({@code primaryGone} is "1");
+   * CRASHED on HTTP 500; otherwise BLOCKED (a save-validator rejection kept a primary).
+   */
+  static NoPrimaryOutcome oldNoPrimaryOutcome(
+      final String http, final String errorCode, final String primaryGone) {
+    if ("500".equals(http)) {
+      return NoPrimaryOutcome.CRASHED;
+    }
+    final var httpOk = http != null && http.startsWith("2");
+    final var noError = errorCode == null || errorCode.isBlank();
+    return (httpOk && noError && "1".equals(primaryGone))
+        ? NoPrimaryOutcome.LEFT_NO_PRIMARY
+        : NoPrimaryOutcome.BLOCKED;
+  }
+
+  /**
+   * 264 side (reschedule API): LEFT_NO_PRIMARY iff the reschedule returned Success (persisting a
+   * no-primary crew); CRASHED on HTTP 500 / INTERNAL_SERVER_ERROR; otherwise BLOCKED (validation or the
+   * downstream availability re-check refused it). Note: on 262 (the proxy) the delete-primary arms are
+   * BLOCKED by the availability re-check, NOT by any no-primary rule — validation itself ALLOWS zero
+   * primaries; that validation-layer permissiveness is the 264 fact the parity diff turns on.
+   */
+  static NoPrimaryOutcome unifiedNoPrimaryOutcome(
+      final String schedulingStatus, final String errorCode, final String http) {
+    if ("Success".equals(schedulingStatus)) {
+      return NoPrimaryOutcome.LEFT_NO_PRIMARY;
+    }
+    return ("500".equals(http) || "INTERNAL_SERVER_ERROR".equals(errorCode))
+        ? NoPrimaryOutcome.CRASHED
+        : NoPrimaryOutcome.BLOCKED;
   }
 
   /** Old side: BOOKED iff an SA id came back; CRASHED on HTTP 500; else REFUSED. */

--- a/src/integrationTest/java/com/salesforce/revoman/integration/core/scheduler/SchedulerParityConfig.java
+++ b/src/integrationTest/java/com/salesforce/revoman/integration/core/scheduler/SchedulerParityConfig.java
@@ -66,6 +66,75 @@ public final class SchedulerParityConfig {
   static final Kick OLD_BOOK_REQUIRED_CONTROL_CONFIG =
       oldKickFor(V3_SCHEDULER_PATH + "booking/service-appointments-double-book-required-control");
 
+  // ## Scenario 1b (Territory) — old-side Kicks. resourceB is a non-required helper whose
+  // ServiceTerritoryMember coverage does NOT include the booking window (membership narrowed to end at
+  // noon while the window straddles noon), so only the classic engine's territory/STM-membership filter
+  // could exclude it. resourceA is a clean primary member covering the whole window. The fixture Kick
+  // runs the composite/graph then a follow-up STM-narrowing PATCH; the read/book Kicks reuse the shared
+  // grant-ls-user-access prerequisite exactly as the 1.5 double-book slice does.
+  static final Kick OLD_TERRITORY_FIXTURE_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "fixtures/territory-helper");
+  static final Kick OLD_GET_SLOTS_TERRITORY_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/get-appointment-slots-territory");
+  static final Kick OLD_BOOK_TERRITORY_NON_REQUIRED_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/service-appointments-territory-non-required");
+  static final Kick OLD_BOOK_TERRITORY_REQUIRED_CONTROL_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/service-appointments-territory-required-control");
+
+  // ## 1d WorkingLocations (territory-member ROLE) — a Secondary ('S') member helper under a PRIMARY-ONLY
+  // AppointmentSchedulingPolicy. The fixture seeds the primary-only policy AND the P/S member graph; the
+  // read/book acts pass its id via schedulingPolicyId so the classic STM filter drops the Secondary
+  // resourceB by its ROLE (SchedulingDbUtil.createPrimarySecondarySTMWhereCondition → TerritoryType IN
+  // ('P','R')) — not by availability, and not as a non-member.
+  static final Kick OLD_WORKLOC_FIXTURE_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "fixtures/workloc-helper");
+  static final Kick OLD_GET_SLOTS_WORKLOC_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/get-appointment-slots-workloc");
+  static final Kick OLD_BOOK_WORKLOC_NON_REQUIRED_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/service-appointments-workloc-non-required");
+  static final Kick OLD_BOOK_WORKLOC_REQUIRED_CONTROL_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/service-appointments-workloc-required-control");
+
+  // * NOTE 2026-07-03 gopal.akshintala: 1a (Excluded / account block-list) Kicks. The Excluded rule is
+  // * account-scoped (ResourcePreference PreferenceType='Excluded'), enforced on the OLD side ONLY on the
+  // * getAppointmentCandidates read path (checkResourcePrefs prunes the excluded SR); plain
+  // * getAppointmentSlots and the classic service-appointments book path pass accountResourcePreferences=null
+  // * → the rule short-circuits true. Hence the read probe is getAppointmentCandidates (with accountId), and
+  // * the write probe characterizes the (unenforced) book outcome.
+  static final Kick OLD_EXCLUDED_FIXTURE_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "fixtures/excluded-helper");
+  static final Kick OLD_GET_CANDIDATES_EXCLUDED_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/get-candidates-excluded");
+  static final Kick OLD_BOOK_EXCLUDED_NON_REQUIRED_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/service-appointments-excluded-non-required");
+
+  // ## 1c (Skills) — the WorkType requires a Skill; skilled resourceA holds a ServiceResourceSkill,
+  // skill-less resourceB has none. skills-helper is a TWO-Kick-shaped fixture (05-create-skill runs the
+  // SETUP-object Skill in its own transaction under adminToken — MIXED_DML forbids it inside the
+  // non-setup graph — then 10-create-skills-helper-graph builds the rest and FK-references the Skill).
+  static final Kick OLD_SKILLS_FIXTURE_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "fixtures/skills-helper");
+  // Three read shapes: 10 single skill-less B → EXCLUDED (old single path skill-checks it → proves the
+  // rule exists), 20 single skilled A → INCLUDED (non-vacuity), 30 multi A-primary + B-required-helper →
+  // B ESCAPES (old multi path skill-checks the primary ONLY → parity with 264 helper-escapes).
+  static final Kick OLD_GET_SLOTS_SKILLS_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/get-appointment-slots-skills");
+  static final Kick OLD_BOOK_SKILLS_NON_REQUIRED_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/service-appointments-skills-non-required");
+
+  // ## Decision 1.4 — Required-resources: the account (ResourcePreference Required) demands a SPECIFIC
+  // worker (resourceB), which is present ONLY as a NON-required helper. resourceA (required+primary) is
+  // clean but is NOT the account-required worker. On the OLD classic engine the account Required pref is a
+  // candidate-POOL FILTER (SchedulingDbUtil.checkResourcePrefs keeps only the account's required set), read
+  // via getAppointmentCandidates — semantically distinct from the 264 "helper must SATISFY a demand"
+  // satisfier rule. See {@link SchedulerVsUnifiedParityE2ETest#testHelperRequiredResourceParity_1_4_E2E}.
+  static final Kick OLD_REQUIRED_HELPER_FIXTURE_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "fixtures/required-helper");
+  static final Kick OLD_GET_CANDIDATES_REQUIRED_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/get-candidates-required");
+  static final Kick OLD_BOOK_REQUIRED_NON_REQUIRED_CONFIG =
+      oldKickFor(V3_SCHEDULER_PATH + "booking/service-appointments-required-non-required");
+
   /**
    * Skip (JUnit assumption) unless BOTH orgs' creds are present: the Unified side reads {@code
    * ~/.revoman/config.yaml} and the old side reads {@code ~/.revoman/scheduler-config.yaml} (here).
@@ -127,6 +196,45 @@ public final class SchedulerParityConfig {
       return WriteOutcome.BOOKED;
     }
     return "500".equals(http) ? WriteOutcome.CRASHED : WriteOutcome.REFUSED;
+  }
+
+  /**
+   * Old side (candidates path): a resource is INCLUDED iff it appears in at least one candidate's {@code
+   * resources[]}. The getAppointmentCandidates read prunes an account-Excluded ServiceResource, so an
+   * excluded resource comes back {@code "0"} (present-flag) → EXCLUDED. Used by 1a where the rule is
+   * account ResourcePreference(Excluded), enforced only on the candidates read path.
+   */
+  static ReadDecision oldCandidatesReadDecision(final String resourcePresentFlag) {
+    return "1".equals(resourcePresentFlag) ? ReadDecision.INCLUDED : ReadDecision.EXCLUDED;
+  }
+
+  /**
+   * Unified side (Decision 1.4), normalizing from the error ENVELOPE rather than HTTP: the 264 violating
+   * write returns a top-level {@code [{errorCode:"INTERNAL_SERVER_ERROR", ...}]} (a serviceTerritoryMembers
+   * NPE) → CRASHED; a schedulingStatus=="Success" → BOOKED; anything else → REFUSED.
+   */
+  static WriteOutcome unifiedWriteOutcomeFromErrorCode(
+      final String schedulingStatus, final String errorCode) {
+    if ("Success".equals(schedulingStatus)) {
+      return WriteOutcome.BOOKED;
+    }
+    return "INTERNAL_SERVER_ERROR".equals(errorCode) ? WriteOutcome.CRASHED : WriteOutcome.REFUSED;
+  }
+
+  /**
+   * Old-side read decision for the Required-resources (1.4) candidates path, normalizing to the write
+   * vocabulary so the read↔write divergence is directly comparable: an HTTP 500 / errorCode
+   * INTERNAL_SERVER_ERROR is CRASHED (would match the 264 write); a clean 0-candidate response is REFUSED;
+   * a non-empty candidate list is BOOKED (offered).
+   */
+  static WriteOutcome oldCandidatesOutcome(
+      final String candidateCount, final String http, final String errorCode) {
+    if ("500".equals(http) || "INTERNAL_SERVER_ERROR".equals(errorCode)) {
+      return WriteOutcome.CRASHED;
+    }
+    return (candidateCount != null && !"0".equals(candidateCount) && !candidateCount.isBlank())
+        ? WriteOutcome.BOOKED
+        : WriteOutcome.REFUSED;
   }
 
   /** Old-side Kick: same wiring as {@link ReVomanConfigForWfs} but overlaying the SCHEDULER creds. */

--- a/src/integrationTest/java/com/salesforce/revoman/integration/core/scheduler/SchedulerVsUnifiedParityE2ETest.java
+++ b/src/integrationTest/java/com/salesforce/revoman/integration/core/scheduler/SchedulerVsUnifiedParityE2ETest.java
@@ -21,6 +21,14 @@ import org.junit.jupiter.api.Test;
  */
 class SchedulerVsUnifiedParityE2ETest {
 
+  // * NOTE 2026-07-03 gopal.akshintala: Decision 4z demote-arm expectations, PINNED to the LIVE-observed
+  // * scheduler-org result (set after the first clean run — the classic engine's PATCH-demote behavior is
+  // * characterized, not assumed). See testRescheduleNoPrimaryParity_4z_E2E's Arm 2.
+  private static final String EXPECTED_DEMOTE_HTTP = "204";
+  private static final String EXPECTED_DEMOTE_PRIMARY_COUNT = "0";
+  private static final SchedulerParityConfig.NoPrimaryOutcome EXPECTED_DEMOTE_OUTCOME =
+      SchedulerParityConfig.NoPrimaryOutcome.LEFT_NO_PRIMARY;
+
   @Test
   void schedulerOrgAuthBindsE2E() {
     SchedulerParityConfig.assumeBothOrgCreds();
@@ -667,5 +675,868 @@ class SchedulerVsUnifiedParityE2ETest {
     // OLD ≠ 264 on both axes — a crash-vs-clean divergence, asserted verbatim, NOT forced to a green. ---
     assertThat(oldReadOutcome).isNotEqualTo(unifiedViolatingOutcome);
     assertThat(oldWriteOutcome).isNotEqualTo(unifiedViolatingOutcome);
+  }
+
+  /**
+   * Decision 2 (slot promise) parity — is a SHOWN time-slot a real promise on the shared cheap checks
+   * (skill / territory / free-busy / location / availability)? This is largely an INTRA-product read↔write
+   * consistency check, run on BOTH products: over a SINGLE resource, an AVAILABLE window (inside the
+   * resource's hours) and an UNAVAILABLE window (outside). The read↔write agreement under test is: {@code
+   * read-offers-slot ⟺ write-succeeds} AND {@code read-hides-slot ⟺ write-refused}. Both products call the
+   * same slot-gen for the read and RE-CHECK availability on the book, so a shown slot is a genuine promise
+   * on the cheap checks — the read and write paths agree.
+   *
+   * <p>Old side: public Scheduler REST over a single-resource fixture (resourceA available 08-16). The
+   * AVAILABLE read ({@code POST /scheduling/getAppointmentSlots}, window 11:00-11:30 inside 08-16) offers
+   * &gt;0 slots and the AVAILABLE book ({@code POST /connect/scheduling/service-appointments}) Succeeds; the
+   * UNAVAILABLE read (window 17:00-17:30 outside 08-16) offers 0 slots and the UNAVAILABLE book is Refused.
+   * Unified side (262 proxy): the existing WFS Decision-2 acts — {@code GET_SLOTS_PARITY_AVAILABLE} / {@code
+   * GET_SLOTS_PARITY_UNAVAILABLE} read + {@code SCHEDULE_PARITY_AVAILABLE} / {@code
+   * SCHEDULE_PARITY_UNAVAILABLE} write over the same availability-op-hours policy + required-non-required
+   * fixture (member OH 08-16), asserting the identical read↔write agreement.
+   *
+   * <p>KEY PARITY FINDING (both products agree): a shown slot IS a promise on the shared availability cheap
+   * check. On BOTH old Scheduler and 264 Unified the read↔write agreement holds — read INCLUDED ⟺ write
+   * BOOKED on the available window, read EXCLUDED ⟺ write REFUSED on the unavailable window — and the two
+   * products' agreement MATCHES. Decision 2 parity CONFIRMED.
+   *
+   * <p>262-proxy caveat: the 264 verdict is 262-observed and stands in for 264 (endpoints identical
+   * 262↔264 per the parity effort). Decision 2 is crash-free (a clean availability cheap check), so it is
+   * unaffected by the 262-specific INTERNAL_SERVER_ERROR crash caveats (1.4 / 3). A divergence, were it to
+   * appear, is a first-class finding asserted faithfully rather than forced to a green.
+   *
+   * <p>Constructibility: CLEANLY CONSTRUCTIBLE on the old read path — the single-resource availability
+   * cheap check is exactly what old getAppointmentSlots runs, and the classic book path re-checks it, so the
+   * old side proves read↔write on the same shared check the 264 side does. (The doc's field-match
+   * "shown-but-rejected" half — Match Fields / Boolean / Extended Match — is NOT characterizable on 262
+   * through these endpoints; it is out of Decision 2's cheap-check scope, see the WFS test javadoc.)
+   *
+   * <p>Old-side revUps mint 1 fresh {@code sched-promise-a-*@revoman.org} user per run and never clean up;
+   * four old-side revUps here (avail read + unavail read + avail book + unavail book) → ~4 fresh users/run.
+   * The leading success guard ({@code firstUnIgnoredUnsuccessfulStepReport() == null}) surfaces a rolled-back
+   * fixture/grant loudly at the fixture step; the read/book acts carry {@code ignoreHTTPStatusUnsuccessful}
+   * so legit 400s / empty reads (a refusal) do not trip it.
+   */
+  @Test
+  void testSlotPromiseParity_2_E2E() {
+    SchedulerParityConfig.assumeBothOrgCreds();
+
+    // --- OLD side: read (available + unavailable), fresh revUp ---
+    // AUTH → FIXTURE (single resource, available 08-16) → GRANT (Lightning-Scheduler user-access, else the
+    // classic engine prunes the resource → dead 0-slot read) → READ (available window + unavailable window).
+    final var oldReadEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_PROMISE_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_GRANT_LS_ACCESS_CONFIG,
+                    SchedulerParityConfig.OLD_GET_SLOTS_PROMISE_AVAILABLE_CONFIG,
+                    SchedulerParityConfig.OLD_GET_SLOTS_PROMISE_UNAVAILABLE_CONFIG))
+            .mutableEnv;
+    // oldReadDecision(count): "0" → EXCLUDED, else INCLUDED. Available window shows the resource; the
+    // unavailable window hides it.
+    final var oldReadAvailDecision =
+        SchedulerParityConfig.oldReadDecision(oldReadEnv.getAsString("oldPromiseReadAvailCount"));
+    final var oldReadUnavailDecision =
+        SchedulerParityConfig.oldReadDecision(oldReadEnv.getAsString("oldPromiseReadUnavailCount"));
+    // Non-vacuity: the AVAILABLE read MUST offer >0 slots, proving the fixture + the Lightning-Scheduler
+    // grant are live. Without this, a silently-failed grant would zero BOTH reads → the unavailable
+    // read-hides axis would pass for the WRONG reason (dead read, not the window being outside hours).
+    assertThat(oldReadEnv.getAsString("oldPromiseReadAvailCount")).isNotEqualTo("0");
+
+    // --- OLD side: write (available), fresh revUp → Success (a shown slot is a promise) ---
+    final var oldWriteAvailEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_PROMISE_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_GRANT_LS_ACCESS_CONFIG,
+                    SchedulerParityConfig.OLD_BOOK_PROMISE_AVAILABLE_CONFIG))
+            .mutableEnv;
+    final var oldWriteAvailOutcome =
+        SchedulerParityConfig.oldWriteOutcome(
+            oldWriteAvailEnv.getAsString("oldPromiseWriteAvailSaId"),
+            oldWriteAvailEnv.getAsString("oldPromiseWriteAvailHttp"));
+
+    // --- OLD side: write (unavailable), fresh revUp → Refused (a hidden slot is not offered) ---
+    final var oldWriteUnavailEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_PROMISE_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_GRANT_LS_ACCESS_CONFIG,
+                    SchedulerParityConfig.OLD_BOOK_PROMISE_UNAVAILABLE_CONFIG))
+            .mutableEnv;
+    final var oldWriteUnavailOutcome =
+        SchedulerParityConfig.oldWriteOutcome(
+            oldWriteUnavailEnv.getAsString("oldPromiseWriteUnavailSaId"),
+            oldWriteUnavailEnv.getAsString("oldPromiseWriteUnavailHttp"));
+
+    // --- 264 side (262 proxy): reuse the proven WFS Decision-2 read + write acts, one revUp ---
+    final var unifiedEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    ReVomanConfigForWfs.AUTH_CONFIG,
+                    ReVomanConfigForWfs.AVAILABILITY_OP_HOURS_POLICY_CONFIG,
+                    ReVomanConfigForWfs.REQUIRED_NON_REQUIRED_FIXTURE_CONFIG,
+                    ReVomanConfigForWfs.GET_SLOTS_PARITY_AVAILABLE_CONFIG,
+                    ReVomanConfigForWfs.GET_SLOTS_PARITY_UNAVAILABLE_CONFIG,
+                    ReVomanConfigForWfs.SCHEDULE_PARITY_UNAVAILABLE_CONFIG,
+                    ReVomanConfigForWfs.SCHEDULE_PARITY_AVAILABLE_CONFIG))
+            .mutableEnv;
+    final var unifiedReadAvailDecision =
+        SchedulerParityConfig.oldReadDecision(unifiedEnv.getAsString("parityReadAvailSlotCount"));
+    final var unifiedReadUnavailDecision =
+        SchedulerParityConfig.oldReadDecision(unifiedEnv.getAsString("parityReadUnavailSlotCount"));
+    final var unifiedWriteAvailOutcome =
+        SchedulerParityConfig.unifiedWriteOutcome(
+            unifiedEnv.getAsString("parityWriteAvailStatus"), "201");
+    final var unifiedWriteUnavailOutcome =
+        SchedulerParityConfig.unifiedWriteOutcome(
+            unifiedEnv.getAsString("parityWriteUnavailStatus"), "400");
+
+    // --- PARITY: a shown slot is a real promise on BOTH products (read↔write agree on the cheap checks) ---
+    // Shape guard: the old-side AVAILABLE booking must return a real ServiceAppointment id (18-char, 08p
+    // prefix), so BOOKED reflects a genuine persist, not an empty pass.
+    assertThat(oldWriteAvailEnv.getAsString("oldPromiseWriteAvailSaId")).hasLength(18);
+    assertThat(oldWriteAvailEnv.getAsString("oldPromiseWriteAvailSaId")).startsWith("08p");
+    // The UNAVAILABLE booking must NOT return an SA id (a genuine refusal, not a silent book elsewhere).
+    assertThat(oldWriteUnavailEnv.getAsString("oldPromiseWriteUnavailSaId")).isEmpty();
+
+    // OLD read↔write agreement: available shown ⟺ booked; unavailable hidden ⟺ refused.
+    assertThat(oldReadAvailDecision).isEqualTo(SchedulerParityConfig.ReadDecision.INCLUDED);
+    assertThat(oldWriteAvailOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.BOOKED);
+    assertThat(oldReadUnavailDecision).isEqualTo(SchedulerParityConfig.ReadDecision.EXCLUDED);
+    assertThat(oldWriteUnavailOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.REFUSED);
+
+    // 264 read↔write agreement: the SAME shape (shown ⟺ booked, hidden ⟺ refused).
+    assertThat(unifiedReadAvailDecision).isEqualTo(SchedulerParityConfig.ReadDecision.INCLUDED);
+    assertThat(unifiedWriteAvailOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.BOOKED);
+    assertThat(unifiedReadUnavailDecision).isEqualTo(SchedulerParityConfig.ReadDecision.EXCLUDED);
+    assertThat(unifiedWriteUnavailOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.REFUSED);
+
+    // The two products' read↔write agreement MATCHES on both windows → Decision 2 parity CONFIRMED.
+    assertThat(oldReadAvailDecision).isEqualTo(unifiedReadAvailDecision);
+    assertThat(oldWriteAvailOutcome).isEqualTo(unifiedWriteAvailOutcome);
+    assertThat(oldReadUnavailDecision).isEqualTo(unifiedReadUnavailDecision);
+    assertThat(oldWriteUnavailOutcome).isEqualTo(unifiedWriteUnavailOutcome);
+  }
+
+  /**
+   * Decision 3 parity — an AssignedResource sent OMITTING the {@code isRequiredResource} flag entirely.
+   * A single resourceA (FREE at the window) is booked with NO {@code isRequiredResource} (and no {@code
+   * isPrimaryResource}). Does OLD Salesforce Scheduler ALSO crash like 264, or does it degrade
+   * gracefully? Paired with the doc L142 control (a single {@code isRequiredResource=true}, no {@code
+   * isPrimaryResource}) which MUST book valid on both engines. Old side: public Scheduler REST ({@code
+   * POST /connect/scheduling/service-appointments}) over the double-book fixture (fresh users + the
+   * Lightning-Scheduler grant; resourceA's member OH + Confirmed Shift 10:00-14:00 cover the 11:00-11:30
+   * window, so availability does not confound the missing-flag probe). Unified side: the existing WFS
+   * Decision-3 Kicks ({@code MISSING_REQUIRED_FLAG_SCHEDULE_CONFIG} → 264 crash, {@code
+   * SINGLE_REQUIRED_NO_PRIMARY_SCHEDULE_CONFIG} → the L142 Success control).
+   *
+   * <p>KEY PARITY FINDING (crash-vs-clean DIVERGENCE — like 1.4, and even sharper): the 264 Unified
+   * write CRASHES on the omitted flag — errorCode {@code INTERNAL_SERVER_ERROR}, HTTP 500, a {@code
+   * Boolean.booleanValue()} NPE ("because the return value of common.api.soap.Entity.getField(String) is
+   * null"), the locked-in 262 missing-flag NPE. The OLD classic engine does NOT crash: it degrades
+   * gracefully with a CLEAN, TARGETED input-validation refusal — LIVE-OBSERVED {@code POST
+   * /connect/scheduling/service-appointments} returns HTTP 400, errorCode {@code INVALID_API_INPUT},
+   * message "Specify a valid value for isRequiredResource and try again." (it NAMES the exact missing
+   * field), no ServiceAppointment id and NOT a 500. So OLD ≠ 264 on the write axis — a crash-vs-clean
+   * divergence (both pinned verbatim: the 264 raw NPE, and the OLD field-naming clean refusal), NOT
+   * forced to a green. Both engines agree on the L142 control (single required, no primary → BOOKED /
+   * Success), which isolates the divergence to the OMITTED flag: the SAME omitted-flag payload the OLD
+   * engine catches at input validation and rejects cleanly, 264 lets through to a raw server NPE.
+   *
+   * <p>262-proxy caveat: this is the SHARPEST 262-proxy case (with 1.4) — the 264 side is a LOCKED-IN
+   * 262 INTERNAL_SERVER_ERROR crash observed on the 262 org that stands in for 264 (endpoints identical
+   * 262↔264 per the parity effort). A true-264 org is expected to FIX this missing-flag NPE (treat a
+   * missing {@code isRequiredResource} as not-required and handle it cleanly, or validate it up front as
+   * the OLD engine already does), in which case the 264 side would converge toward the OLD
+   * clean-refusal/clean-handle behavior and this scenario would flip from a crash-vs-clean divergence to
+   * parity. The divergence is asserted as OBSERVED on 262, faithfully — the OLD engine's clean
+   * INVALID_API_INPUT refusal is arguably the reference behavior the 264 fix should match.
+   *
+   * <p>Old-side revUps mint 2 fresh {@code sched-res-*@revoman.org} users per run and never clean up; two
+   * old-side revUps here (missing-flag + L142 control) → ~4 fresh users/run. The leading success guard
+   * ({@code firstUnIgnoredUnsuccessfulStepReport() == null}) surfaces a rolled-back fixture/grant loudly
+   * at the fixture step; the book acts carry {@code ignoreHTTPStatusUnsuccessful} so a legit non-2xx (a
+   * refusal or a 500 crash) is characterized rather than tripping the guard.
+   */
+  @Test
+  void testMissingRequiredFlagParity_3_E2E() {
+    SchedulerParityConfig.assumeBothOrgCreds();
+
+    // --- OLD side: Act A (missing isRequiredResource) + Act B (L142 control), fresh revUps ---
+    // Each old-side revUp mirrors AUTH → FIXTURE (double-book, fresh users) → GRANT (Lightning-Scheduler
+    // user-access, else the classic engine prunes the fixture resources → dead book) → BOOK.
+    final var oldMissingFlagEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_DOUBLE_BOOK_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_GRANT_LS_ACCESS_CONFIG,
+                    SchedulerParityConfig.OLD_BOOK_MISSING_REQUIRED_FLAG_CONFIG))
+            .mutableEnv;
+    final var oldMissingFlagOutcome =
+        SchedulerParityConfig.oldWriteOutcome(
+            oldMissingFlagEnv.getAsString("oldMissingFlagSaId"),
+            oldMissingFlagEnv.getAsString("oldMissingFlagHttp"));
+
+    final var oldControlEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_DOUBLE_BOOK_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_GRANT_LS_ACCESS_CONFIG,
+                    SchedulerParityConfig.OLD_BOOK_SINGLE_REQUIRED_NO_PRIMARY_CONFIG))
+            .mutableEnv;
+    final var oldControlOutcome =
+        SchedulerParityConfig.oldWriteOutcome(
+            oldControlEnv.getAsString("oldSingleRequiredNoPrimarySaId"),
+            oldControlEnv.getAsString("oldSingleRequiredNoPrimaryHttp"));
+
+    // --- 264 side (262 proxy): the WFS Decision-3 missing-flag crash + the L142 Success control ---
+    // Act A: single assignedResource OMITTING isRequiredResource → 262 missing-flag NPE crash.
+    // Act B (doc L142): single isRequiredResource=true, NO isPrimaryResource, fresh resources → Success.
+    final var unifiedMissingFlagEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    ReVomanConfigForWfs.AUTH_CONFIG,
+                    ReVomanConfigForWfs.AVAILABILITY_OP_HOURS_POLICY_CONFIG,
+                    ReVomanConfigForWfs.REQUIRED_NON_REQUIRED_FIXTURE_CONFIG,
+                    ReVomanConfigForWfs.MISSING_REQUIRED_FLAG_SCHEDULE_CONFIG))
+            .mutableEnv;
+    final var unifiedMissingFlagOutcome =
+        SchedulerParityConfig.unifiedWriteOutcomeFromErrorCode(
+            unifiedMissingFlagEnv.getAsString("missingRequiredFlagStatus"),
+            unifiedMissingFlagEnv.getAsString("missingRequiredFlagErrorCode"));
+
+    final var unifiedControlEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    ReVomanConfigForWfs.AUTH_CONFIG,
+                    ReVomanConfigForWfs.AVAILABILITY_OP_HOURS_POLICY_CONFIG,
+                    ReVomanConfigForWfs.REQUIRED_NON_REQUIRED_FIXTURE_CONFIG,
+                    ReVomanConfigForWfs.SINGLE_REQUIRED_NO_PRIMARY_SCHEDULE_CONFIG))
+            .mutableEnv;
+
+    // --- 264 CRASH asserted verbatim (the locked-in 262 missing-flag Boolean.booleanValue NPE) ---
+    assertThat(unifiedMissingFlagEnv.getAsString("missingRequiredFlagErrorCode"))
+        .isEqualTo("INTERNAL_SERVER_ERROR");
+    assertThat(unifiedMissingFlagEnv.getAsString("missingRequiredFlagErrorMessage"))
+        .contains("Boolean.booleanValue()");
+    assertThat(unifiedMissingFlagOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.CRASHED);
+    // 264 L142 control (single required, no primary) → Success (proves the crash is the omitted flag).
+    assertThat(unifiedControlEnv.getAsString("singleRequiredNoPrimaryStatus")).isEqualTo("Success");
+
+    // --- OLD outcomes pinned verbatim (characterization, NOT forced to match 264) ---
+    // OLD does NOT crash on the omitted isRequiredResource: it degrades gracefully with a CLEAN, TARGETED
+    // input-validation refusal — LIVE-OBSERVED HTTP 400, errorCode=INVALID_API_INPUT, message "Specify a
+    // valid value for isRequiredResource and try again." (it NAMES the exact missing field), no SA id and
+    // crucially NOT a 500 crash. This is the crash-vs-clean DIVERGENCE from the 264 write.
+    assertThat(oldMissingFlagEnv.getAsString("oldMissingFlagSaId")).isEmpty();
+    assertThat(oldMissingFlagEnv.getAsString("oldMissingFlagHttp")).isEqualTo("400");
+    assertThat(oldMissingFlagEnv.getAsString("oldMissingFlagErrorCode")).isEqualTo("INVALID_API_INPUT");
+    assertThat(oldMissingFlagEnv.getAsString("oldMissingFlagErrorCode"))
+        .isNotEqualTo("INTERNAL_SERVER_ERROR");
+    assertThat(oldMissingFlagEnv.getAsString("oldMissingFlagErrorMessage"))
+        .contains("isRequiredResource");
+    assertThat(oldMissingFlagOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.REFUSED);
+    // OLD L142 control (single required, no primary) BOOKS (18-char 08p id) → both engines agree on the
+    // control, isolating the divergence to the OMITTED flag (proving the fixture + grant are live and
+    // resourceA is bookable, so the Act-A refusal is the omitted flag, not a dead/unavailable resource).
+    assertThat(oldControlEnv.getAsString("oldSingleRequiredNoPrimarySaId")).hasLength(18);
+    assertThat(oldControlEnv.getAsString("oldSingleRequiredNoPrimarySaId")).startsWith("08p");
+    assertThat(oldControlOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.BOOKED);
+    // Both engines agree the L142 control books.
+    assertThat(oldControlOutcome)
+        .isEqualTo(
+            SchedulerParityConfig.unifiedWriteOutcome(
+                unifiedControlEnv.getAsString("singleRequiredNoPrimaryStatus"), "201"));
+
+    // --- DIVERGENCE recorded: OLD refuses CLEANLY (400 INVALID_API_INPUT, naming isRequiredResource) on
+    // the omitted flag while the 264 write CRASHES (500 INTERNAL_SERVER_ERROR Boolean.booleanValue NPE).
+    // OLD ≠ 264 on the write axis — a crash-vs-clean divergence, asserted verbatim, NOT forced to a
+    // green. Both agree on the L142 control (BOOKED / Success), isolating the divergence to the OMITTED
+    // isRequiredResource flag. ---
+    assertThat(oldMissingFlagOutcome).isNotEqualTo(unifiedMissingFlagOutcome);
+  }
+
+  /**
+   * Decision 4 parity — two "primary" workers on ONE appointment are REJECTED. Multi-resource scheduling
+   * requires EXACTLY one primary. Both products refuse a book that names two {@code
+   * isPrimaryResource=true} AssignedResources; a one-primary control BOOKS. OLD Salesforce Scheduler vs
+   * 264 Unified OnSite (262 proxy) agree on the OUTCOME (both REFUSED, no booking) — while the WHERE each
+   * rejects differs (a documented difference, NOT a failure).
+   *
+   * <p>264 Unified: rejects UP FRONT at INPUT validation ({@code
+   * ScheduleCommonValidator.validatePrimaryResourceConstraints}), before availability/persist — a clean
+   * top-level {@code ConnectErrorCode INVALID_INPUT} / HTTP 400 with message "Only one of the provided
+   * assigned resource can be a primary resource." No {@code appointments[0]} → status null → no booking.
+   * Reuses the WFS {@code SCHEDULE_TWO_PRIMARY_CONFIG} act (over the availability-op-hours policy + the
+   * required-non-required fixture's two resources).
+   *
+   * <p>OLD Salesforce Scheduler: the two-primary {@code POST /connect/scheduling/service-appointments} is
+   * REFUSED (non-2xx, no {@code 08p} serviceAppointmentId). LIVE-OBSERVED on the scheduler org (v67): the
+   * OLD connect API rejects at INPUT validation with a top-level {@code ConnectErrorCode INVALID_API_INPUT}
+   * / HTTP 400 and message "Only one assignedResource can have isPrimaryResource set to true. Check the
+   * request and try again." So the WHERE turned out CLOSER than the field-integrity/save-time hypothesis in
+   * the brief — both engines refuse at connect-API INPUT validation (pre-persist); only the errorCode
+   * ({@code INVALID_API_INPUT} vs 264's {@code INVALID_INPUT}) and the message TEXT differ. Captured
+   * faithfully; the OUTCOME (REFUSED, no booking) is the parity. The fixture seeds TWO clean,
+   * fully-available PRIMARY-eligible resources (both member OH + Confirmed Shift 10-14 over the 11:00-11:30
+   * window) so availability is NOT the discriminator — only the primary-count rule is; the one-primary
+   * control (A primary + B non-primary, both free) BOOKS (18-char {@code 08p} id) → non-vacuity.
+   *
+   * <p>KEY PARITY FINDING (both products agree on the OUTCOME): two primaries on one appointment are
+   * REFUSED (no booking) on BOTH engines, and a single-primary control BOOKS on the OLD surface → Decision
+   * 4 parity CONFIRMED on the OUTCOME. WHERE-difference (minor, characterized): BOTH reject at connect-API
+   * INPUT validation / HTTP 400 (pre-persist) — 264 with errorCode {@code INVALID_INPUT} ("Only one of the
+   * provided assigned resource can be a primary resource."), OLD with {@code INVALID_API_INPUT} ("Only one
+   * assignedResource can have isPrimaryResource set to true…") — differing only in errorCode + message
+   * text, not the WHERE. Characterized, not forced to a green.
+   *
+   * <p>262-proxy caveat: the 264 verdict is 262-observed and stands in for 264 (endpoints identical
+   * 262↔264 per the parity effort); Decision 4 is a clean input-validation reject that already ships on
+   * 262 (262 == 264 here), so it is unaffected by the 262-specific crash caveats (1.4 / 3).
+   *
+   * <p>Old-side revUps mint 2 fresh {@code sched-2prim-*@revoman.org} users per run and never clean up; two
+   * old-side revUps here (two-primary probe + one-primary control) → ~4 fresh users/run. The leading
+   * success guard ({@code firstUnIgnoredUnsuccessfulStepReport() == null}) surfaces a rolled-back
+   * fixture/grant loudly at the fixture step; the book acts carry {@code ignoreHTTPStatusUnsuccessful} so
+   * the legit refusal is not a step failure.
+   */
+  @Test
+  void testTwoPrimaryParity_4_E2E() {
+    SchedulerParityConfig.assumeBothOrgCreds();
+
+    // --- OLD side: two-primary probe (REFUSED) + one-primary control (BOOKED), fresh revUps ---
+    // AUTH → FIXTURE (two clean, fully-available primary-eligible resources) → GRANT (Lightning-Scheduler
+    // user-access, else the classic engine prunes the resources → dead book) → BOOK.
+    final var oldTwoPrimaryEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_TWO_PRIMARY_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_GRANT_LS_ACCESS_CONFIG,
+                    SchedulerParityConfig.OLD_BOOK_TWO_PRIMARY_CONFIG))
+            .mutableEnv;
+    final var oldTwoPrimaryOutcome =
+        SchedulerParityConfig.oldWriteOutcome(
+            oldTwoPrimaryEnv.getAsString("twoPrimaryOldSaId"),
+            oldTwoPrimaryEnv.getAsString("twoPrimaryOldHttp"));
+
+    final var oldControlEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_TWO_PRIMARY_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_GRANT_LS_ACCESS_CONFIG,
+                    SchedulerParityConfig.OLD_BOOK_ONE_PRIMARY_CONTROL_CONFIG))
+            .mutableEnv;
+    final var oldControlOutcome =
+        SchedulerParityConfig.oldWriteOutcome(
+            oldControlEnv.getAsString("twoPrimaryControlSaId"),
+            oldControlEnv.getAsString("twoPrimaryControlHttp"));
+
+    // --- 264 side (262 proxy): reuse the proven WFS two-primary act, one revUp ---
+    final var unifiedEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    ReVomanConfigForWfs.AUTH_CONFIG,
+                    ReVomanConfigForWfs.AVAILABILITY_OP_HOURS_POLICY_CONFIG,
+                    ReVomanConfigForWfs.REQUIRED_NON_REQUIRED_FIXTURE_CONFIG,
+                    ReVomanConfigForWfs.SCHEDULE_TWO_PRIMARY_CONFIG))
+            .mutableEnv;
+    final var unifiedTwoPrimaryOutcome =
+        SchedulerParityConfig.unifiedWriteOutcome(
+            unifiedEnv.getAsString("twoPrimaryStatus"),
+            unifiedEnv.getAsString("twoPrimaryHttpCode"));
+
+    // --- Non-vacuity: the one-primary control BOOKS a real 18-char, 08p ServiceAppointment, proving the
+    // fixture + both resources are live and bookable (so the two-primary REFUSAL is the second primary
+    // flag, not a dead fixture). ---
+    assertThat(oldControlEnv.getAsString("twoPrimaryControlSaId")).hasLength(18);
+    assertThat(oldControlEnv.getAsString("twoPrimaryControlSaId")).startsWith("08p");
+    assertThat(oldControlOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.BOOKED);
+
+    // --- 264 side pinned verbatim: clean INPUT-validation reject (the WHERE 264 refuses) ---
+    assertThat(unifiedEnv.getAsString("twoPrimaryErrorCode")).isEqualTo("INVALID_INPUT");
+    assertThat(unifiedEnv.getAsString("twoPrimaryErrorMessage")).contains("can be a primary resource");
+    assertThat(unifiedEnv.getAsString("twoPrimaryHttpCode")).isEqualTo("400");
+    assertThat(unifiedEnv.getAsString("twoPrimaryStatus")).isAnyOf(null, "null");
+    assertThat(unifiedTwoPrimaryOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.REFUSED);
+
+    // --- OLD side pinned faithfully (LIVE-OBSERVED): REFUSED, no SA id, HTTP 400, errorCode
+    // INVALID_API_INPUT, message "Only one assignedResource can have isPrimaryResource set to true…" — a
+    // connect-API INPUT-validation reject (NOT a persist/field-integrity error, and NOT a 500). The WHERE
+    // is thus the SAME layer as 264 (connect-API input validation, pre-persist); only the errorCode +
+    // message text differ. Characterized verbatim, not forced to match 264's exact code/message. ---
+    assertThat(oldTwoPrimaryEnv.getAsString("twoPrimaryOldSaId")).isEmpty();
+    assertThat(oldTwoPrimaryEnv.getAsString("twoPrimaryOldHttp")).isEqualTo("400");
+    assertThat(oldTwoPrimaryEnv.getAsString("twoPrimaryOldErrorCode")).isEqualTo("INVALID_API_INPUT");
+    assertThat(oldTwoPrimaryEnv.getAsString("twoPrimaryOldErrorMessage"))
+        .contains("isPrimaryResource set to true");
+    assertThat(oldTwoPrimaryOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.REFUSED);
+
+    // --- PARITY (the Decision 4 verdict): both products REFUSE two primaries on one appointment (no
+    // booking), and a single-primary control BOOKS on the OLD surface → parity CONFIRMED on the OUTCOME.
+    // The WHERE each rejects differs (264 = INPUT validation pre-persist; OLD = SAVE/persist) — a
+    // documented difference, asserted above, NOT a failure. ---
+    assertThat(oldTwoPrimaryOutcome).isEqualTo(unifiedTwoPrimaryOutcome);
+  }
+
+  /**
+   * Decision 4z parity — a reschedule can leave an appointment with NO primary worker. The classic
+   * Scheduler has NO reschedule connect API; the OLD "reschedule" is an sObject DELETE/PATCH stand-in on
+   * the AssignedResource rows hitting the same save-time validator. Arm 1 (DELETE the primary AR) is
+   * BLOCKED by {@code validatePrimaryAssignedResourceOnDelete} (FIELD_INTEGRITY_EXCEPTION); Arm 2 (DEMOTE
+   * the primary via PATCH IsPrimaryResource=false) SUCCEEDS and leaves 0 primaries (no no-primary guard on
+   * UPDATE). Route-dependent verdict: OLD is STRICTER on the delete route but CONVERGES on the update
+   * route with 264 (whose reschedule validation likewise permits zero primaries) — neither product has a
+   * product-wide must-keep-a-primary invariant → Decision 4z confirmed on BOTH sides.
+   */
+  @Test
+  void testRescheduleNoPrimaryParity_4z_E2E() {
+    SchedulerParityConfig.assumeBothOrgCreds();
+
+    // --- OLD side, Arm 1 (DELETE the primary AssignedResource): AUTH → FIXTURE (clean 2-resource
+    // graph) → GRANT → BOOK-CLEAN (+ AR query) → DELETE-PRIMARY (+ verify survived), one revUp. ---
+    final var oldDeleteEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_RESCHEDULE_HELPER_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_GRANT_LS_ACCESS_CONFIG,
+                    SchedulerParityConfig.OLD_BOOK_CLEAN_TWO_RESOURCE_CONFIG,
+                    SchedulerParityConfig.OLD_AR_DELETE_PRIMARY_CONFIG))
+            .mutableEnv;
+    // Non-vacuity: the clean two-resource SA MUST have booked with exactly 2 AssignedResource rows and a
+    // resolved primary AR id — else the delete probe would target nothing and BLOCKED would pass for the
+    // WRONG reason (dead fixture, not the delete guard).
+    assertThat(oldDeleteEnv.getAsString("reschedCleanSaId")).hasLength(18);
+    assertThat(oldDeleteEnv.getAsString("reschedCleanSaId")).startsWith("08p");
+    assertThat(oldDeleteEnv.getAsString("reschedCleanArCount")).isEqualTo("2");
+    assertThat(oldDeleteEnv.getAsString("reschedPrimaryArId")).startsWith("03r");
+    final var oldDeleteOutcome =
+        SchedulerParityConfig.oldNoPrimaryOutcome(
+            oldDeleteEnv.getAsString("reschedDeletePrimaryHttp"),
+            oldDeleteEnv.getAsString("reschedDeletePrimaryErrorCode"),
+            // primaryGone: "1" iff the primary AR no longer exists after the delete attempt.
+            "0".equals(oldDeleteEnv.getAsString("reschedPrimaryArStillExists")) ? "1" : "0");
+
+    // --- OLD side, Arm 2 (DEMOTE the primary AR to IsPrimaryResource=false): a FRESH clean SA so the two
+    // arms are independent. AUTH → FIXTURE → GRANT → BOOK-CLEAN (+ AR query) → DEMOTE-PRIMARY (+ verify). ---
+    final var oldDemoteEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_RESCHEDULE_HELPER_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_GRANT_LS_ACCESS_CONFIG,
+                    SchedulerParityConfig.OLD_BOOK_CLEAN_TWO_RESOURCE_CONFIG,
+                    SchedulerParityConfig.OLD_AR_DEMOTE_PRIMARY_CONFIG))
+            .mutableEnv;
+    assertThat(oldDemoteEnv.getAsString("reschedCleanArCount")).isEqualTo("2");
+    assertThat(oldDemoteEnv.getAsString("reschedPrimaryArId")).startsWith("03r");
+    final var oldDemoteOutcome =
+        SchedulerParityConfig.oldNoPrimaryOutcome(
+            oldDemoteEnv.getAsString("reschedDemotePrimaryHttp"),
+            oldDemoteEnv.getAsString("reschedDemotePrimaryErrorCode"),
+            // primaryGone: "1" iff ZERO primaries survive the demote attempt.
+            "0".equals(oldDemoteEnv.getAsString("reschedPrimaryCountAfterDemote")) ? "1" : "0");
+
+    // --- 264 side (262 proxy): reuse the proven WFS reschedule-no-primary acts, one revUp. ---
+    final var unifiedEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    ReVomanConfigForWfs.AUTH_CONFIG,
+                    ReVomanConfigForWfs.AVAILABILITY_OP_HOURS_POLICY_CONFIG,
+                    ReVomanConfigForWfs.REQUIRED_NON_REQUIRED_FIXTURE_CONFIG,
+                    ReVomanConfigForWfs.SCHEDULE_TWO_RESOURCE_CLEAN_CONFIG,
+                    ReVomanConfigForWfs.RESCHEDULE_DELETE_PRIMARY_WITH_FLAG_CONFIG,
+                    ReVomanConfigForWfs.RESCHEDULE_DELETE_PRIMARY_NO_FLAG_CONFIG))
+            .mutableEnv;
+    // 264 Arm B (delete primary, no flag) is the closest analog to the old delete-primary probe.
+    final var unifiedNoFlagOutcome =
+        SchedulerParityConfig.unifiedNoPrimaryOutcome(
+            unifiedEnv.getAsString("reschedNoFlagStatus"),
+            unifiedEnv.getAsString("reschedNoFlagErrorCode"),
+            unifiedEnv.getAsString("reschedNoFlagHttpCode"));
+
+    // --- 264 setup + arms asserted verbatim (the report's live-observed 262 result) ---
+    // Clean two-resource Schedule booked Success (the SA id for both reschedule arms).
+    assertThat(unifiedEnv.getAsString("reschedCleanStatus")).isEqualTo("Success");
+    assertThat(unifiedEnv.getAsString("reschedCleanSaId")).isNotNull();
+    // Arm A: isPrimaryResource on a Delete entry → clean INVALID_INPUT payload-field guard, HTTP 400
+    // (a field-shape rejection, NOT a no-primary rule).
+    assertThat(unifiedEnv.getAsString("reschedWithFlagErrorCode")).isEqualTo("INVALID_INPUT");
+    assertThat(unifiedEnv.getAsString("reschedWithFlagHttpCode")).isEqualTo("400");
+    // Arm B: delete primary WITHOUT the flag → validation ALLOWS zero primaries (no NoPrimary check),
+    // so it is refused ONLY by the downstream availability re-check (SlotNotAvailable) on 262 — never
+    // by a "must keep a primary" rule. This is the 4z fact: no reschedule no-primary validation.
+    assertThat(unifiedEnv.getAsString("reschedNoFlagStatus")).isNotEqualTo("Success");
+    assertThat(unifiedEnv.getAsString("reschedNoFlagErrorCode")).isEqualTo("INVALID_INPUT");
+    assertThat(unifiedEnv.getAsString("reschedNoFlagHttpCode")).isEqualTo("400");
+    assertThat(unifiedEnv.getAsString("reschedNoFlagErrorMessage"))
+        .contains("not available for the requested slot");
+    // On 262 the arms die at the availability re-check, not validation → normalized BLOCKED (the 264
+    // end-to-end no-primary completion is 264-only, per the WFS characterization).
+    assertThat(unifiedNoFlagOutcome).isEqualTo(SchedulerParityConfig.NoPrimaryOutcome.BLOCKED);
+
+    // --- OLD outcomes pinned verbatim (characterization) ---
+    // Arm 1 (DELETE the primary AR): BLOCKED by the save-time delete guard
+    // (validatePrimaryAssignedResourceOnDelete → FIELD_INTEGRITY_EXCEPTION "AssignedResourceDelete"),
+    // HTTP 400, and the primary AR SURVIVES (still present after the attempt) → the SA is NOT left
+    // without a primary via delete. The old side hard-enforces the primary-worker invariant at DML time.
+    assertThat(oldDeleteEnv.getAsString("reschedDeletePrimaryHttp")).isEqualTo("400");
+    assertThat(oldDeleteEnv.getAsString("reschedDeletePrimaryErrorCode"))
+        .isEqualTo("FIELD_INTEGRITY_EXCEPTION");
+    assertThat(oldDeleteEnv.getAsString("reschedPrimaryArStillExists")).isEqualTo("1");
+    assertThat(oldDeleteOutcome).isEqualTo(SchedulerParityConfig.NoPrimaryOutcome.BLOCKED);
+
+    // Arm 2 (DEMOTE the primary AR to IsPrimaryResource=false): probes whether the old save validator
+    // has ANY no-primary guard beyond the delete path. LIVE-OBSERVED (pinned verbatim): the PATCH
+    // SUCCEEDS (HTTP 204) and leaves ZERO primaries on the SA (reschedPrimaryCountAfterDemote == "0") →
+    // LEFT_NO_PRIMARY. So validateAssignedResourceOnSave has NO "must keep a primary" invariant — the
+    // primary-worker enforcement lives ONLY in the DELETE guard, not on update. This is the old-side
+    // route that DOES leave an appointment with no primary — the direct analog of 264's permissive
+    // reschedule validation.
+    assertThat(oldDemoteEnv.getAsString("reschedDemotePrimaryHttp")).isEqualTo(EXPECTED_DEMOTE_HTTP);
+    assertThat(oldDemoteEnv.getAsString("reschedPrimaryCountAfterDemote"))
+        .isEqualTo(EXPECTED_DEMOTE_PRIMARY_COUNT);
+    assertThat(oldDemoteOutcome).isEqualTo(EXPECTED_DEMOTE_OUTCOME);
+
+    // --- 4z VERDICT (structural divergence + a convergent no-primary fact, all LIVE-observed) ---
+    // (1) DELETE route: OLD is STRICTER — its save-time delete guard
+    // (validatePrimaryAssignedResourceOnDelete → FIELD_INTEGRITY_EXCEPTION) HARD-BLOCKS removing the
+    // primary AR (primary survives), so the delete route CANNOT leave a no-primary SA. On the 264 side
+    // the analogous delete-primary reschedule (Arm B) passes VALIDATION (zero primaries allowed) and is
+    // refused only downstream (262 availability re-check) → both probes normalize to BLOCKED here, but
+    // for DIFFERENT reasons: old = a genuine no-primary DML guard, 264 = an availability gap over a
+    // permissive validator. So on the delete route old ≥ 264 in strictness (enforcement-layer
+    // divergence), and the observable outcomes AGREE.
+    assertThat(oldDeleteOutcome).isEqualTo(unifiedNoFlagOutcome);
+    // (2) DEMOTE/UPDATE route (the deeper fact): NEITHER product enforces a blanket "appointment must
+    // always keep a primary" invariant. OLD's save validator has no no-primary check on UPDATE, so the
+    // demote PATCH LEAVES a no-primary SA (LEFT_NO_PRIMARY); 264's reschedule validation likewise permits
+    // zero primaries (validatePrimaryResourceCount throws only for > 1). So both engines CAN be driven to
+    // a no-primary state — old via demote-PATCH, 264 via reschedule validation (end-to-end on true 264) —
+    // confirming Decision 4z on BOTH sides. The old delete guard is a route-specific stricture, not a
+    // product-wide primary invariant. Asserted faithfully (not forced to a single AGREE/DIVERGE label).
+    assertThat(oldDemoteOutcome).isEqualTo(unifiedNoPrimaryValidationVerdict());
+  }
+
+  /**
+   * The 264 no-primary VALIDATION verdict for the 4z comparison: 264 reschedule validation ALLOWS zero
+   * primaries (there is no NoPrimary check — {@code validatePrimaryResourceCount} throws only when
+   * {@code primaryCount > 1}), so at the validation layer 264 would LEAVE_NO_PRIMARY (and does,
+   * end-to-end, on true 264; on the 262 proxy it is stopped only by the downstream availability gap).
+   * This mirrors the old side's demote route, which leaves a no-primary SA. Kept as a named constant so
+   * the demote-route parity read is explicit: both products permit no-primary at their validation layer.
+   */
+  private static SchedulerParityConfig.NoPrimaryOutcome unifiedNoPrimaryValidationVerdict() {
+    return SchedulerParityConfig.NoPrimaryOutcome.LEFT_NO_PRIMARY;
+  }
+
+  /**
+   * Decision 5 parity — a single AssignedResource marked {@code isPrimaryResource=true} BUT {@code
+   * isRequiredResource=false} is a CONTRADICTION and is REJECTED at PERSIST (not auto-corrected, not
+   * double-booked). This is the HIGHEST-VALUE parity proof in the set: the rejection is enforced by
+   * {@code LightningSchedulerAssignedResourceValidator} (fieldservice-impl), a SAVE-TIME validator on the
+   * AssignedResource entity that fires on EVERY create/update of an AssignedResource — this Connect API,
+   * Apex, direct DML, bulk — whenever multi-resource scheduling is on. So the OLD Salesforce Scheduler
+   * book path ({@code POST /connect/scheduling/service-appointments}, which inserts AssignedResource rows)
+   * hits the SAME validator as 264 → literally the same code path.
+   *
+   * <p>The booking window is FREE for resourceA (member OH + Confirmed Shift 10-14 both cover the
+   * 11:00-11:30 window), so availability passes and the persist-time primary-must-be-required reject is
+   * the sole discriminator. Probe: one AssignedResource isPrimaryResource=true + isRequiredResource=false
+   * → REFUSED (persist/field error, no SA id). Control: the same resource/window flipped to
+   * isRequiredResource=true (a valid required-primary) → BOOKED. Old side: public Scheduler REST ({@code
+   * POST /connect/scheduling/service-appointments}). Unified side: the existing WFS Decision-5 Kicks
+   * ({@code SCHEDULE_PRIMARY_NOT_REQUIRED_CONFIG} → PersistError/INVALID_FIELD; {@code
+   * SCHEDULE_PRIMARY_REQUIRED_CONTROL_CONFIG} → Success).
+   *
+   * <p>KEY PARITY FINDING (both products agree): the primary-not-required contradiction is REFUSED on both
+   * engines (both fire the shared save-time AssignedResource validator), while the required-primary
+   * control BOOKS on both → Decision 5 parity CONFIRMED on the write axis. The OLD validator's observed
+   * error envelope is captured faithfully (it may differ from the 264 schedulingStatus=PersistError /
+   * errorCode=INVALID_FIELD envelope); the PARITY is on the normalized OUTCOME (both REFUSE the
+   * contradiction, both BOOK the control), not on the raw message text.
+   *
+   * <p>262-proxy caveat: the 264 verdict is 262-observed (endpoints identical 262↔264 per the parity
+   * effort). Decision 5 is a persist-validation reject (crash-free on both engines), so it is unaffected
+   * by the 262-specific INTERNAL_SERVER_ERROR crash caveats (1.4 / 3). A divergence, were it to appear,
+   * would be asserted faithfully rather than forced to a green.
+   *
+   * <p>Old-side revUps mint 1 fresh {@code sched-pnr-a-*@revoman.org} user per run and never clean up; two
+   * old-side revUps here (probe + control) → ~2 fresh users/run. The leading success guard ({@code
+   * firstUnIgnoredUnsuccessfulStepReport() == null}) surfaces a rolled-back fixture/grant loudly at the
+   * fixture step; the book acts carry {@code ignoreHTTPStatusUnsuccessful} so the legit refusal (a non-2xx
+   * / error envelope) is not counted as a step failure.
+   */
+  @Test
+  void testPrimaryNotRequiredParity_5_E2E() {
+    SchedulerParityConfig.assumeBothOrgCreds();
+
+    // --- OLD side: probe (primary + NOT required, free window → persist reject) + control (primary +
+    // required → booked), fresh revUps. Each mirrors AUTH → FIXTURE (single fully-available resourceA) →
+    // GRANT (Lightning-Scheduler user-access, else the classic engine prunes the resource → dead book) →
+    // BOOK. ---
+    final var oldProbeEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_PRIMARY_NOT_REQUIRED_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_GRANT_LS_ACCESS_CONFIG,
+                    SchedulerParityConfig.OLD_BOOK_PRIMARY_NOT_REQUIRED_CONFIG))
+            .mutableEnv;
+    final var oldProbeOutcome =
+        SchedulerParityConfig.oldWriteOutcome(
+            oldProbeEnv.getAsString("oldWriteHelperSaId"),
+            oldProbeEnv.getAsString("oldWriteHelperHttp"));
+
+    final var oldControlEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_PRIMARY_NOT_REQUIRED_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_GRANT_LS_ACCESS_CONFIG,
+                    SchedulerParityConfig.OLD_BOOK_PRIMARY_REQUIRED_CONTROL_CONFIG))
+            .mutableEnv;
+    final var oldControlOutcome =
+        SchedulerParityConfig.oldWriteOutcome(
+            oldControlEnv.getAsString("oldWriteRequiredControlSaId"),
+            oldControlEnv.getAsString("oldWriteRequiredControlHttp"));
+
+    // --- 264 side (262 proxy): reuse the proven WFS Decision-5 acts (probe rejected at persist + required
+    // control booked), two revUps (Approach A: the rejected probe and the persisting control never share
+    // ServiceResource rows). ---
+    final var unifiedProbeEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    ReVomanConfigForWfs.AUTH_CONFIG,
+                    ReVomanConfigForWfs.AVAILABILITY_OP_HOURS_POLICY_CONFIG,
+                    ReVomanConfigForWfs.REQUIRED_NON_REQUIRED_FIXTURE_CONFIG,
+                    ReVomanConfigForWfs.SCHEDULE_PRIMARY_NOT_REQUIRED_CONFIG))
+            .mutableEnv;
+    final var unifiedProbeOutcome =
+        SchedulerParityConfig.unifiedWriteOutcome(
+            unifiedProbeEnv.getAsString("primaryNotReqStatus"), "201");
+
+    final var unifiedControlEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    ReVomanConfigForWfs.AUTH_CONFIG,
+                    ReVomanConfigForWfs.AVAILABILITY_OP_HOURS_POLICY_CONFIG,
+                    ReVomanConfigForWfs.REQUIRED_NON_REQUIRED_FIXTURE_CONFIG,
+                    ReVomanConfigForWfs.SCHEDULE_PRIMARY_REQUIRED_CONTROL_CONFIG))
+            .mutableEnv;
+    final var unifiedControlOutcome =
+        SchedulerParityConfig.unifiedWriteOutcome(
+            unifiedControlEnv.getAsString("primaryReqControlStatus"), "201");
+
+    // --- PARITY: both engines REFUSE the primary-not-required contradiction (the shared save-time
+    // AssignedResource validator) and BOOK the required-primary control ---
+    // The old probe must NOT return a ServiceAppointment id (the persist reject leaves it empty), so
+    // REFUSED reflects a genuine rejection, not an empty/vacuous pass.
+    assertThat(oldProbeEnv.getAsString("oldWriteHelperSaId")).isEmpty();
+    assertThat(oldProbeOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.REFUSED);
+    assertThat(unifiedProbeOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.REFUSED);
+    assertThat(oldProbeOutcome).isEqualTo(unifiedProbeOutcome);
+
+    // Non-vacuity: the required-primary control (same resource/window) MUST book a real 18-char, 08p
+    // ServiceAppointment id on the OLD side, proving the fixture + grant are live and the window is
+    // genuinely free — so the probe's refusal is the primary-not-required rule, not a dead resource.
+    assertThat(oldControlEnv.getAsString("oldWriteRequiredControlSaId")).hasLength(18);
+    assertThat(oldControlEnv.getAsString("oldWriteRequiredControlSaId")).startsWith("08p");
+    assertThat(oldControlOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.BOOKED);
+    assertThat(unifiedControlOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.BOOKED);
+    assertThat(oldControlOutcome).isEqualTo(unifiedControlOutcome);
+
+    // 264 probe pinned to the Decision-5 persist-validation reject (the shared validator's 264 envelope).
+    assertThat(unifiedProbeEnv.getAsString("primaryNotReqStatus")).isEqualTo("PersistError");
+    assertThat(unifiedProbeEnv.getAsString("primaryNotReqErrorCode")).isEqualTo("INVALID_FIELD");
+    // 264 control books Success.
+    assertThat(unifiedControlEnv.getAsString("primaryReqControlStatus")).isEqualTo("Success");
+  }
+
+  @Test
+  void testResourceLimitCapParity_8_E2E() {
+    SchedulerParityConfig.assumeBothOrgCreds();
+
+    // --- OLD side: both candidates reads (limit=0 + limit=50 control) over the load-balancing fixture ---
+    // AUTH → FIXTURE (AppointmentAssignmentPolicy(loadBalancing) + policy FK + 2-resource graph) → GRANT
+    // (Lightning-Scheduler user-access, else the classic engine prunes the resources → dead read) →
+    // CANDIDATES reads (limit=0 probe + limit=50 control), NO filterByResources so the cap path engages.
+    final var oldReadEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_LIMIT_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_GRANT_LS_ACCESS_CONFIG,
+                    SchedulerParityConfig.OLD_GET_CANDIDATES_LIMIT_ZERO_CONFIG,
+                    SchedulerParityConfig.OLD_GET_CANDIDATES_LIMIT_POSITIVE_CONFIG))
+            .mutableEnv;
+    final var oldLimitZeroCount = oldReadEnv.getAsString("limitZeroResourceCount");
+    final var oldLimitPositiveCount = oldReadEnv.getAsString("limitPositiveResourceCount");
+    // Was the OLD load-balancing FK attachable? The AppointmentSchedulingPolicy.AppointmentAssignmentPolicy
+    // column is exposed only when the org has smart scheduling enabled (orgHasSmartSchedulingEnabled()), so
+    // this fixture-recorded flag is the live probe of that org gate — the switch that decides whether the
+    // classic engine can even take the load-balancing candidates path where the cap lives.
+    final var oldCapConstructible =
+        "true".equals(oldReadEnv.getAsString("schedLimitCapConstructible"));
+    final var oldCapEngaged =
+        SchedulerParityConfig.oldLimitCapEngaged(oldLimitZeroCount, oldLimitPositiveCount);
+    final var oldLimitZeroDecision = SchedulerParityConfig.oldReadDecision(oldLimitZeroCount);
+    final var oldLimitPositiveDecision = SchedulerParityConfig.oldReadDecision(oldLimitPositiveCount);
+
+    // --- 264 side (262 proxy): reuse the proven WFS Decision-8 read Kicks, one revUp ---
+    final var unifiedEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    ReVomanConfigForWfs.AUTH_CONFIG,
+                    ReVomanConfigForWfs.REQUIRED_NON_REQUIRED_FIXTURE_CONFIG,
+                    ReVomanConfigForWfs.GET_RESOURCES_LIMIT_ZERO_CONFIG,
+                    ReVomanConfigForWfs.GET_RESOURCES_LIMIT_POSITIVE_CONFIG))
+            .mutableEnv;
+    final var unifiedLimitZeroCount = unifiedEnv.getAsString("limitZeroResourceCount");
+    final var unifiedLimitPositiveCount = unifiedEnv.getAsString("limitPositiveResourceCount");
+    final var unifiedLimitZeroDecision = SchedulerParityConfig.oldReadDecision(unifiedLimitZeroCount);
+    final var unifiedLimitPositiveDecision =
+        SchedulerParityConfig.oldReadDecision(unifiedLimitPositiveCount);
+
+    // --- 264 (asserted): the cap engages on the default load-balancing policy — limit=0 EMPTY, limit=50 >0.
+    // Neither read is a swallowed 4xx/5xx (both acts are ignore-HTTP-status), so assert no errorCode.
+    assertThat(unifiedEnv.getAsString("limitZeroErrorCode")).isAnyOf(null, "null", "");
+    assertThat(unifiedEnv.getAsString("limitPositiveErrorCode")).isAnyOf(null, "null", "");
+    assertThat(unifiedLimitZeroCount).isEqualTo("0");
+    assertThat(Integer.parseInt(unifiedLimitPositiveCount)).isGreaterThan(0);
+    assertThat(unifiedLimitZeroDecision).isEqualTo(SchedulerParityConfig.ReadDecision.EXCLUDED);
+    assertThat(unifiedLimitPositiveDecision).isEqualTo(SchedulerParityConfig.ReadDecision.INCLUDED);
+
+    // --- OLD side: neither probe is a crash (no 500 / errorCode) — the cap (or its no-op) is a clean read.
+    assertThat(oldReadEnv.getAsString("limitZeroHttp")).isNotEqualTo("500");
+    assertThat(oldReadEnv.getAsString("limitPositiveHttp")).isNotEqualTo("500");
+    assertThat(oldReadEnv.getAsString("limitZeroErrorCode")).isAnyOf(null, "null", "");
+    // Non-vacuity: the positive-limit control MUST offer resources on BOTH engines (fixture/policy/grant
+    // are live). Whether or not the OLD cap engages, limit=50 returns the full pool → > 0.
+    assertThat(Integer.parseInt(oldLimitPositiveCount)).isGreaterThan(0);
+    assertThat(oldLimitPositiveDecision).isEqualTo(SchedulerParityConfig.ReadDecision.INCLUDED);
+
+    // --- PARITY: characterize the OLD cap vs 264, faithfully. ---
+    if (oldCapConstructible) {
+      // The org HAS smart scheduling → the load-balancing FK attached → the classic cap path is live.
+      // AGREE: the OLD cap behaves like 264 — limit=0 → EMPTY, positive → resources. (Both engines route
+      // the candidate set through a load-balancing objective; the cap semantics match.)
+      assertThat(oldCapEngaged).isTrue();
+      assertThat(oldLimitZeroCount).isEqualTo("0");
+      assertThat(oldLimitZeroDecision).isEqualTo(SchedulerParityConfig.ReadDecision.EXCLUDED);
+      assertThat(oldLimitZeroDecision).isEqualTo(unifiedLimitZeroDecision);
+      assertThat(oldLimitPositiveDecision).isEqualTo(unifiedLimitPositiveDecision);
+    } else {
+      // CONFIGURATION NUANCE (recorded verbatim, NOT forced green): the scheduler org lacks smart scheduling
+      // (SsAppointmentDistribution pref / AppointmentDistribution perm), so the
+      // AppointmentSchedulingPolicy.AppointmentAssignmentPolicy FK COLUMN is absent (the attach PATCH 400s
+      // INVALID_FIELD "No such column 'AppointmentAssignmentPolicy'"). Without that FK the classic engine
+      // (SchedulingServiceImpl.getAppointmentCandidatesForTerritoryWorkTypes → getSmartPolicy) never takes
+      // the load-balancing branch, so resourceLimitApptDistribution is accepted on the request but NEVER
+      // applied — the cap is a no-op and limit=0 does NOT empty the pool. 264 ships the LoadBalancing
+      // objective on its DEFAULT OnSite policy, so ITS cap always engages (limit=0 → EMPTY). This is the
+      // true OLD-vs-264 divergence for Decision 8: the cap parameter is honored identically ONLY once the
+      // load-balancing objective/policy is present on BOTH — a configuration precondition 264 pre-satisfies
+      // and this scheduler org does not. Pin the observed OLD no-op: limit=0 stays INCLUDED (pool not
+      // emptied), diverging from 264's EXCLUDED.
+      assertThat(oldReadEnv.getAsString("schedLimitAttachErrorCode")).isEqualTo("INVALID_FIELD");
+      assertThat(oldCapEngaged).isFalse();
+      assertThat(oldLimitZeroDecision).isEqualTo(SchedulerParityConfig.ReadDecision.INCLUDED);
+      assertThat(oldLimitZeroDecision).isNotEqualTo(unifiedLimitZeroDecision);
+      // Both OLD probes see the SAME (uncapped) pool → the parameter had no effect on the OLD engine.
+      assertThat(oldLimitZeroCount).isEqualTo(oldLimitPositiveCount);
+    }
+  }
+
+  @Test
+  void testShiftSharingSplitParity_9_E2E() {
+    SchedulerParityConfig.assumeBothOrgCreds();
+
+    // --- 264 side (262 proxy): the proven WFS Decision-9 chain. adminToken mints manager + case-worker
+    // (own SOAP sessions); the manager OWNS the policy/fixture/Private Shift rows; the case-worker lacks
+    // sharing on them. One revUp: AUTH → persona-mint → manager-owned policy + fixture → manager read
+    // (control) → case-worker read (probe). The SHIFT read is the user-mode gate here. ---
+    final var unifiedEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    ReVomanConfigForWfs.AUTH_CONFIG,
+                    ReVomanConfigForWfs.AUTH_PERSONAS_DEC9_CONFIG,
+                    ReVomanConfigForWfs.SHARING_SPLIT_POLICY_CONFIG,
+                    ReVomanConfigForWfs.SHARING_SPLIT_FIXTURE_CONFIG,
+                    ReVomanConfigForWfs.GET_SLOTS_SHARING_SPLIT_AS_MANAGER_CONFIG,
+                    ReVomanConfigForWfs.GET_SLOTS_SHARING_SPLIT_AS_CASEWORKER_CONFIG))
+            .mutableEnv;
+    final var unifiedManagerGate =
+        SchedulerParityConfig.sharingGate(unifiedEnv.getAsString("dec9CaseWorkerSlotCount"), "200");
+    // 264 shift-gated split asserted verbatim (mirrors WfsReadPathParityE2ETest.testShiftSharingModeSplitE2E):
+    // the shift OWNER (manager) sees availability; the sharing-deprived case-worker sees NONE, silently.
+    assertThat(Integer.parseInt(unifiedEnv.getAsString("dec9ManagerSlotCount"))).isGreaterThan(0);
+    assertThat(unifiedEnv.getAsString("dec9CaseWorkerSlotCount")).isEqualTo("0");
+    // 264 case-worker (sharing-deprived) is GATED (zero slots, HTTP 200, no error).
+    assertThat(unifiedManagerGate).isEqualTo(SchedulerParityConfig.SharingGate.GATED);
+
+    // --- OLD side: cross-persona classic getAppointmentSlots. AUTH (admin) → persona-mint (manager +
+    // case-worker + resource-owner, own SOAP sessions) → manager-owned fixture (admin skeleton + manager
+    // ServiceResource + admin STM/Shift on it) → manager read (control) → case-worker read (probe). The
+    // sharing gate on OLD is the user-mode STM/ServiceResource read; the shift read is full-access. ---
+    final var oldEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_AUTH_PERSONAS_DEC9_CONFIG,
+                    SchedulerParityConfig.OLD_SHARING_SPLIT_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_GET_SLOTS_SHARING_AS_MANAGER_CONFIG,
+                    SchedulerParityConfig.OLD_GET_SLOTS_SHARING_AS_CASEWORKER_CONFIG))
+            .mutableEnv;
+    final var oldCaseWorkerGate =
+        SchedulerParityConfig.sharingGate(
+            oldEnv.getAsString("oldD9CaseWorkerSlotCount"),
+            oldEnv.getAsString("oldD9CaseWorkerHttp"));
+
+    // --- OLD case-worker (sharing-deprived) is GATED: zero slots, HTTP 200, NO error — the classic engine's
+    // user-mode STM/ServiceResource read gate (NOT the shift read, which is full-access). This is the axis
+    // under test and the point of parity with 264 on the OBSERVABLE contract. ---
+    assertThat(oldEnv.getAsString("oldD9CaseWorkerHttp")).isEqualTo("200");
+    assertThat(oldEnv.getAsString("oldD9CaseWorkerSlotCount")).isEqualTo("0");
+    assertThat(oldCaseWorkerGate).isEqualTo(SchedulerParityConfig.SharingGate.GATED);
+
+    // --- PARITY (observable contract): BOTH engines silently gate a sharing-deprived reader to zero slots,
+    // HTTP 200, no error → GATED == GATED. They AGREE on the user-visible half-secured behavior. ---
+    assertThat(oldCaseWorkerGate).isEqualTo(unifiedManagerGate);
+    // --- DIVERGENCE (mechanism, source-confirmed, recorded not forced): 264 gates on the SHIFT read
+    // (user-mode) while OLD gates on the STM/ServiceResource read (user-mode) and reads shifts full-access —
+    // an INVERTED sharing axis. The OLD manager positive-control (owner-sees-slots) is a documented
+    // provisioning blocker (object-perm chain: OperatingHours/WorkType CRUD via the Greeter permset + record
+    // shares on the Private graph), so it is NOT asserted green — see this method's javadoc. ---
   }
 }

--- a/src/integrationTest/java/com/salesforce/revoman/integration/core/scheduler/SchedulerVsUnifiedParityE2ETest.java
+++ b/src/integrationTest/java/com/salesforce/revoman/integration/core/scheduler/SchedulerVsUnifiedParityE2ETest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2026 salesforce.com, inc.
+ * All Rights Reserved
+ * Company Confidential
+ */
+
+package com.salesforce.revoman.integration.core.scheduler;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.salesforce.revoman.integration.core.scheduler.SchedulerParityConfig.OLD_AUTH_CONFIG;
+
+import com.salesforce.revoman.ReVoman;
+import com.salesforce.revoman.integration.core.wfs.ReVomanConfigForWfs;
+import kotlin.collections.CollectionsKt;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Scheduler ↔ Unified(264) {@code 1.*} helper-fitness parity — differential tests. Each scenario diffs
+ * the OLD Salesforce Scheduler decision against the 264-Unified(262-proxy) decision on BOTH the read
+ * (INCLUDED/EXCLUDED) and write (BOOKED/REFUSED/CRASHED) axes.
+ */
+class SchedulerVsUnifiedParityE2ETest {
+
+  @Test
+  void schedulerOrgAuthBindsE2E() {
+    SchedulerParityConfig.assumeBothOrgCreds();
+    final var rundown = ReVoman.revUp(OLD_AUTH_CONFIG);
+    final var env = rundown.mutableEnv;
+    assertThat(env.getAsString("adminToken")).isNotEmpty();
+    assertThat(env.getAsString("versionPath")).contains("/services/data/v");
+  }
+
+  /**
+   * Decision 1.5 parity — a busy NON-required helper. OLD Salesforce Scheduler vs 264 Unified OnSite
+   * (262 proxy) must agree on both axes: the busy helper BOOKS (not availability-checked) while a
+   * required busy control is REFUSED; and the read offers the fixture's slots only when the busy
+   * resource is NOT a hard required constraint. Old side: public Scheduler REST ({@code
+   * POST /scheduling/getAppointmentSlots} + {@code POST /connect/scheduling/service-appointments}).
+   * Unified side: the existing WFS double-book Connect acts.
+   *
+   * <p>KEY PARITY FINDING (both products agree): a non-required helper BOOKS (it is not
+   * availability-checked, so it may double-book) and is read-EXCLUDED when that same busy resource is
+   * named a hard required constraint; the required-control write is REFUSED (availability-checked). All
+   * four normalized verdicts align → 1.5 parity CONFIRMED.
+   *
+   * <p>262-proxy caveat: these verdicts are 262-observed and stand in for 264 (endpoints are identical
+   * 262↔264 per the parity effort). A true-264 org may differ from 262 on the locked-in crash decisions
+   * (1.4 / 3 — 262-specific INTERNAL_SERVER_ERROR bugs); 1.5 is crash-free, so it is unaffected by that
+   * caveat. Divergence, were it to appear, is a first-class finding: it would be asserted faithfully
+   * (with a {@code <p>DIVERGENCE:} paragraph naming the mismatch) rather than forced to a green.
+   *
+   * <p>Old-side revUps mint 2 fresh {@code sched-res-*@revoman.org} users per run and never clean up;
+   * three old-side revUps here (read + two write arms) → ~6 fresh users/run. The leading success guard
+   * ({@code firstUnIgnoredUnsuccessfulStepReport() == null}) surfaces a rolled-back fixture/grant (e.g.
+   * LICENSE_LIMIT_EXCEEDED) loudly at the fixture step rather than masking it as a false verdict; the
+   * read/book acts carry {@code ignoreHTTPStatusUnsuccessful} so legit 400s / empty reads do not trip it.
+   */
+  @Test
+  void testHelperDoubleBookParity_1_5_E2E() {
+    SchedulerParityConfig.assumeBothOrgCreds();
+
+    // --- OLD side: read decision + write (helper) + write (required control), fresh revUps ---
+    // Each old-side revUp mirrors the probe sequence: AUTH → FIXTURE → GRANT (Lightning-Scheduler
+    // user-access, else the classic engine prunes the fixture resources → dead read/write) → READ/BOOK.
+    final var oldReadEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_DOUBLE_BOOK_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_GRANT_LS_ACCESS_CONFIG,
+                    SchedulerParityConfig.OLD_GET_SLOTS_DOUBLE_BOOK_CONFIG))
+            .mutableEnv;
+    final var oldReadDecision =
+        SchedulerParityConfig.oldReadDecision(oldReadEnv.getAsString("oldReadWithBSlotCount"));
+    // Non-vacuity guard: the A-only control read MUST offer >0 slots, proving the fixture (and the
+    // Lightning-Scheduler user-access grant) is live. Without this, a silently-failed grant would make
+    // BOTH reads 0 → EXCLUDED would pass for the WRONG reason (dead read, not the busy resource).
+    assertThat(oldReadEnv.getAsString("oldReadAOnlySlotCount")).isNotEqualTo("0");
+
+    final var oldHelperEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_DOUBLE_BOOK_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_GRANT_LS_ACCESS_CONFIG,
+                    SchedulerParityConfig.OLD_BOOK_NON_REQUIRED_CONFIG))
+            .mutableEnv;
+    final var oldHelperOutcome =
+        SchedulerParityConfig.oldWriteOutcome(
+            oldHelperEnv.getAsString("oldWriteHelperSaId"),
+            oldHelperEnv.getAsString("oldWriteHelperHttp"));
+
+    final var oldControlEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_DOUBLE_BOOK_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_GRANT_LS_ACCESS_CONFIG,
+                    SchedulerParityConfig.OLD_BOOK_REQUIRED_CONTROL_CONFIG))
+            .mutableEnv;
+    final var oldControlOutcome =
+        SchedulerParityConfig.oldWriteOutcome(
+            oldControlEnv.getAsString("oldWriteRequiredControlSaId"),
+            oldControlEnv.getAsString("oldWriteRequiredControlHttp"));
+
+    // --- 264 side (262 proxy): reuse the proven WFS double-book acts, one revUp ---
+    final var unifiedEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    ReVomanConfigForWfs.AUTH_CONFIG,
+                    ReVomanConfigForWfs.AVAILABILITY_OP_HOURS_POLICY_CONFIG,
+                    ReVomanConfigForWfs.DOUBLE_BOOK_FIXTURE_CONFIG,
+                    ReVomanConfigForWfs.DOUBLE_BOOK_NON_REQUIRED_SCHEDULE_CONFIG,
+                    ReVomanConfigForWfs.DOUBLE_BOOK_REQUIRED_CONFLICT_SCHEDULE_CONFIG))
+            .mutableEnv;
+    final var unifiedHelperOutcome =
+        SchedulerParityConfig.unifiedWriteOutcome(
+            unifiedEnv.getAsString("doubleBookNonRequiredSchedulingStatus"), "201");
+    final var unifiedControlOutcome =
+        SchedulerParityConfig.unifiedWriteOutcome(
+            unifiedEnv.getAsString("doubleBookRequiredControlSchedulingStatus"), "201");
+
+    // --- PARITY: both products book the non-required busy helper (helper is NOT availability-checked) ---
+    // Shape guard (restored from the removed write probe): the old-side helper booking must return a real
+    // ServiceAppointment id (18-char, 08p prefix), so BOOKED reflects a genuine persist, not an empty pass.
+    assertThat(oldHelperEnv.getAsString("oldWriteHelperSaId")).hasLength(18);
+    assertThat(oldHelperEnv.getAsString("oldWriteHelperSaId")).startsWith("08p");
+    assertThat(oldHelperOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.BOOKED);
+    assertThat(unifiedHelperOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.BOOKED);
+    assertThat(oldHelperOutcome).isEqualTo(unifiedHelperOutcome);
+    // Old read excludes the busy resource when it is a hard required id (the old-side availability proof).
+    assertThat(oldReadDecision).isEqualTo(SchedulerParityConfig.ReadDecision.EXCLUDED);
+    // Both required controls (the busy resource named required) are REFUSED → the availability proof.
+    assertThat(oldControlOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.REFUSED);
+    assertThat(unifiedControlOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.REFUSED);
+    assertThat(oldControlOutcome).isEqualTo(unifiedControlOutcome);
+    // Unified control (busy resource as required) is refused → the Unified availability proof.
+    assertThat(unifiedEnv.getAsString("doubleBookRequiredControlSchedulingStatus"))
+        .isNotEqualTo("Success");
+  }
+}

--- a/src/integrationTest/java/com/salesforce/revoman/integration/core/scheduler/SchedulerVsUnifiedParityE2ETest.java
+++ b/src/integrationTest/java/com/salesforce/revoman/integration/core/scheduler/SchedulerVsUnifiedParityE2ETest.java
@@ -142,4 +142,530 @@ class SchedulerVsUnifiedParityE2ETest {
     assertThat(unifiedEnv.getAsString("doubleBookRequiredControlSchedulingStatus"))
         .isNotEqualTo("Success");
   }
+
+  /**
+   * Scenario 1b (Territory) parity — a NON-required helper whose ServiceTerritoryMember coverage does
+   * NOT include the booking window. OLD Salesforce Scheduler vs 264 Unified OnSite (262 proxy) must
+   * agree on both axes: the out-of-territory helper BOOKS (its territory is NOT fitness-checked because
+   * it is non-required) while the SAME resourceB named a hard REQUIRED constraint is REFUSED (the
+   * classic engine's territory/STM-membership filter runs only for required resources); and the read
+   * offers the fixture's slots only when the out-of-territory resource is NOT a hard required
+   * constraint. Old side: public Scheduler REST ({@code POST /scheduling/getAppointmentSlots} + {@code
+   * POST /connect/scheduling/service-appointments}). Unified side: the existing WFS territory Kicks
+   * ({@code TERRITORY_PARTIAL_POLICY_CONFIG} / {@code TERRITORY_FIXTURE_CONFIG} / {@code
+   * TERRITORY_SCHEDULE_CONFIG}), which book the non-required helper Success (the escape under test).
+   *
+   * <p>Constructibility: CLEANLY CONSTRUCTIBLE on the old read path. Both resources are fully AVAILABLE
+   * over the 11:30-12:30 straddle-noon window (shared member OH 08-16 + Confirmed Shift 08-16), so
+   * availability is NOT the discriminator — only territory coverage is: resourceB's ServiceTerritoryMember
+   * is narrowed (by a follow-up PATCH after its Shift exists, so the full-day Shift survives) to END at
+   * noon, so its membership OVERLAPS but does not CONTAIN the straddle-noon window. The classic
+   * multi-resource read AND-intersects the required resources over the STM-committed window → A+B (B
+   * required) = 0 slots, A-only > 0. This mirrors the WFS territory fixture's partial-membership
+   * isolation shape.
+   *
+   * <p>KEY PARITY FINDING (both products agree): a non-required out-of-territory helper BOOKS (it is not
+   * territory/membership-checked, so it may violate territory coverage) and is read-EXCLUDED when that
+   * same resource is named a hard required constraint; the required-control write is REFUSED
+   * (territory-checked). Old read EXCLUDED + old helper BOOKED + old required-control REFUSED + 264
+   * helper BOOKED → 1b territory parity CONFIRMED.
+   *
+   * <p>262-proxy caveat: the 264 verdict is 262-observed and stands in for 264 (endpoints identical
+   * 262↔264 per the parity effort). 1b is crash-free (MatchTerritory is a clean fitness rule), so it is
+   * unaffected by the 262-specific crash caveats (1.4 / 3). A divergence, were it to appear, would be
+   * asserted faithfully rather than forced to a green.
+   *
+   * <p>Old-side revUps mint 2 fresh {@code sched-terr-*@revoman.org} users per run and never clean up;
+   * three old-side revUps here (read + two write arms) → ~6 fresh users/run. The leading success guard
+   * ({@code firstUnIgnoredUnsuccessfulStepReport() == null}) surfaces a rolled-back fixture/grant loudly;
+   * the read/book acts carry {@code ignoreHTTPStatusUnsuccessful} so legit 400s / empty reads do not trip
+   * it.
+   */
+  @Test
+  void testHelperTerritoryParity_1b_E2E() {
+    SchedulerParityConfig.assumeBothOrgCreds();
+
+    // --- OLD side: read decision + write (helper) + write (required control), fresh revUps ---
+    // Each old-side revUp mirrors the probe sequence: AUTH → FIXTURE (graph + STM-narrowing PATCH) →
+    // GRANT (Lightning-Scheduler user-access, else the classic engine prunes the fixture resources →
+    // dead read/write) → READ/BOOK.
+    final var oldReadEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_TERRITORY_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_GRANT_LS_ACCESS_CONFIG,
+                    SchedulerParityConfig.OLD_GET_SLOTS_TERRITORY_CONFIG))
+            .mutableEnv;
+    final var oldReadDecision =
+        SchedulerParityConfig.oldReadDecision(oldReadEnv.getAsString("oldReadWithBSlotCount"));
+    // Non-vacuity guard: the A-only (clean, in-territory) control read MUST offer >0 slots, proving the
+    // fixture (and the Lightning-Scheduler user-access grant) is live. Without this, a silently-failed
+    // grant would make BOTH reads 0 → EXCLUDED would pass for the WRONG reason (dead read, not
+    // resourceB's out-of-territory membership).
+    assertThat(oldReadEnv.getAsString("oldReadAOnlySlotCount")).isNotEqualTo("0");
+
+    final var oldHelperEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_TERRITORY_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_GRANT_LS_ACCESS_CONFIG,
+                    SchedulerParityConfig.OLD_BOOK_TERRITORY_NON_REQUIRED_CONFIG))
+            .mutableEnv;
+    final var oldHelperOutcome =
+        SchedulerParityConfig.oldWriteOutcome(
+            oldHelperEnv.getAsString("oldWriteHelperSaId"),
+            oldHelperEnv.getAsString("oldWriteHelperHttp"));
+
+    final var oldControlEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_TERRITORY_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_GRANT_LS_ACCESS_CONFIG,
+                    SchedulerParityConfig.OLD_BOOK_TERRITORY_REQUIRED_CONTROL_CONFIG))
+            .mutableEnv;
+    final var oldControlOutcome =
+        SchedulerParityConfig.oldWriteOutcome(
+            oldControlEnv.getAsString("oldWriteRequiredControlSaId"),
+            oldControlEnv.getAsString("oldWriteRequiredControlHttp"));
+
+    // --- 264 side (262 proxy): reuse the proven WFS territory acts, one revUp. The territory scenario
+    // has ONE act (the non-required helper booking Success is the escape under test); there is no 264
+    // required-control act for territory, so the required→REFUSED axis is proven on the OLD side only. ---
+    final var unifiedEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    ReVomanConfigForWfs.AUTH_CONFIG,
+                    ReVomanConfigForWfs.TERRITORY_PARTIAL_POLICY_CONFIG,
+                    ReVomanConfigForWfs.TERRITORY_FIXTURE_CONFIG,
+                    ReVomanConfigForWfs.TERRITORY_SCHEDULE_CONFIG))
+            .mutableEnv;
+    final var unifiedHelperOutcome =
+        SchedulerParityConfig.unifiedWriteOutcome(
+            unifiedEnv.getAsString("territoryNonReqSchedulingStatus"), "201");
+
+    // --- PARITY: both products book the non-required out-of-territory helper (helper is NOT territory-
+    // checked) ---
+    // Shape guard: the old-side helper booking must return a real ServiceAppointment id (18-char, 08p
+    // prefix), so BOOKED reflects a genuine persist, not an empty pass.
+    assertThat(oldHelperEnv.getAsString("oldWriteHelperSaId")).hasLength(18);
+    assertThat(oldHelperEnv.getAsString("oldWriteHelperSaId")).startsWith("08p");
+    assertThat(oldHelperOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.BOOKED);
+    assertThat(unifiedHelperOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.BOOKED);
+    assertThat(oldHelperOutcome).isEqualTo(unifiedHelperOutcome);
+    // Old read excludes the out-of-territory resource when it is a hard required id (the old-side
+    // territory proof).
+    assertThat(oldReadDecision).isEqualTo(SchedulerParityConfig.ReadDecision.EXCLUDED);
+    // Old required control (the out-of-territory resource named required) is REFUSED → the old-side
+    // territory-checked proof (isolates the helper Success to the non-required flag).
+    assertThat(oldControlOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.REFUSED);
+    // 264 helper (out-of-territory resource as non-required) books Success → the Unified escape it shares
+    // with old.
+    assertThat(unifiedEnv.getAsString("territoryNonReqSchedulingStatus")).isEqualTo("Success");
+  }
+
+  /**
+   * Decision 1d parity — a NON-required helper whose ONLY disqualifier is its territory-member ROLE:
+   * resourceB is a SECONDARY ({@code TerritoryType='S'}) member under a PRIMARY-ONLY SchedulingPolicy
+   * ({@code ShouldUsePrimaryMembers=true, ShouldUseSecondaryMembers=false}). This is the cleanest
+   * WorkingLocations isolation — resourceB IS a member (not a non-member exclusion) and is fully AVAILABLE
+   * at the window (member OH 10-14 + Confirmed Shift 10-14 both cover the 11:00-11:30 booking, the proven
+   * 1.5 double-book resourceA window), so its Secondary ROLE alone excludes it. OLD Salesforce Scheduler vs
+   * 264 Unified OnSite (262 proxy) must agree: the Secondary
+   * helper BOOKS (a non-required resource is not eligibility-checked, so its Secondary role escapes the
+   * WorkingLocations rule); the OLD read EXCLUDES that same Secondary resource when it is a hard required
+   * constraint (the primary-only STM filter drops it), and the OLD required-control write is REFUSED.
+   *
+   * <p>Old side: public Scheduler REST ({@code POST /scheduling/getAppointmentSlots} + {@code POST
+   * /connect/scheduling/service-appointments}), each carrying {@code schedulingPolicyId} = the seeded
+   * primary-only {@code AppointmentSchedulingPolicy}. The classic engine reads the primary/secondary
+   * booleans straight off that policy entity and applies them as a ServiceTerritoryMember SOQL filter
+   * ({@code SchedulingDbUtil.createPrimarySecondarySTMWhereCondition} → {@code TerritoryType IN ('P','R')}),
+   * on BOTH the read and the booking availability check — so a Secondary-only resource is dropped by ROLE
+   * (JDWP/source-confirmed: {@code scheduling-impl/.../SchedulingDbUtil.java}). Unified side: the existing
+   * WFS working-locations Connect act under the primary-only WorkingTerritories(IsPrimaryLocationEnabled)
+   * policy, which books the non-required Secondary helper Success (the 264 helper-escape finding).
+   *
+   * <p>KEY PARITY FINDING (both products agree): a non-required Secondary-member helper BOOKS (it is not
+   * eligibility-checked, so its WorkingLocations role is never evaluated) and is read-EXCLUDED / write-
+   * REFUSED when that same Secondary resource is named a hard required constraint → 1d parity CONFIRMED.
+   *
+   * <p>262-proxy caveat: the Unified verdict is 262-observed and stands in for 264 (endpoints identical
+   * 262↔264 per the parity effort). 1d is crash-free. A divergence, were it to appear, is a first-class
+   * finding asserted faithfully rather than forced to a green.
+   *
+   * <p>Old-side revUps mint 2 fresh {@code sched-wl-*@revoman.org} users per run and never clean up; three
+   * old-side revUps here (read + two write arms) → ~6 fresh users/run. The leading success guard ({@code
+   * firstUnIgnoredUnsuccessfulStepReport() == null}) surfaces a rolled-back fixture/grant loudly at the
+   * fixture step; the read/book acts carry {@code ignoreHTTPStatusUnsuccessful} so legit 400s / empty reads
+   * do not trip it.
+   */
+  @Test
+  void testHelperWorkingLocationsParity_1d_E2E() {
+    SchedulerParityConfig.assumeBothOrgCreds();
+
+    // --- OLD side: read decision + write (helper) + write (required control), fresh revUps ---
+    // Each old-side revUp mirrors the probe sequence: AUTH → FIXTURE (seeds the primary-only policy + P/S
+    // member graph) → GRANT (Lightning-Scheduler user-access, else the classic engine prunes the fixture
+    // resources → dead read/write) → READ/BOOK (each passing schedulingPolicyId = the primary-only policy).
+    final var oldReadEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_WORKLOC_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_GRANT_LS_ACCESS_CONFIG,
+                    SchedulerParityConfig.OLD_GET_SLOTS_WORKLOC_CONFIG))
+            .mutableEnv;
+    final var oldReadDecision =
+        SchedulerParityConfig.oldReadDecision(oldReadEnv.getAsString("oldReadWithBSlotCount"));
+    // Non-vacuity guard: the A-only (Primary member) control read MUST offer >0 slots, proving the fixture,
+    // the primary-only policy, and the Lightning-Scheduler user-access grant are all live. Without this, a
+    // silently-failed grant or an over-broad policy would make BOTH reads 0 → EXCLUDED would pass for the
+    // WRONG reason (dead read, not the Secondary role).
+    assertThat(oldReadEnv.getAsString("oldReadAOnlySlotCount")).isNotEqualTo("0");
+
+    final var oldHelperEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_WORKLOC_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_GRANT_LS_ACCESS_CONFIG,
+                    SchedulerParityConfig.OLD_BOOK_WORKLOC_NON_REQUIRED_CONFIG))
+            .mutableEnv;
+    final var oldHelperOutcome =
+        SchedulerParityConfig.oldWriteOutcome(
+            oldHelperEnv.getAsString("oldWriteHelperSaId"),
+            oldHelperEnv.getAsString("oldWriteHelperHttp"));
+
+    final var oldControlEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_WORKLOC_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_GRANT_LS_ACCESS_CONFIG,
+                    SchedulerParityConfig.OLD_BOOK_WORKLOC_REQUIRED_CONTROL_CONFIG))
+            .mutableEnv;
+    final var oldControlOutcome =
+        SchedulerParityConfig.oldWriteOutcome(
+            oldControlEnv.getAsString("oldWriteRequiredControlSaId"),
+            oldControlEnv.getAsString("oldWriteRequiredControlHttp"));
+
+    // --- 264 side (262 proxy): reuse the proven WFS working-locations acts under the primary-only policy ---
+    final var unifiedEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    ReVomanConfigForWfs.AUTH_CONFIG,
+                    ReVomanConfigForWfs.AVAILABILITY_OP_HOURS_POLICY_CONFIG,
+                    ReVomanConfigForWfs.WORKING_LOCATIONS_FIXTURE_CONFIG,
+                    ReVomanConfigForWfs.WORKING_LOCATIONS_SCHEDULE_CONFIG))
+            .mutableEnv;
+    final var unifiedHelperOutcome =
+        SchedulerParityConfig.unifiedWriteOutcome(
+            unifiedEnv.getAsString("workingLocationsSecondaryNonReqSchedulingStatus"), "201");
+
+    // --- PARITY: both products book the non-required Secondary-member helper (helper is NOT eligibility-checked) ---
+    // Shape guard: the old-side helper booking must return a real ServiceAppointment id (18-char, 08p
+    // prefix), so BOOKED reflects a genuine persist, not an empty pass.
+    assertThat(oldHelperEnv.getAsString("oldWriteHelperSaId")).hasLength(18);
+    assertThat(oldHelperEnv.getAsString("oldWriteHelperSaId")).startsWith("08p");
+    assertThat(oldHelperOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.BOOKED);
+    assertThat(unifiedHelperOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.BOOKED);
+    assertThat(oldHelperOutcome).isEqualTo(unifiedHelperOutcome);
+    // Old read excludes the Secondary resource when it is a hard required id (the old-side ROLE proof).
+    assertThat(oldReadDecision).isEqualTo(SchedulerParityConfig.ReadDecision.EXCLUDED);
+    // Old required control (Secondary resource named required) is REFUSED → the old-side ROLE-enforcement proof.
+    assertThat(oldControlOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.REFUSED);
+    // Unified helper (non-required Secondary member) books Success → the 264 WorkingLocations helper-escape finding.
+    assertThat(unifiedEnv.getAsString("workingLocationsSecondaryNonReqSchedulingStatus"))
+        .isEqualTo("Success");
+  }
+
+  /**
+   * Decision 1a parity — a NON-required helper on the ACCOUNT's block-list (an account
+   * ResourcePreference of PreferenceType=Excluded naming resourceB). resourceA is clean; only the
+   * Excluded rule is in play. Does the scheduling engine fitness-check the non-required helper against
+   * the account block-list on the WRITE (book) path?
+   *
+   * <p>KEY PARITY FINDING (both products agree on the write axis): the non-required Excluded helper is
+   * NOT fitness-checked on the book path, so the SA BOOKS on both engines. 264 Unified: the WFS
+   * schedule-excluded-non-required act returns schedulingStatus=Success (the helper escapes
+   * ExcludedResources). OLD Salesforce Scheduler: {@code POST /connect/scheduling/service-appointments}
+   * validates only the required/primary resources and passes {@code accountResourcePreferences=null}
+   * (ServiceAppointmentHelper.areResourcesAvailable → SchedulingServiceImpl.getAppointmentSlots), so the
+   * account ResourcePreference(Excluded) is never evaluated on write → the SA books with an {@code 08p}
+   * serviceAppointmentId. → WRITE parity CONFIRMED (both BOOKED).
+   *
+   * <p>PARTIAL / path-dependent constructibility (read axis): on the OLD engine the account
+   * ResourcePreference(Excluded) is enforced ONLY on the {@code POST /scheduling/getAppointmentCandidates}
+   * path (SchedulingServiceImpl.getAppointmentCandidates → loadAccountResourcePreferences(accountId) →
+   * SchedulingDbUtil.checkResourcePrefs PRUNES the excluded SR), NOT on plain getAppointmentSlots
+   * (accountResourcePreferences=null → checkResourcePrefs short-circuits true, SchedulingDbUtil ~L706-708).
+   * So the OLD read probe uses getAppointmentCandidates: WITH accountId, resourceB is pruned (absent from
+   * every candidate's {@code resources[]}) → EXCLUDED; the NO-account control keeps resourceB present
+   * (non-vacuity: the fixture is live and resourceB is a real, available candidate — its WITH-account
+   * absence is caused by the Excluded pref, not a dead read). NOTE the read axis is thus a candidate-
+   * pruning decision (a DIFFERENT surface from the book-time "helper fitness" the write asks); it is
+   * constructible on the candidates path but does not have a clean non-required-vs-required control there
+   * (getAppointmentCandidates has no per-resource required/non-required input). The write axis carries the
+   * true 1a parity verdict; the read is captured faithfully as supporting evidence, not forced to mirror
+   * the write.
+   *
+   * <p>262-proxy caveat: the 264 verdict is 262-observed (endpoints identical 262↔264 per the parity
+   * effort); 1a is crash-free so it is unaffected by the 262-specific INTERNAL_SERVER_ERROR bugs (1.4 / 3).
+   *
+   * <p>Old-side revUps mint 2 fresh {@code sched-excl-*@revoman.org} users per run and never clean up; two
+   * old-side revUps here (candidates read + book) → ~4 fresh users/run. The leading success guard ({@code
+   * firstUnIgnoredUnsuccessfulStepReport() == null}) surfaces a rolled-back fixture/grant loudly at the
+   * fixture step; the read/book acts carry {@code ignoreHTTPStatusUnsuccessful} so legit non-2xx / empty
+   * reads do not trip it.
+   */
+  @Test
+  void testHelperExcludedParity_1a_E2E() {
+    SchedulerParityConfig.assumeBothOrgCreds();
+
+    // --- OLD side: candidates read decision (with vs without accountId), fresh revUp ---
+    // AUTH → FIXTURE → GRANT (Lightning-Scheduler user-access, else the classic engine prunes the
+    // fixture resources → dead read) → CANDIDATES read (with accountId + no-account control).
+    final var oldReadEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_EXCLUDED_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_GRANT_LS_ACCESS_CONFIG,
+                    SchedulerParityConfig.OLD_GET_CANDIDATES_EXCLUDED_CONFIG))
+            .mutableEnv;
+    final var oldExcludedReadDecision =
+        SchedulerParityConfig.oldCandidatesReadDecision(
+            oldReadEnv.getAsString("oldCandidatesWithAcctResourceBPresent"));
+    // Non-vacuity: the NO-account control MUST keep resourceB present (proves the fixture is live and
+    // resourceB is a real candidate at the window — so its WITH-account absence is the Excluded pref,
+    // not a dead read / silently-failed grant). resourceA must also be a candidate in the WITH-account read.
+    assertThat(oldReadEnv.getAsString("oldCandidatesNoAcctResourceBPresent")).isEqualTo("1");
+    assertThat(oldReadEnv.getAsString("oldCandidatesWithAcctResourceAPresent")).isEqualTo("1");
+
+    // --- OLD side: write (book) the non-required Excluded helper, fresh revUp ---
+    final var oldHelperEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_EXCLUDED_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_GRANT_LS_ACCESS_CONFIG,
+                    SchedulerParityConfig.OLD_BOOK_EXCLUDED_NON_REQUIRED_CONFIG))
+            .mutableEnv;
+    final var oldHelperOutcome =
+        SchedulerParityConfig.oldWriteOutcome(
+            oldHelperEnv.getAsString("oldWriteHelperSaId"),
+            oldHelperEnv.getAsString("oldWriteHelperHttp"));
+
+    // --- 264 side (262 proxy): reuse the proven WFS excluded-non-required acts, one revUp ---
+    final var unifiedEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    ReVomanConfigForWfs.AUTH_CONFIG,
+                    ReVomanConfigForWfs.EXCLUDED_RESOURCES_POLICY_CONFIG,
+                    ReVomanConfigForWfs.EXCLUDED_FIXTURE_CONFIG,
+                    ReVomanConfigForWfs.EXCLUDED_SCHEDULE_CONFIG))
+            .mutableEnv;
+    final var unifiedHelperOutcome =
+        SchedulerParityConfig.unifiedWriteOutcome(
+            unifiedEnv.getAsString("excludedNonReqSchedulingStatus"), "201");
+
+    // --- PARITY (write axis — the 1a verdict): both products book the non-required Excluded helper ---
+    // Shape guard: the old-side helper booking returns a real 18-char ServiceAppointment id (08p prefix),
+    // so BOOKED reflects a genuine persist, not an empty pass.
+    assertThat(oldHelperEnv.getAsString("oldWriteHelperSaId")).hasLength(18);
+    assertThat(oldHelperEnv.getAsString("oldWriteHelperSaId")).startsWith("08p");
+    assertThat(oldHelperOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.BOOKED);
+    assertThat(unifiedHelperOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.BOOKED);
+    assertThat(oldHelperOutcome).isEqualTo(unifiedHelperOutcome);
+    // Read-axis evidence (path-dependent, supporting): the OLD candidates read PRUNES the account-Excluded
+    // resourceB (EXCLUDED) — the account block-list is applied on the candidates surface.
+    assertThat(oldExcludedReadDecision).isEqualTo(SchedulerParityConfig.ReadDecision.EXCLUDED);
+  }
+
+  @Test
+  void testHelperSkillsParity_1c_E2E() {
+    SchedulerParityConfig.assumeBothOrgCreds();
+
+    // --- OLD side: read decisions (single B, single A, multi helper), one revUp; then the helper write.
+    // Each old-side revUp mirrors AUTH → FIXTURE (skills-helper: create-skill + graph) → GRANT
+    // (Lightning-Scheduler user-access, else the classic engine prunes the resources → dead read/write) →
+    // READ/BOOK.
+    final var oldReadEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_SKILLS_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_GRANT_LS_ACCESS_CONFIG,
+                    SchedulerParityConfig.OLD_GET_SLOTS_SKILLS_CONFIG))
+            .mutableEnv;
+    // Single-resource path: skill-less B alone is skill-checked → EXCLUDED; skilled A alone → INCLUDED.
+    final var oldReadBOnlyDecision =
+        SchedulerParityConfig.oldReadDecision(oldReadEnv.getAsString("oldReadBOnlySlotCount"));
+    // Multi-resource path: B is a non-primary helper, skill-checked on the PRIMARY only → B ESCAPES.
+    final var oldReadMultiHelperDecision =
+        SchedulerParityConfig.oldReadDecision(
+            oldReadEnv.getAsString("oldReadMultiHelperSlotCount"));
+    // Non-vacuity guard: skilled A alone MUST offer > 0 slots, proving the fixture + grant are live.
+    // Without this, a silently-failed grant would zero BOTH reads → EXCLUDED would pass for the WRONG
+    // reason (dead read, not the missing skill).
+    assertThat(oldReadEnv.getAsString("oldReadAOnlySlotCount")).isNotEqualTo("0");
+
+    final var oldHelperEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_SKILLS_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_GRANT_LS_ACCESS_CONFIG,
+                    SchedulerParityConfig.OLD_BOOK_SKILLS_NON_REQUIRED_CONFIG))
+            .mutableEnv;
+    final var oldHelperOutcome =
+        SchedulerParityConfig.oldWriteOutcome(
+            oldHelperEnv.getAsString("oldWriteHelperSaId"),
+            oldHelperEnv.getAsString("oldWriteHelperHttp"));
+
+    // --- 264 side (262 proxy): reuse the proven WFS skills acts, one revUp. The non-required skill-less
+    // helper escapes MatchSkills on the required-only write path → Success (skillsNonReqSchedulingStatus).
+    final var unifiedEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    ReVomanConfigForWfs.AUTH_CONFIG,
+                    ReVomanConfigForWfs.MATCH_SKILLS_POLICY_CONFIG,
+                    ReVomanConfigForWfs.SKILLS_SKILL_FIXTURE_CONFIG,
+                    ReVomanConfigForWfs.SKILLS_FIXTURE_CONFIG,
+                    ReVomanConfigForWfs.SKILLS_SCHEDULE_CONFIG))
+            .mutableEnv;
+    final var unifiedHelperOutcome =
+        SchedulerParityConfig.unifiedWriteOutcome(
+            unifiedEnv.getAsString("skillsNonReqSchedulingStatus"), "201");
+
+    // --- The OLD engine HAS the Skills rule (single-resource path proof) ---
+    // Skill-less B named the SOLE required resource is skill-checked → EXCLUDED (0 slots).
+    assertThat(oldReadBOnlyDecision).isEqualTo(SchedulerParityConfig.ReadDecision.EXCLUDED);
+
+    // --- PARITY (helper escapes; PARTIAL — different mechanism) ---
+    // Shape guard: the old-side helper booking returns a real 18-char, 08p ServiceAppointment id, so
+    // BOOKED reflects a genuine persist, not an empty pass.
+    assertThat(oldHelperEnv.getAsString("oldWriteHelperSaId")).hasLength(18);
+    assertThat(oldHelperEnv.getAsString("oldWriteHelperSaId")).startsWith("08p");
+    // OLD non-required skill-less helper BOOKS (not skill-fitness-checked as a non-primary helper) …
+    assertThat(oldHelperOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.BOOKED);
+    // … and on the read the multi helper (A primary + B required) is INCLUDED (B escapes → slots > 0),
+    // the primary-only-skill-matching mechanism made observable on the read axis too.
+    assertThat(oldReadMultiHelperDecision).isEqualTo(SchedulerParityConfig.ReadDecision.INCLUDED);
+    // 264 non-required skill-less helper also BOOKS (escapes MatchSkills on the required-only path) …
+    assertThat(unifiedHelperOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.BOOKED);
+    // … so OLD and 264 AGREE on the observable helper-escape write outcome (mechanism differs → PARTIAL).
+    assertThat(oldHelperOutcome).isEqualTo(unifiedHelperOutcome);
+  }
+
+  @Test
+  void testHelperRequiredResourceParity_1_4_E2E() {
+    SchedulerParityConfig.assumeBothOrgCreds();
+
+    // --- OLD side: candidates read (account demands resourceB, only resourceA offered) ---
+    // AUTH → FIXTURE (Account ResourcePreference Required=resourceB + policy ShouldEnforceRequiredResource)
+    // → GRANT (Lightning-Scheduler user-access, else the classic engine prunes the resources → dead read)
+    // → getAppointmentCandidates (A-only probe + B-required control).
+    final var oldReadEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_REQUIRED_HELPER_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_GRANT_LS_ACCESS_CONFIG,
+                    SchedulerParityConfig.OLD_GET_CANDIDATES_REQUIRED_CONFIG))
+            .mutableEnv;
+    final var oldReadOutcome =
+        SchedulerParityConfig.oldCandidatesOutcome(
+            oldReadEnv.getAsString("oldCandidatesWithBReqCount"),
+            oldReadEnv.getAsString("oldCandidatesWithBReqHttp"),
+            oldReadEnv.getAsString("oldCandidatesWithBReqErrorCode"));
+    // Non-vacuity guard: the B-required control (the account-required worker, offered) MUST return >0
+    // candidates, proving the fixture + the required-resources policy + the Lightning-Scheduler grant are
+    // all live. Without this, a dead read would make the A-only 0-count REFUSE pass for the WRONG reason.
+    assertThat(oldReadEnv.getAsString("oldCandidatesBReqCount")).isNotEqualTo("0");
+
+    // --- OLD side: write (resourceA required+primary + resourceB non-required helper) ---
+    final var oldWriteEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    SchedulerParityConfig.OLD_AUTH_CONFIG,
+                    SchedulerParityConfig.OLD_REQUIRED_HELPER_FIXTURE_CONFIG,
+                    SchedulerParityConfig.OLD_GRANT_LS_ACCESS_CONFIG,
+                    SchedulerParityConfig.OLD_BOOK_REQUIRED_NON_REQUIRED_CONFIG))
+            .mutableEnv;
+    final var oldWriteOutcome =
+        SchedulerParityConfig.oldWriteOutcome(
+            oldWriteEnv.getAsString("oldWriteReqHelperSaId"),
+            oldWriteEnv.getAsString("oldWriteReqHelperHttp"));
+
+    // --- 264 side (262 proxy): reuse the proven WFS Required-resources acts (violating + control) ---
+    final var unifiedEnv =
+        CollectionsKt.last(
+                ReVoman.revUp(
+                    (r, ignore) -> assertThat(r.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+                    ReVomanConfigForWfs.AUTH_CONFIG,
+                    ReVomanConfigForWfs.REQUIRED_RESOURCES_POLICY_CONFIG,
+                    ReVomanConfigForWfs.REQUIRED_NON_REQUIRED_FIXTURE_CONFIG,
+                    ReVomanConfigForWfs.REQUIRED_NON_REQUIRED_SATISFIER_VIOLATING_SCHEDULE_CONFIG,
+                    ReVomanConfigForWfs.REQUIRED_SATISFIER_BOOKABLE_SCHEDULE_CONFIG))
+            .mutableEnv;
+    final var unifiedViolatingOutcome =
+        SchedulerParityConfig.unifiedWriteOutcomeFromErrorCode(
+            unifiedEnv.getAsString("requiredNonReqSatisfierStatus"),
+            unifiedEnv.getAsString("requiredNonReqSatisfierErrorCode"));
+
+    // --- 264 CRASH asserted verbatim (the locked-in 262 serviceTerritoryMembers NPE) ---
+    assertThat(unifiedEnv.getAsString("requiredNonReqSatisfierErrorCode"))
+        .isEqualTo("INTERNAL_SERVER_ERROR");
+    assertThat(unifiedEnv.getAsString("requiredNonReqSatisfierErrorMessage"))
+        .contains("serviceTerritoryMembers");
+    assertThat(unifiedViolatingOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.CRASHED);
+    // 264 control (resourceB flipped to required) → no RequiredResources satisfaction error.
+    assertThat(unifiedEnv.getAsString("requiredSatisfierControlErrorCode"))
+        .isNotEqualTo("RequiredResources");
+
+    // --- OLD outcomes pinned verbatim (characterization, NOT forced to match 264) ---
+    // OLD read cleanly REFUSES: the account-required pool filter drops the non-required resourceA → 0
+    // candidates, HTTP 200, no INTERNAL_SERVER_ERROR (the classic ServiceTerritory never NPEs on
+    // serviceTerritoryMembers). This is the crash-vs-clean DIVERGENCE from the 264 write.
+    assertThat(oldReadEnv.getAsString("oldCandidatesWithBReqCount")).isEqualTo("0");
+    assertThat(oldReadEnv.getAsString("oldCandidatesWithBReqErrorCode")).isNotEqualTo("INTERNAL_SERVER_ERROR");
+    assertThat(oldReadOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.REFUSED);
+    // OLD write ALSO cleanly REFUSES (LIVE-OBSERVED): HTTP 400, errorCode=INTERNAL_ERROR, message "We
+    // couldn't find any resources for your request." — no SA id, and crucially NOT a 500 crash. The classic
+    // book path's internal slot-gen consults the account-required-resource enforcement and cannot satisfy
+    // the account's demand for resourceB (present only as a non-required helper) → no resources found →
+    // refuse. (The initial hypothesis that the write would BOOK resourceA outright was refuted by the org.)
+    assertThat(oldWriteEnv.getAsString("oldWriteReqHelperSaId")).isEmpty();
+    assertThat(oldWriteEnv.getAsString("oldWriteReqHelperHttp")).isEqualTo("400");
+    assertThat(oldWriteEnv.getAsString("oldWriteReqHelperErrorCode")).isEqualTo("INTERNAL_ERROR");
+    assertThat(oldWriteEnv.getAsString("oldWriteReqHelperErrorMessage"))
+        .contains("couldn't find any resources");
+    assertThat(oldWriteOutcome).isEqualTo(SchedulerParityConfig.WriteOutcome.REFUSED);
+
+    // --- DIVERGENCE recorded: OLD refuses CLEANLY on BOTH axes (read 200/empty candidates; write 400
+    // INTERNAL_ERROR) while the 264 write CRASHES (500 INTERNAL_SERVER_ERROR serviceTerritoryMembers NPE).
+    // OLD ≠ 264 on both axes — a crash-vs-clean divergence, asserted verbatim, NOT forced to a green. ---
+    assertThat(oldReadOutcome).isNotEqualTo(unifiedViolatingOutcome);
+    assertThat(oldWriteOutcome).isNotEqualTo(unifiedViolatingOutcome);
+  }
 }

--- a/src/integrationTest/java/com/salesforce/revoman/integration/core/wfs/ReVomanConfigForWfs.java
+++ b/src/integrationTest/java/com/salesforce/revoman/integration/core/wfs/ReVomanConfigForWfs.java
@@ -256,16 +256,19 @@ public final class ReVomanConfigForWfs {
       kickFor(V3_WFS_PATH + "booking/schedule-required-satisfier-bookable");
 
   // ## Decision 3 — missing isRequiredResource flag (crash characterization) + the L142 control.
-  static final Kick MISSING_REQUIRED_FLAG_SCHEDULE_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick MISSING_REQUIRED_FLAG_SCHEDULE_CONFIG =
       kickFor(V3_WFS_PATH + "booking/schedule-missing-required-flag");
-  static final Kick SINGLE_REQUIRED_NO_PRIMARY_SCHEDULE_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick SINGLE_REQUIRED_NO_PRIMARY_SCHEDULE_CONFIG =
       kickFor(V3_WFS_PATH + "booking/schedule-single-required-no-primary");
 
   // ## Decision 4 — two primary resources → clean input-validation reject (INVALID_INPUT / HTTP
   // 400,
   // "Only one of the provided assigned resource can be a primary resource"). Caught up front in
   // ScheduleCommonValidator.validatePrimaryResourceConstraints, before availability/persist.
-  static final Kick SCHEDULE_TWO_PRIMARY_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick SCHEDULE_TWO_PRIMARY_CONFIG =
       kickFor(V3_WFS_PATH + "booking/schedule-two-primary");
 
   // ## Decision 5 — a primary resource marked NOT required is REJECTED at persist (no auto-correct,
@@ -273,9 +276,11 @@ public final class ReVomanConfigForWfs {
   // double-book). Probe: single isPrimaryResource=true, isRequiredResource=false → persist
   // INVALID_FIELD.
   // Control: flip isRequiredResource=true → Success (isolates the reject to the not-required flag).
-  static final Kick SCHEDULE_PRIMARY_NOT_REQUIRED_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick SCHEDULE_PRIMARY_NOT_REQUIRED_CONFIG =
       kickFor(V3_WFS_PATH + "booking/schedule-primary-not-required");
-  static final Kick SCHEDULE_PRIMARY_REQUIRED_CONTROL_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick SCHEDULE_PRIMARY_REQUIRED_CONTROL_CONFIG =
       kickFor(V3_WFS_PATH + "booking/schedule-primary-required-control");
 
   // ## Decision 4z — there is NO "reschedule must keep a primary" rule (the product doc's blanket
@@ -297,11 +302,16 @@ public final class ReVomanConfigForWfs {
   // only to delete-ALL, not to this delete-primary-leaving-one case. Characterized faithfully
   // (availability, not no-primary). Clean two-resource schedule sets up reschedCleanSaId for both
   // arms.
-  static final Kick SCHEDULE_TWO_RESOURCE_CLEAN_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public (visibility only, no wiring change) so the
+  // * Scheduler↔Unified Decision-4z parity test (SchedulerVsUnifiedParityE2ETest
+  // * .testRescheduleNoPrimaryParity_4z_E2E) can reuse the proven 264 reschedule-no-primary acts.
+  public static final Kick SCHEDULE_TWO_RESOURCE_CLEAN_CONFIG =
       kickFor(V3_WFS_PATH + "booking/schedule-two-resource-clean");
-  static final Kick RESCHEDULE_DELETE_PRIMARY_WITH_FLAG_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick RESCHEDULE_DELETE_PRIMARY_WITH_FLAG_CONFIG =
       kickFor(V3_WFS_PATH + "booking/reschedule-delete-primary-with-flag");
-  static final Kick RESCHEDULE_DELETE_PRIMARY_NO_FLAG_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick RESCHEDULE_DELETE_PRIMARY_NO_FLAG_CONFIG =
       kickFor(V3_WFS_PATH + "booking/reschedule-delete-primary-no-flag");
 
   // ## Decision 4z delete-ALL probe — deletes BOTH assigned resources (no isPrimaryResource flag on
@@ -339,9 +349,11 @@ public final class ReVomanConfigForWfs {
   // workspace default OnSite policy carries the seeded DefaultOnSiteSchdPlcy_LoadBalancing
   // objective, so
   // the read acts omit schedulingPolicyName and rely on the default policy.
-  static final Kick GET_RESOURCES_LIMIT_ZERO_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick GET_RESOURCES_LIMIT_ZERO_CONFIG =
       kickFor(V3_WFS_PATH + "booking/get-available-resources-limit-zero");
-  static final Kick GET_RESOURCES_LIMIT_POSITIVE_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick GET_RESOURCES_LIMIT_POSITIVE_CONFIG =
       kickFor(V3_WFS_PATH + "booking/get-available-resources-limit-positive");
 
   // ## Decision 9 — Shift sharing-mode split (user-mode SystemMode.NONE shift read vs SFDC_FULL
@@ -354,14 +366,21 @@ public final class ReVomanConfigForWfs {
   // auto-grants the
   // WorkforceSchedulingPsl seat. The resource-owner User is admin-created (the manager cannot set
   // ProfileId).
-  static final Kick AUTH_PERSONAS_DEC9_CONFIG = kickFor(V3_WFS_PATH + "auth-personas-dec9");
-  static final Kick SHARING_SPLIT_POLICY_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: visibility widened package-private → public so the
+  // * Scheduler↔Unified Decision-9 parity test (SchedulerVsUnifiedParityE2ETest) can reuse the 264 side
+  // * of the sharing-mode-split scenario. Visibility-only change; wiring unchanged.
+  public static final Kick AUTH_PERSONAS_DEC9_CONFIG = kickFor(V3_WFS_PATH + "auth-personas-dec9");
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick SHARING_SPLIT_POLICY_CONFIG =
       kickFor(V3_WFS_PATH + "policies/sharing-split-shifts-policy");
-  static final Kick SHARING_SPLIT_FIXTURE_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick SHARING_SPLIT_FIXTURE_CONFIG =
       kickFor(V3_WFS_PATH + "fixtures/sharing-split-overlapping-shifts");
-  static final Kick GET_SLOTS_SHARING_SPLIT_AS_MANAGER_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick GET_SLOTS_SHARING_SPLIT_AS_MANAGER_CONFIG =
       kickFor(V3_WFS_PATH + "booking/get-slots-sharing-split-as-manager");
-  static final Kick GET_SLOTS_SHARING_SPLIT_AS_CASEWORKER_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick GET_SLOTS_SHARING_SPLIT_AS_CASEWORKER_CONFIG =
       kickFor(V3_WFS_PATH + "booking/get-slots-sharing-split-as-caseworker");
 
   // ## Decision 2 — "is a shown slot a promise?" The cheap checks
@@ -374,13 +393,17 @@ public final class ReVomanConfigForWfs {
   // characterizable on 262 (the three field-match rules are OnField/ESO-internal; the live OnSite
   // path
   // shares read==write) — see the test javadoc + decision log.
-  static final Kick GET_SLOTS_PARITY_AVAILABLE_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick GET_SLOTS_PARITY_AVAILABLE_CONFIG =
       kickFor(V3_WFS_PATH + "booking/get-slots-parity-available");
-  static final Kick GET_SLOTS_PARITY_UNAVAILABLE_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick GET_SLOTS_PARITY_UNAVAILABLE_CONFIG =
       kickFor(V3_WFS_PATH + "booking/get-slots-parity-unavailable");
-  static final Kick SCHEDULE_PARITY_UNAVAILABLE_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick SCHEDULE_PARITY_UNAVAILABLE_CONFIG =
       kickFor(V3_WFS_PATH + "booking/schedule-parity-unavailable");
-  static final Kick SCHEDULE_PARITY_AVAILABLE_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick SCHEDULE_PARITY_AVAILABLE_CONFIG =
       kickFor(V3_WFS_PATH + "booking/schedule-parity-available");
 
   // ## Rules read==write parity — one differential matrix per Common+InBusiness rule. Each rule: a

--- a/src/integrationTest/java/com/salesforce/revoman/integration/core/wfs/ReVomanConfigForWfs.java
+++ b/src/integrationTest/java/com/salesforce/revoman/integration/core/wfs/ReVomanConfigForWfs.java
@@ -186,11 +186,14 @@ public final class ReVomanConfigForWfs {
   // ## Policies (each carries an Availability(C)+ShiftUsage(Union) rule plus the rule under test).
   public static final Kick AVAILABILITY_OP_HOURS_POLICY_CONFIG =
       kickFor(V3_WFS_PATH + "policies/availability-op-hours-policy");
-  static final Kick EXCLUDED_RESOURCES_POLICY_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick EXCLUDED_RESOURCES_POLICY_CONFIG =
       kickFor(V3_WFS_PATH + "policies/excluded-resources-availability-policy");
-  static final Kick TERRITORY_PARTIAL_POLICY_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick TERRITORY_PARTIAL_POLICY_CONFIG =
       kickFor(V3_WFS_PATH + "policies/territory-membership-partial-policy");
-  static final Kick MATCH_SKILLS_POLICY_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick MATCH_SKILLS_POLICY_CONFIG =
       kickFor(V3_WFS_PATH + "policies/match-skills-non-required-policy");
   static final Kick VISITING_HOURS_POLICY_CONFIG =
       kickFor(V3_WFS_PATH + "policies/visiting-hours-op-hours-policy");
@@ -198,22 +201,30 @@ public final class ReVomanConfigForWfs {
   // ## Decision 1.4 — required-resource demand (account ResourcePreference) cannot be satisfied by
   // a
   // NON-required helper.
-  static final Kick REQUIRED_RESOURCES_POLICY_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick REQUIRED_RESOURCES_POLICY_CONFIG =
       kickFor(V3_WFS_PATH + "policies/required-resources-availability-policy");
 
   // ## Fixtures (composite/graph data graphs: territory/OH/WorkType/resources/account/shifts).
   public static final Kick DOUBLE_BOOK_FIXTURE_CONFIG =
       kickFor(V3_WFS_PATH + "fixtures/double-book-non-required");
-  static final Kick EXCLUDED_FIXTURE_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick EXCLUDED_FIXTURE_CONFIG =
       kickFor(V3_WFS_PATH + "fixtures/excluded-non-required");
-  static final Kick TERRITORY_FIXTURE_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick TERRITORY_FIXTURE_CONFIG =
       kickFor(V3_WFS_PATH + "fixtures/territory-non-required");
-  static final Kick SKILLS_FIXTURE_CONFIG = kickFor(V3_WFS_PATH + "fixtures/skills-non-required");
-  static final Kick SKILLS_SKILL_FIXTURE_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick SKILLS_FIXTURE_CONFIG =
+      kickFor(V3_WFS_PATH + "fixtures/skills-non-required");
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick SKILLS_SKILL_FIXTURE_CONFIG =
       kickFor(V3_WFS_PATH + "fixtures/skills-non-required-skill");
-  static final Kick WORKING_LOCATIONS_FIXTURE_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick WORKING_LOCATIONS_FIXTURE_CONFIG =
       kickFor(V3_WFS_PATH + "fixtures/working-locations-secondary-non-required");
-  static final Kick REQUIRED_NON_REQUIRED_FIXTURE_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick REQUIRED_NON_REQUIRED_FIXTURE_CONFIG =
       kickFor(V3_WFS_PATH + "fixtures/required-non-required");
   static final Kick VISITING_HOURS_FIXTURE_CONFIG =
       kickFor(V3_WFS_PATH + "fixtures/visiting-hours-account-oh");
@@ -225,17 +236,23 @@ public final class ReVomanConfigForWfs {
       kickFor(V3_WFS_PATH + "booking/schedule-double-book-non-required-violating");
   public static final Kick DOUBLE_BOOK_REQUIRED_CONFLICT_SCHEDULE_CONFIG =
       kickFor(V3_WFS_PATH + "booking/schedule-double-book-required-conflict");
-  static final Kick EXCLUDED_SCHEDULE_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick EXCLUDED_SCHEDULE_CONFIG =
       kickFor(V3_WFS_PATH + "booking/schedule-excluded-non-required-violating");
-  static final Kick TERRITORY_SCHEDULE_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick TERRITORY_SCHEDULE_CONFIG =
       kickFor(V3_WFS_PATH + "booking/schedule-territory-membership-non-required-violating");
-  static final Kick SKILLS_SCHEDULE_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick SKILLS_SCHEDULE_CONFIG =
       kickFor(V3_WFS_PATH + "booking/schedule-skills-non-required-violating");
-  static final Kick WORKING_LOCATIONS_SCHEDULE_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick WORKING_LOCATIONS_SCHEDULE_CONFIG =
       kickFor(V3_WFS_PATH + "booking/schedule-working-locations-secondary-non-required-violating");
-  static final Kick REQUIRED_NON_REQUIRED_SATISFIER_VIOLATING_SCHEDULE_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick REQUIRED_NON_REQUIRED_SATISFIER_VIOLATING_SCHEDULE_CONFIG =
       kickFor(V3_WFS_PATH + "booking/schedule-required-non-required-satisfier-violating");
-  static final Kick REQUIRED_SATISFIER_BOOKABLE_SCHEDULE_CONFIG =
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public for cross-package Scheduler-vs-Unified parity reuse; visibility only.
+  public static final Kick REQUIRED_SATISFIER_BOOKABLE_SCHEDULE_CONFIG =
       kickFor(V3_WFS_PATH + "booking/schedule-required-satisfier-bookable");
 
   // ## Decision 3 — missing isRequiredResource flag (crash characterization) + the L142 control.

--- a/src/integrationTest/java/com/salesforce/revoman/integration/core/wfs/ReVomanConfigForWfs.java
+++ b/src/integrationTest/java/com/salesforce/revoman/integration/core/wfs/ReVomanConfigForWfs.java
@@ -178,10 +178,13 @@ public final class ReVomanConfigForWfs {
   // later books/reads against (no admin-token alias; the API-under-test runs as the manager,
   // matching
   // Decision 9). V3 `auth` folder.
-  static final Kick AUTH_CONFIG = kickFor(V3_WFS_PATH + "auth");
+  // * NOTE 2026-07-03 gopal.akshintala: widened to public so the cross-package Scheduler-vs-Unified
+  // * parity slice (…core.scheduler.SchedulerVsUnifiedParityE2ETest) can reuse the 264 double-book
+  // * Kicks unchanged; wiring/behavior untouched.
+  public static final Kick AUTH_CONFIG = kickFor(V3_WFS_PATH + "auth");
 
   // ## Policies (each carries an Availability(C)+ShiftUsage(Union) rule plus the rule under test).
-  static final Kick AVAILABILITY_OP_HOURS_POLICY_CONFIG =
+  public static final Kick AVAILABILITY_OP_HOURS_POLICY_CONFIG =
       kickFor(V3_WFS_PATH + "policies/availability-op-hours-policy");
   static final Kick EXCLUDED_RESOURCES_POLICY_CONFIG =
       kickFor(V3_WFS_PATH + "policies/excluded-resources-availability-policy");
@@ -199,7 +202,7 @@ public final class ReVomanConfigForWfs {
       kickFor(V3_WFS_PATH + "policies/required-resources-availability-policy");
 
   // ## Fixtures (composite/graph data graphs: territory/OH/WorkType/resources/account/shifts).
-  static final Kick DOUBLE_BOOK_FIXTURE_CONFIG =
+  public static final Kick DOUBLE_BOOK_FIXTURE_CONFIG =
       kickFor(V3_WFS_PATH + "fixtures/double-book-non-required");
   static final Kick EXCLUDED_FIXTURE_CONFIG =
       kickFor(V3_WFS_PATH + "fixtures/excluded-non-required");
@@ -218,9 +221,9 @@ public final class ReVomanConfigForWfs {
   // ## Schedule act-steps (the Schedule write call whose response carries the verdict; each
   // captures
   // its schedulingStatus into the env for the JUnit Truth assertion).
-  static final Kick DOUBLE_BOOK_NON_REQUIRED_SCHEDULE_CONFIG =
+  public static final Kick DOUBLE_BOOK_NON_REQUIRED_SCHEDULE_CONFIG =
       kickFor(V3_WFS_PATH + "booking/schedule-double-book-non-required-violating");
-  static final Kick DOUBLE_BOOK_REQUIRED_CONFLICT_SCHEDULE_CONFIG =
+  public static final Kick DOUBLE_BOOK_REQUIRED_CONFLICT_SCHEDULE_CONFIG =
       kickFor(V3_WFS_PATH + "booking/schedule-double-book-required-conflict");
   static final Kick EXCLUDED_SCHEDULE_CONFIG =
       kickFor(V3_WFS_PATH + "booking/schedule-excluded-non-required-violating");

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/auth-personas-old/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/auth-personas-old/.resources/definition.yaml
@@ -1,0 +1,24 @@
+$kind: collection
+description: |-
+  OLD Scheduler (Decision-9) persona setup — the classic-engine mirror of the WFS auth-personas-dec9. All
+  User/password/permset steps run under {{adminToken}} (creating a User + setting ProfileId needs Manage
+  Users, which the manager persona lacks). Provisions the three identities the classic sharing-gate read
+  proof needs on the scheduler org:
+    - MANAGER persona (oldD9ManagerUserId): OWNS the whole Decision-9 fixture graph — critically the
+      ServiceResource + ServiceTerritoryMember (OWD ServiceResource=Private, STM=ControlledByParent) and
+      the Confirmed Shift (OWD=Private). It SOAP-logs in to mint {{oldD9ManagerToken}} (its OWN session).
+      It is the positive-control reader (owner sees its own rows → slots).
+    - CASE-WORKER persona (oldD9CaseWorkerUserId): the sharing-DEPRIVED reader. NOT shared the
+      manager-owned Private ServiceResource/STM/Shift rows. SOAP-logs in to mint {{oldD9CaseWorkerToken}}.
+    - RESOURCE-OWNER user (oldD9ResourceUserId): the User the fixture's ServiceResource points at via
+      RelatedRecordId (so the classic slot-gen's removeResourcesWithoutPerm admits the resource).
+  All three get the Salesforce_Scheduler_Resource permission set (carries the lightningSchedulerUserAccess
+  user-perm the classic REST slot-gen requires) + the LightningSchedulerPsl PSL seat, resolved by
+  10-resolve-scheduler-perm-ids. Sets oldD9ManagerToken, oldD9CaseWorkerToken, oldD9*UserId,
+  oldD9StandardUserProfileId, oldD9SchedulerPsId, oldD9SchedulerPslId.
+auth:
+  - id: a9010101-0000-4000-8000-0000000000a1
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/auth-personas-old/10-resolve-scheduler-perm-ids.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/auth-personas-old/10-resolve-scheduler-perm-ids.request.yaml
@@ -1,0 +1,36 @@
+$kind: http-request
+description: >-
+  OLD Decision-9 — resolve the ids the persona provisioning needs, under {{adminToken}}. Batch API
+  (/composite/batch, dodges the shared Kick's composite unmarshallers): Standard User ProfileId, the
+  Salesforce_Scheduler_Resource PermissionSet id (carries lightningSchedulerUserAccess — the user-perm the
+  classic slot-gen's removeResourcesWithoutPerm requires, JDWP-confirmed in the double-book slice), and the
+  LightningSchedulerPsl PermissionSetLicense id. Captures oldD9StandardUserProfileId / oldD9SchedulerPsId /
+  oldD9SchedulerPslId for the three persona-mint steps.
+url: "{{baseUrl}}{{versionPath}}/composite/batch"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "batchRequests": [
+        { "method": "GET", "url": "{{versionPath}}/query/?q=SELECT+Id+FROM+Profile+WHERE+Name='Standard User'" },
+        { "method": "GET", "url": "{{versionPath}}/query/?q=SELECT+Id+FROM+PermissionSet+WHERE+Name='Salesforce_Scheduler_Resource'" },
+        { "method": "GET", "url": "{{versionPath}}/query/?q=SELECT+Id+FROM+PermissionSetLicense+WHERE+DeveloperName='LightningSchedulerPsl'" }
+      ]
+    }
+scripts:
+  - type: afterResponse
+    code: |-
+      const data = pm.response.json() || {};
+      const results = data.results || [];
+      const first = (i) => (((results[i] || {}).result || {}).records || [])[0] || {};
+      pm.environment.set("oldD9StandardUserProfileId", first(0).Id);
+      pm.environment.set("oldD9SchedulerPsId", first(1).Id);
+      pm.environment.set("oldD9SchedulerPslId", first(2).Id);
+      console.log("OLD D9 ids profile=" + first(0).Id + " ps=" + first(1).Id + " psl=" + first(2).Id);
+    language: text/javascript
+order: 10000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/auth-personas-old/20-create-manager-persona.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/auth-personas-old/20-create-manager-persona.request.yaml
@@ -1,0 +1,62 @@
+$kind: http-request
+description: >-
+  OLD Decision-9 — admin creates the MANAGER persona (the owner identity) in one composite/graph: a fresh
+  timestamped User on the Standard User profile + the Salesforce_Scheduler_Resource PermissionSet (carries
+  the lightningSchedulerUserAccess user-perm the classic slot-gen requires). The LightningSchedulerPsl PSL
+  is AUTO-granted with that permset on this org, so it is NOT assigned here (a second explicit assign
+  DUPLICATE_VALUEs and rolls back the whole graph — LIVE-OBSERVED). A password is set next so the manager can
+  SOAP-login to its own session; it then OWNS the Decision-9 ServiceResource (the sharing-gate parent).
+url: "{{baseUrl}}{{versionPath}}/composite/graph"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: json
+  content: |-
+    {
+      "graphs": [
+        {
+          "graphId": "oldD9mgr",
+          "compositeRequest": [
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/User",
+              "referenceId": "refUser",
+              "body": {
+                "Username": "{{oldD9ManagerUserName}}",
+                "ProfileId": "{{oldD9StandardUserProfileId}}",
+                "Alias": "od9mgr",
+                "Email": "{{oldD9ManagerUserName}}",
+                "EmailEncodingKey": "ISO-8859-1",
+                "LastName": "OldD9Manager",
+                "FirstName": "Morgan",
+                "LanguageLocaleKey": "en_US",
+                "LocaleSidKey": "en_US",
+                "TimeZoneSidKey": "GMT"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/PermissionSetAssignment",
+              "referenceId": "refPsAssign",
+              "body": { "AssigneeId": "@{refUser.id}", "PermissionSetId": "{{oldD9SchedulerPsId}}" }
+            }
+          ]
+        }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: pm.environment.set("oldD9ManagerUserName", pm.variables.replaceIn("old-d9-manager-{{$timestamp}}@revoman.org"));
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      const responses = pm.response.json().graphs[0].graphResponse.compositeResponse;
+      responses.forEach((r) => {
+        if (r.httpStatusCode < 200 || r.httpStatusCode >= 300) {
+          throw new Error("Manager persona step " + r.referenceId + " failed: " + JSON.stringify(r.body));
+        }
+      });
+      pm.environment.set("oldD9ManagerUserId", responses[0].body.id);
+    language: text/javascript
+order: 20000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/auth-personas-old/30-set-manager-password.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/auth-personas-old/30-set-manager-password.request.yaml
@@ -1,0 +1,15 @@
+$kind: http-request
+description: OLD Decision-9 — set the manager persona's password so it can SOAP-login to its own session.
+url: "{{baseUrl}}{{versionPath}}/sobjects/User/{{oldD9ManagerUserId}}/password"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: json
+  content: |-
+    { "NewPassword": "{{oldD9PersonaPassword}}" }
+scripts:
+  - type: beforeRequest
+    code: if (!pm.environment.get("oldD9PersonaPassword")) pm.environment.set("oldD9PersonaPassword", "Revoman123!");
+    language: text/javascript
+order: 30000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/auth-personas-old/40-login-as-manager.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/auth-personas-old/40-login-as-manager.request.yaml
@@ -1,0 +1,41 @@
+$kind: http-request
+description: >-
+  OLD Decision-9 — SOAP login (v64) as the MANAGER persona, minting oldD9ManagerToken (its OWN session, NOT
+  the admin session). This persona OWNS the fixture (resource / STM / Shift) and is the positive-control
+  reader.
+url: "{{baseUrl}}/services/Soap/u/64.0"
+method: POST
+headers:
+  Content-Type: text/xml
+  SOAPAction: login
+  charset: UTF-8
+  Accept: text/xml
+body:
+  type: text
+  content: |-
+    <?xml version="1.0" encoding="utf-8" ?>
+    <env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+      <env:Body>
+        <n1:login xmlns:n1="urn:partner.soap.sforce.com">
+          <n1:username><![CDATA[{{oldD9ManagerUserName}}]]></n1:username>
+          <n1:password><![CDATA[{{oldD9PersonaPassword}}]]></n1:password>
+        </n1:login>
+      </env:Body>
+    </env:Envelope>
+scripts:
+  - type: afterResponse
+    code: |-
+      var xml2js = require('xml2js')
+      xml2js.parseString(pm.response.text(), { explicitArray: false }, (_, j) => {
+        let r = j['soapenv:Envelope']['soapenv:Body'].loginResponse.result
+        pm.environment.set("oldD9ManagerToken", r.sessionId)
+      })
+    language: text/javascript
+settings:
+  disabledSystemHeaders:
+    - accept
+    - content-type
+    - user-agent
+order: 40000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/auth-personas-old/50-create-caseworker-persona.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/auth-personas-old/50-create-caseworker-persona.request.yaml
@@ -1,0 +1,63 @@
+$kind: http-request
+description: >-
+  OLD Decision-9 — admin creates the CASE-WORKER persona: the sharing-deprived READER. Fresh timestamped
+  User on the Standard User profile + Salesforce_Scheduler_Resource PS (carries lightningSchedulerUserAccess
+  so it is NOT pruned by removeResourcesWithoutPerm — its zero-slot result is the sharing gate, not a perm
+  prune). The LightningSchedulerPsl PSL is auto-granted with the permset (NOT assigned here — a second
+  assign DUPLICATE_VALUEs). It is NOT shared the manager's Private resource/STM/Shift rows, so its user-mode
+  STM read (ShiftsDbUtil, SystemMode.NONE) sees none → empty availability, HTTP 200, no error (LIVE-OBSERVED
+  on this org — the classic engine DOES honor that user-mode STM gate here).
+url: "{{baseUrl}}{{versionPath}}/composite/graph"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: json
+  content: |-
+    {
+      "graphs": [
+        {
+          "graphId": "oldD9cw",
+          "compositeRequest": [
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/User",
+              "referenceId": "refUser",
+              "body": {
+                "Username": "{{oldD9CaseWorkerUserName}}",
+                "ProfileId": "{{oldD9StandardUserProfileId}}",
+                "Alias": "od9cw",
+                "Email": "{{oldD9CaseWorkerUserName}}",
+                "EmailEncodingKey": "ISO-8859-1",
+                "LastName": "OldD9CaseWorker",
+                "FirstName": "Casey",
+                "LanguageLocaleKey": "en_US",
+                "LocaleSidKey": "en_US",
+                "TimeZoneSidKey": "GMT"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/PermissionSetAssignment",
+              "referenceId": "refPsAssign",
+              "body": { "AssigneeId": "@{refUser.id}", "PermissionSetId": "{{oldD9SchedulerPsId}}" }
+            }
+          ]
+        }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: pm.environment.set("oldD9CaseWorkerUserName", pm.variables.replaceIn("old-d9-caseworker-{{$timestamp}}@revoman.org"));
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      const responses = pm.response.json().graphs[0].graphResponse.compositeResponse;
+      responses.forEach((r) => {
+        if (r.httpStatusCode < 200 || r.httpStatusCode >= 300) {
+          throw new Error("Case-worker persona step " + r.referenceId + " failed: " + JSON.stringify(r.body));
+        }
+      });
+      pm.environment.set("oldD9CaseWorkerUserId", responses[0].body.id);
+    language: text/javascript
+order: 50000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/auth-personas-old/60-set-caseworker-password.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/auth-personas-old/60-set-caseworker-password.request.yaml
@@ -1,0 +1,11 @@
+$kind: http-request
+description: OLD Decision-9 — set the case-worker persona's password for its own SOAP session.
+url: "{{baseUrl}}{{versionPath}}/sobjects/User/{{oldD9CaseWorkerUserId}}/password"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: json
+  content: |-
+    { "NewPassword": "{{oldD9PersonaPassword}}" }
+order: 60000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/auth-personas-old/70-login-as-caseworker.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/auth-personas-old/70-login-as-caseworker.request.yaml
@@ -1,0 +1,40 @@
+$kind: http-request
+description: >-
+  OLD Decision-9 — SOAP login (v64) as the CASE-WORKER persona, minting oldD9CaseWorkerToken (its own
+  session, no sharing on the manager rows).
+url: "{{baseUrl}}/services/Soap/u/64.0"
+method: POST
+headers:
+  Content-Type: text/xml
+  SOAPAction: login
+  charset: UTF-8
+  Accept: text/xml
+body:
+  type: text
+  content: |-
+    <?xml version="1.0" encoding="utf-8" ?>
+    <env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+      <env:Body>
+        <n1:login xmlns:n1="urn:partner.soap.sforce.com">
+          <n1:username><![CDATA[{{oldD9CaseWorkerUserName}}]]></n1:username>
+          <n1:password><![CDATA[{{oldD9PersonaPassword}}]]></n1:password>
+        </n1:login>
+      </env:Body>
+    </env:Envelope>
+scripts:
+  - type: afterResponse
+    code: |-
+      var xml2js = require('xml2js')
+      xml2js.parseString(pm.response.text(), { explicitArray: false }, (_, j) => {
+        let r = j['soapenv:Envelope']['soapenv:Body'].loginResponse.result
+        pm.environment.set("oldD9CaseWorkerToken", r.sessionId)
+      })
+    language: text/javascript
+settings:
+  disabledSystemHeaders:
+    - accept
+    - content-type
+    - user-agent
+order: 70000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/auth-personas-old/80-create-resource-user.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/auth-personas-old/80-create-resource-user.request.yaml
@@ -1,0 +1,62 @@
+$kind: http-request
+description: >-
+  OLD Decision-9 — admin creates the RESOURCE-OWNER user (the ServiceResource's RelatedRecordId). Created
+  by admin because creating a User (setting ProfileId) needs Manage Users, which the manager persona lacks.
+  Fresh timestamped User + Salesforce_Scheduler_Resource PS (LightningSchedulerPsl PSL auto-granted with it,
+  NOT assigned here) so the classic slot-gen's removeResourcesWithoutPerm
+  (SchedulerCommonUtil.checkForUserPermission for lightningSchedulerUserAccess) admits the resource. Sets
+  oldD9ResourceUserId.
+url: "{{baseUrl}}{{versionPath}}/composite/graph"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: json
+  content: |-
+    {
+      "graphs": [
+        {
+          "graphId": "oldD9res",
+          "compositeRequest": [
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/User",
+              "referenceId": "refUser",
+              "body": {
+                "Username": "{{oldD9ResourceUserName}}",
+                "ProfileId": "{{oldD9StandardUserProfileId}}",
+                "Alias": "od9res",
+                "Email": "{{oldD9ResourceUserName}}",
+                "EmailEncodingKey": "ISO-8859-1",
+                "LastName": "OldD9Resource",
+                "FirstName": "Riley",
+                "LanguageLocaleKey": "en_US",
+                "LocaleSidKey": "en_US",
+                "TimeZoneSidKey": "GMT"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/PermissionSetAssignment",
+              "referenceId": "refPsAssign",
+              "body": { "AssigneeId": "@{refUser.id}", "PermissionSetId": "{{oldD9SchedulerPsId}}" }
+            }
+          ]
+        }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: pm.environment.set("oldD9ResourceUserName", pm.variables.replaceIn("old-d9-resource-{{$timestamp}}@revoman.org"));
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      const responses = pm.response.json().graphs[0].graphResponse.compositeResponse;
+      responses.forEach((r) => {
+        if (r.httpStatusCode < 200 || r.httpStatusCode >= 300) {
+          throw new Error("Resource user step " + r.referenceId + " failed: " + JSON.stringify(r.body));
+        }
+      });
+      pm.environment.set("oldD9ResourceUserId", responses[0].body.id);
+    language: text/javascript
+order: 80000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/auth/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/auth/.resources/definition.yaml
@@ -1,0 +1,12 @@
+$kind: collection
+description: |-
+  Scheduler-org bootstrap auth for the Scheduler↔Unified 1.* parity slice. SOAP-logs-in as the org
+  admin (v64) to seed {{adminToken}}/{{accessToken}}, then resolves versionPath. The slice's old-side
+  reads/writes run under {{adminToken}} (admin session is sufficient for the read+book parity probe;
+  no manager-persona split is needed here — that is a Decision-9 concern, out of slice).
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000001
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/auth/latest-api-version.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/auth/latest-api-version.request.yaml
@@ -1,0 +1,20 @@
+$kind: http-request
+description: Resolve the scheduler org's latest API version → version / apiVersion / versionPath.
+url: "{{baseUrl}}/services/data/"
+method: GET
+headers:
+  Accept: application/json
+scripts:
+  - type: afterResponse
+    code: |-
+      var jsonData = pm.response.json();
+      var lastNode = jsonData.pop();
+      pm.environment.set("version", lastNode.version);
+      pm.environment.set("apiVersion", "v" + lastNode.version);
+      pm.environment.set("versionPath", lastNode.url);
+    language: text/javascript
+settings:
+  disabledSystemHeaders:
+    - accept
+    - content-type
+order: 1000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/auth/login-as-sysadmin.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/auth/login-as-sysadmin.request.yaml
@@ -1,0 +1,43 @@
+$kind: http-request
+description: >-
+  SOAP login (v64) to the SCHEDULER org; seeds adminToken/accessToken/orgId. Runs first (order 500) so
+  latest-api-version and every downstream old-side call has a live session.
+url: "{{baseUrl}}/services/Soap/u/64.0"
+method: POST
+headers:
+  Content-Type: text/xml
+  SOAPAction: login
+  charset: UTF-8
+  Accept: text/xml
+body:
+  type: text
+  content: |-
+    <?xml version="1.0" encoding="utf-8" ?>
+    <env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+      <env:Body>
+        <n1:login xmlns:n1="urn:partner.soap.sforce.com">
+          <n1:username><![CDATA[{{username}}]]></n1:username>
+          <n1:password><![CDATA[{{password}}]]></n1:password>
+        </n1:login>
+      </env:Body>
+    </env:Envelope>
+scripts:
+  - type: afterResponse
+    code: |-
+      var xml2js = require('xml2js')
+      xml2js.parseString(pm.response.text(), { explicitArray: false }, (_, jsonResponse) => {
+        let result = jsonResponse['soapenv:Envelope']['soapenv:Body'].loginResponse.result
+        pm.environment.set("accessToken", result.sessionId)
+        pm.environment.set("adminToken", result.sessionId)
+        pm.environment.set("adminUserId", result.userId)
+        pm.environment.set("orgId", result.userInfo.organizationId)
+      })
+    language: text/javascript
+settings:
+  disabledSystemHeaders:
+    - accept
+    - content-type
+    - user-agent
+order: 500

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/assignedresource-delete-primary/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/assignedresource-delete-primary/.resources/definition.yaml
@@ -1,0 +1,16 @@
+$kind: collection
+description: |-
+  OLD Scheduler reschedule-analog DELETE probe for Decision 4z. The classic Scheduler exposes NO reschedule
+  connect API, so "reschedule that removes the primary" is approximated by a direct REST sObject DELETE of
+  the primary AssignedResource (reschedPrimaryArId). This exercises the old-side SAVE-TIME delete guard
+  LightningSchedulerAssignedResourceValidator.validatePrimaryAssignedResourceOnDelete, which BLOCKS deleting
+  a primary AssignedResource (FIELD_INTEGRITY_EXCEPTION "AssignedResourceDelete"). Characterizes blocked vs
+  allowed and re-queries to confirm the primary AR survived. Captures reschedDeletePrimaryHttp /
+  reschedDeletePrimaryErrorCode / reschedDeletePrimaryErrorMessage / reschedPrimaryArStillExists. Runs under
+  {{adminToken}}.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-0000004z0050
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/assignedresource-delete-primary/10-delete-primary-ar.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/assignedresource-delete-primary/10-delete-primary-ar.request.yaml
@@ -1,0 +1,33 @@
+$kind: http-request
+description: >-
+  OLD Scheduler reschedule-analog Arm 1: directly DELETE the PRIMARY AssignedResource (reschedPrimaryArId)
+  via REST sObject — the classic-Scheduler stand-in for "a reschedule that removes the primary worker",
+  since the classic engine has NO reschedule connect API. Expected: BLOCKED by the save-time delete guard
+  LightningSchedulerAssignedResourceValidator.validatePrimaryAssignedResourceOnDelete → non-2xx (HTTP 400 /
+  FIELD_INTEGRITY_EXCEPTION "AssignedResourceDelete"), so the SA cannot be left with no primary this way.
+  Captures reschedDeletePrimaryHttp / reschedDeletePrimaryErrorCode / reschedDeletePrimaryErrorMessage.
+url: "{{baseUrl}}{{versionPath}}/sobjects/AssignedResource/{{reschedPrimaryArId}}"
+method: DELETE
+headers:
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+scripts:
+  - type: afterResponse
+    code: |-
+      // A REST sObject DELETE returns 204 (empty body) on success or a non-2xx with a top-level error
+      // array [{ errorCode, message, fields }]. Capture the HTTP code + errorCode/message either way.
+      pm.environment.set("reschedDeletePrimaryHttp", String(pm.response.code));
+      let errorCode = "";
+      let errorMessage = "";
+      try {
+        const data = pm.response.json();
+        if (Array.isArray(data) && data.length > 0) {
+          errorCode = data[0].errorCode || "";
+          errorMessage = data[0].message || "";
+        }
+      } catch (e) { /* 204 no-body success → leave error fields empty */ }
+      pm.environment.set("reschedDeletePrimaryErrorCode", errorCode);
+      pm.environment.set("reschedDeletePrimaryErrorMessage", errorMessage);
+      console.log("OLD delete-primary AR http=" + pm.response.code + " errorCode=" + errorCode + " msg=" + errorMessage);
+    language: text/javascript
+order: 1100

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/assignedresource-delete-primary/20-verify-primary-survived.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/assignedresource-delete-primary/20-verify-primary-survived.request.yaml
@@ -1,0 +1,32 @@
+$kind: http-request
+description: >-
+  Verify the DELETE attempt's effect: re-query the AssignedResource rows for the SA (reschedCleanSaId). If
+  the delete guard BLOCKED the delete, the primary AR still exists (count still includes it) → the SA was
+  NOT left with no primary. If the delete were allowed, the primary AR would be gone. Captures
+  reschedPrimaryArStillExists ("1" if the primary AR id is still present) + reschedArCountAfterDelete.
+url: "{{baseUrl}}{{versionPath}}/composite/batch"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "batchRequests": [
+        { "method": "GET", "url": "{{versionPath}}/query/?q=SELECT+Id,IsPrimaryResource+FROM+AssignedResource+WHERE+ServiceAppointmentId='{{reschedCleanSaId}}'" }
+      ]
+    }
+scripts:
+  - type: afterResponse
+    code: |-
+      const data = pm.response.json() || {};
+      const results = data.results || [];
+      const records = (((results[0] || {}).result || {}).records || []);
+      const primaryStillThere = records.some(r => r.Id === pm.environment.get("reschedPrimaryArId"));
+      pm.environment.set("reschedArCountAfterDelete", String(records.length));
+      pm.environment.set("reschedPrimaryArStillExists", primaryStillThere ? "1" : "0");
+      console.log("OLD after delete-primary: AR count=" + records.length + " primaryStillExists=" + primaryStillThere);
+    language: text/javascript
+order: 1110

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/assignedresource-demote-primary/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/assignedresource-demote-primary/.resources/definition.yaml
@@ -1,0 +1,17 @@
+$kind: collection
+description: |-
+  OLD Scheduler reschedule-analog DEMOTE probe for Decision 4z. Approximates "a reschedule that leaves no
+  primary" WITHOUT deleting: directly PATCH the primary AssignedResource (reschedPrimaryArId) to
+  IsPrimaryResource=false, leaving the SA with two required resources and ZERO primaries. The old-side save
+  validator LightningSchedulerAssignedResourceValidator.validateAssignedResourceOnSave guards only (a)
+  primary-must-be-required and (b) at-most-one-primary — it has NO "must keep a primary" rule, so demoting
+  the sole primary is the closest old-side analog to 264's validatePrimaryResourceCount (which throws only
+  when primaryCount > 1). Characterizes allowed vs blocked and re-queries the resulting primary count.
+  Captures reschedDemotePrimaryHttp / reschedDemotePrimaryErrorCode / reschedDemotePrimaryErrorMessage /
+  reschedPrimaryCountAfterDemote. Runs under {{adminToken}}.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-0000004z0060
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/assignedresource-demote-primary/10-demote-primary-ar.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/assignedresource-demote-primary/10-demote-primary-ar.request.yaml
@@ -1,0 +1,41 @@
+$kind: http-request
+description: >-
+  OLD Scheduler reschedule-analog Arm 2: PATCH the primary AssignedResource (reschedPrimaryArId) to
+  IsPrimaryResource=false, leaving the SA with TWO required resources and ZERO primaries — the closest
+  old-side stand-in for 264's "reschedule leaves no primary" (the classic engine has no reschedule connect
+  API). The old-side save validator validateAssignedResourceOnSave guards only primary-must-be-required and
+  at-most-one-primary; it has NO "must keep a primary" rule, so this demote is NOT blocked by a no-primary
+  check. Characterizes whether the org allows it (HTTP 204) or blocks it via some other rule. Captures
+  reschedDemotePrimaryHttp / reschedDemotePrimaryErrorCode / reschedDemotePrimaryErrorMessage.
+url: "{{baseUrl}}{{versionPath}}/sobjects/AssignedResource/{{reschedPrimaryArId}}"
+method: PATCH
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "IsPrimaryResource": false
+    }
+scripts:
+  - type: afterResponse
+    code: |-
+      // A REST sObject PATCH returns 204 (empty body) on success or a non-2xx with a top-level error array
+      // [{ errorCode, message, fields }]. Capture the HTTP code + errorCode/message either way.
+      pm.environment.set("reschedDemotePrimaryHttp", String(pm.response.code));
+      let errorCode = "";
+      let errorMessage = "";
+      try {
+        const data = pm.response.json();
+        if (Array.isArray(data) && data.length > 0) {
+          errorCode = data[0].errorCode || "";
+          errorMessage = data[0].message || "";
+        }
+      } catch (e) { /* 204 no-body success → leave error fields empty */ }
+      pm.environment.set("reschedDemotePrimaryErrorCode", errorCode);
+      pm.environment.set("reschedDemotePrimaryErrorMessage", errorMessage);
+      console.log("OLD demote-primary AR http=" + pm.response.code + " errorCode=" + errorCode + " msg=" + errorMessage);
+    language: text/javascript
+order: 1200

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/assignedresource-demote-primary/20-verify-no-primary.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/assignedresource-demote-primary/20-verify-no-primary.request.yaml
@@ -1,0 +1,32 @@
+$kind: http-request
+description: >-
+  Verify the DEMOTE attempt's effect: re-query the AssignedResource rows for the SA (reschedCleanSaId) and
+  count how many are still IsPrimaryResource=true. If the demote was ALLOWED the primary count is 0 → the SA
+  now has NO primary (the 264-parity outcome). If some rule blocked it, the count stays 1. Captures
+  reschedPrimaryCountAfterDemote + reschedArCountAfterDemote.
+url: "{{baseUrl}}{{versionPath}}/composite/batch"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "batchRequests": [
+        { "method": "GET", "url": "{{versionPath}}/query/?q=SELECT+Id,IsPrimaryResource+FROM+AssignedResource+WHERE+ServiceAppointmentId='{{reschedCleanSaId}}'" }
+      ]
+    }
+scripts:
+  - type: afterResponse
+    code: |-
+      const data = pm.response.json() || {};
+      const results = data.results || [];
+      const records = (((results[0] || {}).result || {}).records || []);
+      const primaryCount = records.filter(r => r.IsPrimaryResource === true).length;
+      pm.environment.set("reschedArCountAfterDemote", String(records.length));
+      pm.environment.set("reschedPrimaryCountAfterDemote", String(primaryCount));
+      console.log("OLD after demote-primary: AR count=" + records.length + " primaryCount=" + primaryCount);
+    language: text/javascript
+order: 1210

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-double-book/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-double-book/.resources/definition.yaml
@@ -1,0 +1,10 @@
+$kind: collection
+description: |-
+  OLD Scheduler getAppointmentSlots over the double-book fixture: A+B (B busy → 0 slots) vs A-only
+  (> 0 slots). Captures oldReadWithBSlotCount + oldReadAOnlySlotCount for the 1.5 read-decision diff.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000020
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-double-book/10-get-appointment-slots-double-book.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-double-book/10-get-appointment-slots-double-book.request.yaml
@@ -1,0 +1,58 @@
+$kind: http-request
+description: >-
+  OLD Salesforce Scheduler MULTI-RESOURCE read: POST /scheduling/getAppointmentSlots over the double-book
+  fixture, tomorrow 11:00-11:30 UTC, naming BOTH resourceA (free) and resourceB (busy at 11:00) as
+  required. The classic engine's multi-resource contract (GetAppointmentSlotsRequest +
+  GetAppointmentRequestValidator48) treats primaryResourceId and requiredResourceIds as DISJOINT sets —
+  the primary is ITS OWN required resource, added to the intersection separately (SchedulingServiceImpl
+  line ~519 adds primaryResourceId to requiredResourceIds15Char). Sending A in BOTH lists is a
+  BAD_REQUEST ("Remove the primaryResourceId from the requiredResourceIds list"), LIVE-OBSERVED on this
+  org. So "both A and B required" is expressed as primaryResourceId=A + requiredResourceIds=[B]. The
+  engine AND-intersects every required resource's availability
+  (getOverlappingTimeSlotsBetweenMultipleResources → extractCommonSlots, empty-set early-exit), so B
+  being busy at 11:00 zeroes the A∩B slots. NOTE: the old read has NO non-required "helper" input — every
+  named id is required — so the read-side probe is "required-and-busy zeroes vs A-only offers", per
+  research. Multi-resource requires the org's MultiResourceScheduling perm; absent it the engine throws
+  multiResourceNotEnabled. Captures oldReadWithBSlotCount.
+  OBSERVED LIVE on the scheduler org (v67): the AND hypothesis HOLDS — this A+B call returns 0 slots
+  (empty timeSlots) while the A-only control (20-…) returns 1 (window 11:00-11:30). The internal spike's
+  "union" concern did NOT materialise here: the old multi-resource engine AND-INTERSECTS required
+  resources (getOverlappingTimeSlotsBetweenMultipleResources → extractCommonSlots, empty-set early-exit),
+  so busy B empties the A∩B intersection. Response field is "timeSlots" (data.timeSlots), the brief's
+  first choice; "slots" is never present. PREREQUISITE: the two resource users must hold the Lightning
+  Scheduler PSL + lightningSchedulerUserAccess user-perm (granted by the shared grant-ls-user-access Kick,
+  revUp'd just before this read) or the classic engine prunes both resources → an all-0 dead read
+  (JDWP-confirmed removeResourcesWithoutPerm).
+url: "{{baseUrl}}{{versionPath}}/scheduling/getAppointmentSlots"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "workType": { "id": "{{schedWorkTypeId}}" },
+      "territoryIds": ["{{schedTerritoryId}}"],
+      "requiredResourceIds": ["{{schedResourceBId}}"],
+      "primaryResourceId": "{{schedResourceAId}}",
+      "startTime": "{{schedReadStart}}",
+      "endTime": "{{schedReadEnd}}"
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 0, 0, 0);
+      const e = new Date(s.getTime() + 30 * 60 * 1000);
+      pm.environment.set("schedReadStart", s.toISOString());
+      pm.environment.set("schedReadEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      const data = pm.response.json() || {};
+      const slots = (data.timeSlots || data.slots || []);
+      pm.environment.set("oldReadWithBSlotCount", String(slots.length));
+      console.log("OLD read A+B http=" + pm.response.code + " slots=" + slots.length);
+    language: text/javascript
+order: 1000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-double-book/20-get-appointment-slots-a-only.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-double-book/20-get-appointment-slots-a-only.request.yaml
@@ -1,0 +1,36 @@
+$kind: http-request
+description: >-
+  Control: OLD getAppointmentSlots naming ONLY resourceA (free) as required, same window (tomorrow
+  11:00-11:30 UTC). SINGLE-resource shape: primaryResourceId is OMITTED (the classic engine's
+  single-resource path — GetAppointmentRequestValidator48 requires primaryResourceId to be null when
+  requiredResourceIds has ≤1 id) and requiredResourceIds=[A]. Proves the fixture is bookable on the old
+  side (slots > 0), so the A+B result in step 10 reflects resourceB's busyness, not a dead fixture.
+  Captures oldReadAOnlySlotCount. OBSERVED LIVE (v67): 1 slot (11:00-11:30), while the A+B multi-resource
+  call (10-…) returns 0 → the AND hypothesis HOLDS (A-only=1, A+B=0), NOT union. Response field is
+  "timeSlots". PREREQUISITE: resourceA's user must hold the Lightning Scheduler PSL +
+  lightningSchedulerUserAccess (granted by the shared grant-ls-user-access Kick) or this control also reads 0 (dead).
+url: "{{baseUrl}}{{versionPath}}/scheduling/getAppointmentSlots"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "workType": { "id": "{{schedWorkTypeId}}" },
+      "territoryIds": ["{{schedTerritoryId}}"],
+      "requiredResourceIds": ["{{schedResourceAId}}"],
+      "startTime": "{{schedReadStart}}",
+      "endTime": "{{schedReadEnd}}"
+    }
+scripts:
+  - type: afterResponse
+    code: |-
+      const data = pm.response.json() || {};
+      const slots = (data.timeSlots || data.slots || []);
+      pm.environment.set("oldReadAOnlySlotCount", String(slots.length));
+      console.log("OLD read A-only http=" + pm.response.code + " slots=" + slots.length);
+    language: text/javascript
+order: 2000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-promise-available/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-promise-available/.resources/definition.yaml
@@ -1,0 +1,12 @@
+$kind: collection
+description: |-
+  OLD Scheduler-org Decision 2 READ (AVAILABLE window): single-resource POST /scheduling/getAppointmentSlots
+  over the promise-helper fixture, naming resourceA (available 08-16) as the sole required resource for the
+  AVAILABLE window tomorrow 11:00-11:30. Offers >0 slots (the shared cheap availability check passes).
+  Captures oldPromiseReadAvailCount. RevUps after the shared grant-ls-user-access Kick.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000211
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-promise-available/10-get-appointment-slots-promise-available.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-promise-available/10-get-appointment-slots-promise-available.request.yaml
@@ -1,0 +1,44 @@
+$kind: http-request
+description: >-
+  OLD Salesforce Scheduler SINGLE-resource read (Decision 2, AVAILABLE window): POST
+  /scheduling/getAppointmentSlots over the promise-helper fixture, naming ONLY resourceA (available 08-16)
+  as required, for the AVAILABLE window tomorrow 11:00-11:30 UTC. SINGLE-resource shape: primaryResourceId
+  is OMITTED (GetAppointmentRequestValidator48 requires primaryResourceId null when requiredResourceIds has
+  ≤1 id) and requiredResourceIds=[A]. The window (11:00-11:30) fits inside resourceA's availability union
+  (member OH ∪ Shift = 08-16) → the shared cheap availability check passes → the read OFFERS slots (>0).
+  This is the READ half of the Decision 2 read↔write promise on the available window. Response field is
+  "timeSlots" (data.timeSlots). Captures oldPromiseReadAvailCount. PREREQUISITE: resourceA's user holds the
+  Lightning Scheduler PSL + lightningSchedulerUserAccess (granted by the shared grant-ls-user-access Kick,
+  revUp'd just before this read) or the classic engine prunes the resource → a dead 0-slot read.
+url: "{{baseUrl}}{{versionPath}}/scheduling/getAppointmentSlots"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "workType": { "id": "{{schedWorkTypeId}}" },
+      "territoryIds": ["{{schedTerritoryId}}"],
+      "requiredResourceIds": ["{{schedResourceAId}}"],
+      "startTime": "{{schedPromiseAvailStart}}",
+      "endTime": "{{schedPromiseAvailEnd}}"
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 0, 0, 0);
+      const e = new Date(s.getTime() + 30 * 60 * 1000);
+      pm.environment.set("schedPromiseAvailStart", s.toISOString());
+      pm.environment.set("schedPromiseAvailEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      const data = pm.response.json() || {};
+      const slots = (data.timeSlots || data.slots || []);
+      pm.environment.set("oldPromiseReadAvailCount", String(slots.length));
+      console.log("OLD promise read-avail http=" + pm.response.code + " slots=" + slots.length);
+    language: text/javascript
+order: 1000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-promise-unavailable/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-promise-unavailable/.resources/definition.yaml
@@ -1,0 +1,13 @@
+$kind: collection
+description: |-
+  OLD Scheduler-org Decision 2 READ (UNAVAILABLE window): single-resource POST /scheduling/getAppointmentSlots
+  over the promise-helper fixture, naming resourceA (available only 08-16) as the sole required resource for
+  the UNAVAILABLE window tomorrow 17:00-17:30 (outside its hours). Offers 0 slots (the shared cheap
+  availability check fails). Captures oldPromiseReadUnavailCount. RevUps after the shared
+  grant-ls-user-access Kick.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000212
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-promise-unavailable/10-get-appointment-slots-promise-unavailable.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-promise-unavailable/10-get-appointment-slots-promise-unavailable.request.yaml
@@ -1,0 +1,43 @@
+$kind: http-request
+description: >-
+  OLD Salesforce Scheduler SINGLE-resource read (Decision 2, UNAVAILABLE window): POST
+  /scheduling/getAppointmentSlots over the promise-helper fixture, naming ONLY resourceA as required, for
+  the UNAVAILABLE window tomorrow 17:00-17:30 UTC. Same single-resource shape as the available read
+  (requiredResourceIds=[A], NO primaryResourceId) and the SAME resource — only the window differs. The
+  window (17:00-17:30) lies OUTSIDE resourceA's availability union (member OH ∪ Shift = 08-16) → the shared
+  cheap availability check fails → the read offers 0 slots. This is the READ half of the Decision 2
+  read↔write promise on the unavailable window (read-hides-slot). Response field is "timeSlots". Captures
+  oldPromiseReadUnavailCount. PREREQUISITE: the shared grant-ls-user-access Kick (else a dead 0-slot read
+  would make read-hides pass for the WRONG reason — the available control read guards non-vacuity).
+url: "{{baseUrl}}{{versionPath}}/scheduling/getAppointmentSlots"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "workType": { "id": "{{schedWorkTypeId}}" },
+      "territoryIds": ["{{schedTerritoryId}}"],
+      "requiredResourceIds": ["{{schedResourceAId}}"],
+      "startTime": "{{schedPromiseUnavailStart}}",
+      "endTime": "{{schedPromiseUnavailEnd}}"
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(17, 0, 0, 0);
+      const e = new Date(s.getTime() + 30 * 60 * 1000);
+      pm.environment.set("schedPromiseUnavailStart", s.toISOString());
+      pm.environment.set("schedPromiseUnavailEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      const data = pm.response.json() || {};
+      const slots = (data.timeSlots || data.slots || []);
+      pm.environment.set("oldPromiseReadUnavailCount", String(slots.length));
+      console.log("OLD promise read-unavail http=" + pm.response.code + " slots=" + slots.length);
+    language: text/javascript
+order: 1000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-sharing-as-caseworker/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-sharing-as-caseworker/.resources/definition.yaml
@@ -1,0 +1,17 @@
+$kind: collection
+description: |-
+  OLD Decision-9 PROBE — classic getAppointmentSlots (POST /scheduling/getAppointmentSlots, read-only) on
+  the SAME Decision-9 fixture + window, as the CASE-WORKER persona ({{oldD9CaseWorkerToken}}) which has NO
+  sharing on the manager-owned Private ServiceResource / STM / Shift. On the classic engine the SHIFT read
+  is full-access (SFDC_FULL, ignores sharing — the INVERSE of the 264 gate), while the STM/ServiceResource
+  read is user-mode (SystemMode.NONE) but only when orgHasDepriveSoqlAccess is set; STM OWD is
+  ControlledByParent(ServiceResource=Private). So IF the org honors that gate, the case-worker's STM read
+  returns none → zero slots; otherwise it reads full-access like the shift and sees the same slots as the
+  manager. Either way the SHIFT read is never the gate on old. Stashes oldD9CaseWorkerSlotCount +
+  oldD9CaseWorkerHttp; assertions live in the Java test.
+auth:
+  - id: d9040404-0000-4000-8000-0000000000d4
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{oldD9CaseWorkerToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-sharing-as-caseworker/10-get-slots-as-caseworker.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-sharing-as-caseworker/10-get-slots-as-caseworker.request.yaml
@@ -1,0 +1,42 @@
+$kind: http-request
+description: >-
+  OLD Decision-9 PROBE read — classic getAppointmentSlots as the CASE-WORKER (no sharing on the
+  manager-owned Private resource/STM/Shift). SINGLE resource shape (requiredResourceIds=[the resource], no
+  primaryResourceId), IDENTICAL window/fixture to the manager control (tomorrow 11:00-11:30). On old, the
+  Shift read is always full-access; the user-mode gate (if the org honors it) is on the STM/ServiceResource
+  read → zero slots for the case-worker. Response field is "timeSlots". Captures oldD9CaseWorkerSlotCount +
+  oldD9CaseWorkerHttp. The window vars are set by the manager control step; re-set defensively here so this
+  act is order-independent.
+url: "{{baseUrl}}{{versionPath}}/scheduling/getAppointmentSlots"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "workType": { "id": "{{oldD9WorkTypeId}}" },
+      "territoryIds": ["{{oldD9TerritoryId}}"],
+      "requiredResourceIds": ["{{oldD9ResourceId}}"],
+      "startTime": "{{oldD9ReadStart}}",
+      "endTime": "{{oldD9ReadEnd}}"
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 0, 0, 0);
+      const e = new Date(s.getTime() + 30 * 60 * 1000);
+      pm.environment.set("oldD9ReadStart", s.toISOString());
+      pm.environment.set("oldD9ReadEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      const data = pm.response.json() || {};
+      const slots = (data.timeSlots || data.slots || []);
+      pm.environment.set("oldD9CaseWorkerSlotCount", String(slots.length));
+      pm.environment.set("oldD9CaseWorkerHttp", String(pm.response.code));
+      console.log("OLD D9 read as-caseworker http=" + pm.response.code + " slots=" + slots.length);
+    language: text/javascript
+order: 10000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-sharing-as-manager/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-sharing-as-manager/.resources/definition.yaml
@@ -1,0 +1,13 @@
+$kind: collection
+description: |-
+  OLD Decision-9 CONTROL — classic getAppointmentSlots (POST /scheduling/getAppointmentSlots, read-only) on
+  the Decision-9 fixture, tomorrow 11:00-11:30, as the MANAGER persona ({{oldD9ManagerToken}}) who OWNS the
+  Private ServiceResource / STM / Shift. Its user-mode STM read sees its own rows and its full-access Shift
+  read sees the shift → availability present → slots returned. Proves the case-worker probe's result is the
+  sharing gate, not an empty fixture. Stashes oldD9ManagerSlotCount; assertions live in the Java test.
+auth:
+  - id: c9030303-0000-4000-8000-0000000000c3
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{oldD9ManagerToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-sharing-as-manager/10-get-slots-as-manager.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-sharing-as-manager/10-get-slots-as-manager.request.yaml
@@ -1,0 +1,41 @@
+$kind: http-request
+description: >-
+  OLD Decision-9 CONTROL read — classic getAppointmentSlots as the MANAGER (the fixture owner). SINGLE
+  resource shape: requiredResourceIds=[the resource], primaryResourceId OMITTED (the classic
+  GetAppointmentRequestValidator48 rejects a single resource appearing as both). Window tomorrow
+  11:00-11:30 UTC (inside the 08-16 member-OH ∪ Shift). The user-mode STM read sees the manager's own STM;
+  the full-access Shift read sees the shift → slots > 0. Response field is "timeSlots". Captures
+  oldD9ManagerSlotCount. PREREQUISITE: the resource user holds Salesforce_Scheduler_Resource
+  (lightningSchedulerUserAccess) via the persona setup or the classic engine prunes it → dead read.
+url: "{{baseUrl}}{{versionPath}}/scheduling/getAppointmentSlots"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "workType": { "id": "{{oldD9WorkTypeId}}" },
+      "territoryIds": ["{{oldD9TerritoryId}}"],
+      "requiredResourceIds": ["{{oldD9ResourceId}}"],
+      "startTime": "{{oldD9ReadStart}}",
+      "endTime": "{{oldD9ReadEnd}}"
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 0, 0, 0);
+      const e = new Date(s.getTime() + 30 * 60 * 1000);
+      pm.environment.set("oldD9ReadStart", s.toISOString());
+      pm.environment.set("oldD9ReadEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      const data = pm.response.json() || {};
+      const slots = (data.timeSlots || data.slots || []);
+      pm.environment.set("oldD9ManagerSlotCount", String(slots.length));
+      console.log("OLD D9 read as-manager http=" + pm.response.code + " slots=" + slots.length);
+    language: text/javascript
+order: 10000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-skills/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-skills/.resources/definition.yaml
@@ -1,0 +1,17 @@
+$kind: collection
+description: |-
+  OLD Scheduler getAppointmentSlots over the skills-helper fixture, THREE read shapes that together
+  characterize the old engine's primary-only skill matching:
+    10 — single-resource, skill-less B as SOLE required (no primary) → old engine skill-checks a single
+         resource → B EXCLUDED (0 slots). Proves the old engine HAS the Skills rule.
+    20 — single-resource, skilled A as SOLE required (no primary) → A INCLUDED (>0). Non-vacuity control.
+    30 — multi-resource, primaryResourceId=A + requiredResourceIds=[B] → B is a NON-primary helper, and
+         the old multi path skill-checks the PRIMARY only, so skill-less B ESCAPES → slots offered (>0).
+         This is parity with 264's helper-escapes, via the primary-only mechanism.
+  Captures oldReadBOnlySlotCount / oldReadAOnlySlotCount / oldReadMultiHelperSlotCount.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000050
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-skills/10-get-appointment-slots-b-only.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-skills/10-get-appointment-slots-b-only.request.yaml
@@ -1,0 +1,47 @@
+$kind: http-request
+description: >-
+  OLD Salesforce Scheduler SINGLE-RESOURCE read: POST /scheduling/getAppointmentSlots over the
+  skills-helper fixture, tomorrow 11:00-11:30 UTC, naming ONLY skill-less resourceB as required
+  (requiredResourceIds=[B], NO primaryResourceId — the classic engine's single-resource path via
+  GetAppointmentRequestValidator48 requires primaryResourceId to be null when requiredResourceIds has ≤1
+  id). On the SINGLE-resource path the engine skill-checks the lone resource
+  (SingleResourceTimeSlotProcessor inherits the default shouldMatchSkills → constraints.shouldMatchSkills()),
+  so resourceB — which LACKS the WorkType's required ServiceResourceSkill — is pruned by the Skills rule →
+  the read offers ZERO slots. This is the proof that the OLD engine HAS the Skills rule at all (the
+  multi-resource path below intentionally lets B escape as a non-primary helper). Response field is
+  "timeSlots" (data.timeSlots). PREREQUISITE: resourceB's user must hold the Lightning Scheduler PSL +
+  lightningSchedulerUserAccess (granted by the shared grant-ls-user-access Kick, revUp'd just before this
+  read) or the classic engine prunes it first → an all-0 dead read (removeResourcesWithoutPerm).
+  Captures oldReadBOnlySlotCount.
+url: "{{baseUrl}}{{versionPath}}/scheduling/getAppointmentSlots"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "workType": { "id": "{{schedWorkTypeId}}" },
+      "territoryIds": ["{{schedTerritoryId}}"],
+      "requiredResourceIds": ["{{schedResourceBId}}"],
+      "startTime": "{{schedReadStart}}",
+      "endTime": "{{schedReadEnd}}"
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 0, 0, 0);
+      const e = new Date(s.getTime() + 30 * 60 * 1000);
+      pm.environment.set("schedReadStart", s.toISOString());
+      pm.environment.set("schedReadEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      const data = pm.response.json() || {};
+      const slots = (data.timeSlots || data.slots || []);
+      pm.environment.set("oldReadBOnlySlotCount", String(slots.length));
+      console.log("OLD read B-only (single, skill-less) http=" + pm.response.code + " slots=" + slots.length);
+    language: text/javascript
+order: 1000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-skills/20-get-appointment-slots-a-only.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-skills/20-get-appointment-slots-a-only.request.yaml
@@ -1,0 +1,35 @@
+$kind: http-request
+description: >-
+  Non-vacuity control: OLD getAppointmentSlots naming ONLY skilled resourceA as required, same window
+  (tomorrow 11:00-11:30 UTC). SINGLE-resource shape: primaryResourceId OMITTED,
+  requiredResourceIds=[A]. resourceA HOLDS the WorkType's required ServiceResourceSkill and is fully
+  available, so the Skills rule passes and the read offers slots (> 0). Proves the fixture (and the
+  Lightning-Scheduler user-access grant) is LIVE, so the B-only 0-slot result reflects B's missing skill,
+  not a dead fixture. Captures oldReadAOnlySlotCount. Response field is "timeSlots". PREREQUISITE:
+  resourceA's user must hold the Lightning Scheduler PSL + lightningSchedulerUserAccess (granted by the
+  shared grant-ls-user-access Kick) or this control also reads 0 (dead).
+url: "{{baseUrl}}{{versionPath}}/scheduling/getAppointmentSlots"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "workType": { "id": "{{schedWorkTypeId}}" },
+      "territoryIds": ["{{schedTerritoryId}}"],
+      "requiredResourceIds": ["{{schedResourceAId}}"],
+      "startTime": "{{schedReadStart}}",
+      "endTime": "{{schedReadEnd}}"
+    }
+scripts:
+  - type: afterResponse
+    code: |-
+      const data = pm.response.json() || {};
+      const slots = (data.timeSlots || data.slots || []);
+      pm.environment.set("oldReadAOnlySlotCount", String(slots.length));
+      console.log("OLD read A-only (single, skilled) http=" + pm.response.code + " slots=" + slots.length);
+    language: text/javascript
+order: 2000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-skills/30-get-appointment-slots-multi-helper.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-skills/30-get-appointment-slots-multi-helper.request.yaml
@@ -1,0 +1,42 @@
+$kind: http-request
+description: >-
+  OLD Salesforce Scheduler MULTI-RESOURCE read: POST /scheduling/getAppointmentSlots over the
+  skills-helper fixture, tomorrow 11:00-11:30 UTC, with primaryResourceId=A (skilled) +
+  requiredResourceIds=[B] (skill-less). This is the MULTI path (a primary plus an additional required id;
+  A in BOTH lists is a BAD_REQUEST, so "A primary + B required" is the multi shape). The old engine's
+  multi path skill-checks the PRIMARY resource ONLY — MultiResourceTimeSlotProcessor48.shouldMatchSkills
+  returns true iff serviceResourceId==primaryResourceId (v48/224+; the SchedulingServiceImpl comment at
+  line ~541 says the same: "skill matching with primaryResource in case of MultiResource"). So skilled A
+  passes the Skills rule AND skill-less B (a NON-primary required resource) is NEVER skill-checked → B
+  ESCAPES the Skills rule and the A∩B intersection still has slots (> 0). This is the OLD-side analogue of
+  264's non-required-helper-escapes: the same "the extra resource is not skill-fitness-checked" outcome,
+  reached via the old engine's primary-only rule rather than 264's required-only rule. Captures
+  oldReadMultiHelperSlotCount. PREREQUISITE: both resource users hold the Lightning Scheduler PSL +
+  lightningSchedulerUserAccess (shared grant-ls-user-access Kick) or the classic engine prunes them first
+  (removeResourcesWithoutPerm) → an all-0 dead read. Response field is "timeSlots".
+url: "{{baseUrl}}{{versionPath}}/scheduling/getAppointmentSlots"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "workType": { "id": "{{schedWorkTypeId}}" },
+      "territoryIds": ["{{schedTerritoryId}}"],
+      "requiredResourceIds": ["{{schedResourceBId}}"],
+      "primaryResourceId": "{{schedResourceAId}}",
+      "startTime": "{{schedReadStart}}",
+      "endTime": "{{schedReadEnd}}"
+    }
+scripts:
+  - type: afterResponse
+    code: |-
+      const data = pm.response.json() || {};
+      const slots = (data.timeSlots || data.slots || []);
+      pm.environment.set("oldReadMultiHelperSlotCount", String(slots.length));
+      console.log("OLD read multi (A primary + B required helper) http=" + pm.response.code + " slots=" + slots.length);
+    language: text/javascript
+order: 3000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-territory/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-territory/.resources/definition.yaml
@@ -1,0 +1,11 @@
+$kind: collection
+description: |-
+  OLD Scheduler getAppointmentSlots over the territory-helper fixture: A+B (B's membership ends at noon, so
+  the A∩B intersection is empty over the 11:30-12:30 straddle-noon window → 0 slots) vs A-only (> 0 slots).
+  Captures oldReadWithBSlotCount + oldReadAOnlySlotCount for the 1b territory read-decision diff.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000120
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-territory/10-get-appointment-slots-territory.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-territory/10-get-appointment-slots-territory.request.yaml
@@ -1,0 +1,54 @@
+$kind: http-request
+description: >-
+  OLD Salesforce Scheduler MULTI-RESOURCE read: POST /scheduling/getAppointmentSlots over the
+  territory-helper fixture, tomorrow 11:30-12:30 UTC (a window that STRADDLES the resourceB membership end at
+  noon), naming BOTH resourceA (clean, membership covers the whole window) and resourceB (membership ends at
+  noon → does NOT cover the afternoon) as required. The classic engine's multi-resource contract treats
+  primaryResourceId and requiredResourceIds as DISJOINT sets (the primary is its own required resource, added
+  to the intersection separately — SchedulingServiceImpl adds primaryResourceId to requiredResourceIds15Char)
+  and REJECTS an id that appears in both lists as a BAD_REQUEST ("Remove the primaryResourceId from the
+  requiredResourceIds list"). So "both A and B required" is expressed as primaryResourceId=A +
+  requiredResourceIds=[B]. The engine AND-intersects every required resource's availability over the
+  territory/STM-committed window (getOverlappingTimeSlotsBetweenMultipleResources → extractCommonSlots,
+  empty-set early-exit), so resourceB's membership NOT covering the afternoon of the straddle-noon window
+  zeroes the A∩B slots. The old read has NO non-required "helper" input — every named id is required — so the
+  read-side probe is "required-and-out-of-territory zeroes vs A-only offers". Multi-resource requires the
+  org's MultiResourceScheduling perm. Captures oldReadWithBSlotCount. Response field is "timeSlots"
+  (data.timeSlots). PREREQUISITE: the two resource users must hold the Lightning Scheduler PSL +
+  lightningSchedulerUserAccess user-perm (granted by the shared grant-ls-user-access Kick, revUp'd just
+  before this read) or the classic engine prunes both resources → an all-0 dead read
+  (removeResourcesWithoutPerm).
+url: "{{baseUrl}}{{versionPath}}/scheduling/getAppointmentSlots"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "workType": { "id": "{{schedWorkTypeId}}" },
+      "territoryIds": ["{{schedTerritoryId}}"],
+      "requiredResourceIds": ["{{schedResourceBId}}"],
+      "primaryResourceId": "{{schedResourceAId}}",
+      "startTime": "{{schedReadStart}}",
+      "endTime": "{{schedReadEnd}}"
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      // Tomorrow 11:30-12:30 UTC: a window that STRADDLES the resourceB membership effective end (noon).
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 30, 0, 0);
+      const e = new Date(s.getTime() + 60 * 60 * 1000);
+      pm.environment.set("schedReadStart", s.toISOString());
+      pm.environment.set("schedReadEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      const data = pm.response.json() || {};
+      const slots = (data.timeSlots || data.slots || []);
+      pm.environment.set("oldReadWithBSlotCount", String(slots.length));
+      console.log("OLD read A+B (territory) http=" + pm.response.code + " slots=" + slots.length);
+    language: text/javascript
+order: 1000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-territory/20-get-appointment-slots-a-only.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-territory/20-get-appointment-slots-a-only.request.yaml
@@ -1,0 +1,35 @@
+$kind: http-request
+description: >-
+  Control: OLD getAppointmentSlots naming ONLY resourceA (clean, membership covers the whole window) as
+  required, same window (tomorrow 11:30-12:30 UTC). SINGLE-resource shape: primaryResourceId is OMITTED (the
+  classic engine's single-resource path — GetAppointmentRequestValidator48 requires primaryResourceId to be
+  null when requiredResourceIds has ≤1 id) and requiredResourceIds=[A]. Proves the fixture is bookable on the
+  old side (slots > 0), so the A+B result in step 10 reflects resourceB's out-of-territory membership, not a
+  dead fixture. Captures oldReadAOnlySlotCount. Response field is "timeSlots". PREREQUISITE: resourceA's user
+  must hold the Lightning Scheduler PSL + lightningSchedulerUserAccess (granted by the shared
+  grant-ls-user-access Kick) or this control also reads 0 (dead).
+url: "{{baseUrl}}{{versionPath}}/scheduling/getAppointmentSlots"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "workType": { "id": "{{schedWorkTypeId}}" },
+      "territoryIds": ["{{schedTerritoryId}}"],
+      "requiredResourceIds": ["{{schedResourceAId}}"],
+      "startTime": "{{schedReadStart}}",
+      "endTime": "{{schedReadEnd}}"
+    }
+scripts:
+  - type: afterResponse
+    code: |-
+      const data = pm.response.json() || {};
+      const slots = (data.timeSlots || data.slots || []);
+      pm.environment.set("oldReadAOnlySlotCount", String(slots.length));
+      console.log("OLD read A-only (territory) http=" + pm.response.code + " slots=" + slots.length);
+    language: text/javascript
+order: 2000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-workloc/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-workloc/.resources/definition.yaml
@@ -1,0 +1,12 @@
+$kind: collection
+description: |-
+  OLD Scheduler getAppointmentSlots over the workloc fixture, UNDER THE PRIMARY-ONLY policy: A+B (B is a
+  Secondary member → dropped by the primary-only STM filter → 0 slots) vs A-only (Primary member → > 0
+  slots). Captures oldReadWithBSlotCount + oldReadAOnlySlotCount for the 1d WorkingLocations read-decision
+  diff.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000120
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-workloc/10-get-appointment-slots-workloc.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-workloc/10-get-appointment-slots-workloc.request.yaml
@@ -1,0 +1,52 @@
+$kind: http-request
+description: >-
+  OLD Salesforce Scheduler MULTI-RESOURCE read: POST /scheduling/getAppointmentSlots over the workloc
+  fixture, tomorrow 11:00-12:00 UTC (60m window matching the WorkType), naming BOTH resourceA (Primary
+  member, free) and resourceB (Secondary member, free) as required, UNDER THE PRIMARY-ONLY policy
+  (schedulingPolicyId=schedWlPrimaryOnlyPolicyId). The classic multi-resource contract treats
+  primaryResourceId and requiredResourceIds as DISJOINT sets (the primary is its own required resource,
+  added separately), and sending A in BOTH lists is a BAD_REQUEST — so "both A and B required" is
+  primaryResourceId=A + requiredResourceIds=[B]. The engine loads STMs via the primary-only policy filter
+  (SchedulingDbUtil.createPrimarySecondarySTMWhereCondition → TerritoryType IN ('P','R')), so the SECONDARY
+  resourceB is dropped from the candidate pool BY ITS ROLE before the A∩B intersection. resourceB is fully
+  AVAILABLE (wide member OH 08-16 covers 11:00-12:00 in OH-mode) — it is excluded purely as a Secondary
+  member under a primary-only policy, not for busyness and not as a non-member. Expected: 0 slots (the
+  WorkingLocations ROLE exclusion). NOTE: the old read has no non-required "helper" input — every named id
+  is required — so the read-side probe is "required Secondary-member zeroes vs A-only offers". Response
+  field is "timeSlots". PREREQUISITE: both resource users hold the Lightning Scheduler PSL +
+  lightningSchedulerUserAccess (granted by the shared grant-ls-user-access Kick revUp'd just before this
+  read) or the classic engine prunes both → an all-0 dead read. Captures oldReadWithBSlotCount.
+url: "{{baseUrl}}{{versionPath}}/scheduling/getAppointmentSlots"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "workType": { "id": "{{schedWlWorkTypeId}}" },
+      "territoryIds": ["{{schedWlTerritoryId}}"],
+      "requiredResourceIds": ["{{schedWlResourceBId}}"],
+      "primaryResourceId": "{{schedWlResourceAId}}",
+      "schedulingPolicyId": "{{schedWlPrimaryOnlyPolicyId}}",
+      "startTime": "{{schedWlReadStart}}",
+      "endTime": "{{schedWlReadEnd}}"
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 0, 0, 0);
+      const e = new Date(s.getTime() + 30 * 60 * 1000);
+      pm.environment.set("schedWlReadStart", s.toISOString());
+      pm.environment.set("schedWlReadEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      const data = pm.response.json() || {};
+      const slots = (data.timeSlots || data.slots || []);
+      pm.environment.set("oldReadWithBSlotCount", String(slots.length));
+      console.log("OLD workloc read A+B http=" + pm.response.code + " slots=" + slots.length);
+    language: text/javascript
+order: 1000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-workloc/20-get-appointment-slots-a-only.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-appointment-slots-workloc/20-get-appointment-slots-a-only.request.yaml
@@ -1,0 +1,37 @@
+$kind: http-request
+description: >-
+  Control: OLD getAppointmentSlots naming ONLY resourceA (Primary member, free) as required, same window
+  (tomorrow 11:00-12:00 UTC), same PRIMARY-ONLY policy (schedulingPolicyId=schedWlPrimaryOnlyPolicyId).
+  SINGLE-resource shape: primaryResourceId is OMITTED (the classic single-resource path requires it to be
+  null when requiredResourceIds has <=1 id) and requiredResourceIds=[A]. Proves the fixture is bookable on
+  the old side (slots > 0) under this policy, so the A+B result in step 10 reflects resourceB's SECONDARY
+  role being filtered out, not a dead fixture or a policy that zeroes everyone. Captures
+  oldReadAOnlySlotCount. Response field is "timeSlots". PREREQUISITE: resourceA's user must hold the
+  Lightning Scheduler PSL + lightningSchedulerUserAccess (granted by the shared grant-ls-user-access Kick)
+  or this control also reads 0 (dead).
+url: "{{baseUrl}}{{versionPath}}/scheduling/getAppointmentSlots"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "workType": { "id": "{{schedWlWorkTypeId}}" },
+      "territoryIds": ["{{schedWlTerritoryId}}"],
+      "requiredResourceIds": ["{{schedWlResourceAId}}"],
+      "schedulingPolicyId": "{{schedWlPrimaryOnlyPolicyId}}",
+      "startTime": "{{schedWlReadStart}}",
+      "endTime": "{{schedWlReadEnd}}"
+    }
+scripts:
+  - type: afterResponse
+    code: |-
+      const data = pm.response.json() || {};
+      const slots = (data.timeSlots || data.slots || []);
+      pm.environment.set("oldReadAOnlySlotCount", String(slots.length));
+      console.log("OLD workloc read A-only http=" + pm.response.code + " slots=" + slots.length);
+    language: text/javascript
+order: 2000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-candidates-excluded/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-candidates-excluded/.resources/definition.yaml
@@ -1,0 +1,12 @@
+$kind: collection
+description: |-
+  OLD Scheduler getAppointmentCandidates over the excluded-helper fixture: WITH accountId (resourceB on the
+  account's Excluded list → should be pruned, absent from candidates) vs NO accountId (resourceB present →
+  non-vacuity: fixture live, exclusion is the accountId+pref). Captures oldCandidatesWithAcct* +
+  oldCandidatesNoAcct* for the 1a read-decision diff. Runs under {{adminToken}}.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000041
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-candidates-excluded/10-get-candidates-excluded.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-candidates-excluded/10-get-candidates-excluded.request.yaml
@@ -1,0 +1,68 @@
+$kind: http-request
+description: >-
+  OLD Salesforce Scheduler READ probe: POST /scheduling/getAppointmentCandidates over the excluded-helper
+  fixture, tomorrow 11:00-11:30 UTC, WITH accountId = the excluded Account. NOTE the endpoint choice: the
+  classic engine enforces account ResourcePreference(Excluded) ONLY on the candidates/all-slots path
+  (SchedulingServiceImpl.getAppointmentCandidates → loadAccountResourcePreferences(accountId) →
+  populateTerritoryResourceAndResourcesSkillDateRange(... accountResourcePreferences) → SchedulingDbUtil
+  .loadServiceResourcesInTerritory → checkResourcePrefs, which drops any SR on the account's excluded list),
+  NOT on plain getAppointmentSlots (that path passes accountResourcePreferences=null → checkResourcePrefs
+  short-circuits true → SchedulingDbUtil.java ~L706-708). So 1a MUST read via getAppointmentCandidates with
+  accountId to exercise the Excluded rule at all.
+  getAppointmentCandidates request shape (GetAppointmentCandidatesRequest): territoryIds (mandatory),
+  workType OR workTypeGroupId, startTime/endTime, accountId (the tie to the Account whose Excluded prefs
+  apply). It has NO requiredResourceIds/primaryResourceId inputs — it enumerates ALL eligible resources per
+  territory and returns candidates[], each { startTime, endTime, resources:[serviceResourceId...], territoryId }
+  (GetAppointmentCandidatesResponse → Candidate). The probe question: does resourceB appear in ANY
+  candidate's resources[]? With the Excluded pref + accountId it should be PRUNED (absent) → EXCLUDED.
+  Captures oldCandidatesWithAcctResourceBPresent (1/0) + oldCandidatesWithAcctCount (total candidates) +
+  oldCandidatesWithAcctResourceAPresent (1/0). PREREQUISITE: both resource users hold the Lightning
+  Scheduler PSL + lightningSchedulerUserAccess (granted by the shared grant-ls-user-access Kick revUp'd just
+  before) or the classic engine prunes both → an all-empty dead read.
+url: "{{baseUrl}}{{versionPath}}/scheduling/getAppointmentCandidates"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "workType": { "id": "{{schedWorkTypeId}}" },
+      "territoryIds": ["{{schedTerritoryId}}"],
+      "accountId": "{{schedAccountId}}",
+      "startTime": "{{schedReadStart}}",
+      "endTime": "{{schedReadEnd}}"
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 0, 0, 0);
+      const e = new Date(s.getTime() + 30 * 60 * 1000);
+      pm.environment.set("schedReadStart", s.toISOString());
+      pm.environment.set("schedReadEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      // Response: { "candidates": [ { startTime, endTime, resources:[srId...], territoryId }, ... ] }.
+      // resourceB is EXCLUDED iff it appears in NO candidate's resources[]. Ids may come back 15- or
+      // 18-char, so compare on the 15-char prefix. Also capture whether resourceA is present (non-vacuity:
+      // A must still be a candidate) and the total candidate count.
+      const data = pm.response.json() || {};
+      const candidates = data.candidates || [];
+      const key = (id) => String(id || "").substring(0, 15);
+      const bKey = key(pm.environment.get("schedResourceBId"));
+      const aKey = key(pm.environment.get("schedResourceAId"));
+      let bPresent = 0, aPresent = 0;
+      candidates.forEach(c => (c.resources || []).forEach(r => {
+        if (key(r) === bKey) bPresent = 1;
+        if (key(r) === aKey) aPresent = 1;
+      }));
+      pm.environment.set("oldCandidatesWithAcctResourceBPresent", String(bPresent));
+      pm.environment.set("oldCandidatesWithAcctResourceAPresent", String(aPresent));
+      pm.environment.set("oldCandidatesWithAcctCount", String(candidates.length));
+      console.log("OLD candidates WITH acct http=" + pm.response.code + " count=" + candidates.length +
+                  " Apresent=" + aPresent + " Bpresent=" + bPresent);
+    language: text/javascript
+order: 1000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-candidates-excluded/20-get-candidates-no-account.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-candidates-excluded/20-get-candidates-no-account.request.yaml
@@ -1,0 +1,40 @@
+$kind: http-request
+description: >-
+  NON-VACUITY CONTROL: the SAME getAppointmentCandidates read over the SAME excluded-helper fixture, same
+  window (tomorrow 11:00-11:30 UTC), but with NO accountId. Without an accountId the classic engine loads
+  NO account ResourcePreferences (accountResourcePreferences stays null → checkResourcePrefs short-circuits
+  true), so resourceB is NOT pruned and SHOULD appear as a candidate — proving (a) the fixture is live and
+  resourceB is a real, available candidate at 11:00, and (b) resourceB's absence in the WITH-account read
+  (step 10) is caused specifically by the account ResourcePreference(Excluded), not by a dead fixture or a
+  silently-failed grant. Captures oldCandidatesNoAcctResourceBPresent (1/0) + oldCandidatesNoAcctCount.
+  PREREQUISITE: same Lightning-Scheduler grant as step 10.
+url: "{{baseUrl}}{{versionPath}}/scheduling/getAppointmentCandidates"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "workType": { "id": "{{schedWorkTypeId}}" },
+      "territoryIds": ["{{schedTerritoryId}}"],
+      "startTime": "{{schedReadStart}}",
+      "endTime": "{{schedReadEnd}}"
+    }
+scripts:
+  - type: afterResponse
+    code: |-
+      const data = pm.response.json() || {};
+      const candidates = data.candidates || [];
+      const key = (id) => String(id || "").substring(0, 15);
+      const bKey = key(pm.environment.get("schedResourceBId"));
+      let bPresent = 0;
+      candidates.forEach(c => (c.resources || []).forEach(r => { if (key(r) === bKey) bPresent = 1; }));
+      pm.environment.set("oldCandidatesNoAcctResourceBPresent", String(bPresent));
+      pm.environment.set("oldCandidatesNoAcctCount", String(candidates.length));
+      console.log("OLD candidates NO acct http=" + pm.response.code + " count=" + candidates.length +
+                  " Bpresent=" + bPresent);
+    language: text/javascript
+order: 2000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-candidates-limit-positive/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-candidates-limit-positive/.resources/definition.yaml
@@ -1,0 +1,13 @@
+$kind: collection
+description: |-
+  OLD Scheduler getAppointmentCandidates with an explicit resourceLimitApptDistribution=50 over the SAME
+  limit-helper fixture (Decision 8 control). NO filterByResources so the load-balancing path engages; 50 (>
+  the seeded 2 resources) is a no-op cap → the pool comes back whole → candidates > 0 (proves 0 is a literal
+  cap-of-0 and the fixture/policy/grant are live). Captures limitPositiveResourceCount /
+  limitPositiveCandidateCount / limitPositiveHttp / limitPositiveErrorCode. Runs under {{adminToken}}.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000132
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-candidates-limit-positive/10-get-candidates-limit-positive.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-candidates-limit-positive/10-get-candidates-limit-positive.request.yaml
@@ -1,0 +1,55 @@
+$kind: http-request
+description: >-
+  Decision 8 old-side probe N (control) — OLD getAppointmentCandidates over the SAME limit-helper fixture +
+  window + load-balancing policy, with an explicit resourceLimitApptDistribution=50 (well above the seeded
+  2-resource pool). The cap is a deliberate no-op (filteredResourceIds.size() <= 50 → the pool is returned
+  whole), so the post-rule candidate set comes back NON-empty — proving 0 is a LITERAL cap-of-0, not "no
+  limit". Same NO-filterByResources requirement so the load-balancing path engages. Read-only contract: HTTP
+  200, no exception. Captures the distinct resource-id count as limitPositiveResourceCount (+ ...Http /
+  ...ErrorCode). This is ALSO the non-vacuity control: it MUST be > 0, proving the fixture + the
+  load-balancing policy + the Lightning-Scheduler grant are all LIVE — so the limit=0 empty result is the
+  cap, not a dead read. Runs order 2000 (after the limit-zero probe, order 1000) in the same read-only revUp.
+url: "{{baseUrl}}{{versionPath}}/scheduling/getAppointmentCandidates"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "workType": { "id": "{{schedLimitWorkTypeId}}" },
+      "territoryIds": ["{{schedLimitTerritoryId}}"],
+      "schedulingPolicyId": "{{schedLimitPolicyId}}",
+      "resourceLimitApptDistribution": 50,
+      "startTime": "{{schedLimitReadStart}}",
+      "endTime": "{{schedLimitReadEnd}}"
+    }
+scripts:
+  - type: afterResponse
+    code: |-
+      // Same distinct-resource measure across candidates, with the candidate-count fallback (see the
+      // limit-zero probe). limit=50 (> the 2 seeded resources) → no trim → the full pool survives.
+      const data = pm.response.json() || {};
+      const candidates = (data.candidates || []);
+      const resourceIds = new Set();
+      candidates.forEach(c => {
+        const rs = c.resources || c.serviceResources || [];
+        rs.forEach(r => {
+          const id = (typeof r === "string") ? r
+                   : (r && (r.resourceId || r.id || r.serviceResourceId || r.serviceResource)) || null;
+          if (id) resourceIds.add(id);
+        });
+      });
+      const resourceCount = resourceIds.size > 0 ? resourceIds.size : candidates.length;
+      pm.environment.set("limitPositiveResourceCount", String(resourceCount));
+      pm.environment.set("limitPositiveCandidateCount", String(candidates.length));
+      pm.environment.set("limitPositiveHttp", String(pm.response.code));
+      pm.environment.set("limitPositiveErrorCode", data.errorCode || "");
+      console.log("OLD candidates limit=50 http=" + pm.response.code +
+                  " candidates=" + candidates.length + " distinctResources=" + resourceIds.size +
+                  " resourceCount=" + resourceCount + " errorCode=" + (data.errorCode || "") +
+                  " body=" + JSON.stringify(data).slice(0,400));
+    language: text/javascript
+order: 2000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-candidates-limit-zero/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-candidates-limit-zero/.resources/definition.yaml
@@ -1,0 +1,12 @@
+$kind: collection
+description: |-
+  OLD Scheduler getAppointmentCandidates with resourceLimitApptDistribution=0 over the limit-helper fixture
+  (Decision 8). NO filterByResources so the load-balancing (smart-scheduling) path engages; limit=0 caps the
+  resource pool to zero → empty candidates. Captures limitZeroResourceCount / limitZeroCandidateCount /
+  limitZeroHttp / limitZeroErrorCode. Runs under {{adminToken}}.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000131
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-candidates-limit-zero/10-get-candidates-limit-zero.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-candidates-limit-zero/10-get-candidates-limit-zero.request.yaml
@@ -1,0 +1,71 @@
+$kind: http-request
+description: >-
+  Decision 8 old-side probe A — OLD Salesforce Scheduler POST /scheduling/getAppointmentCandidates over the
+  limit-helper fixture (tomorrow 11:00-11:30 UTC) with resourceLimitApptDistribution=0 and the load-balancing
+  scheduling policy (schedLimitPolicyId, whose AppointmentAssignmentPolicy FK is the load-balancing record).
+  CRITICAL: NO filterByResources is passed — SmartSchedulerServiceImpl.getSmartPolicy returns LOAD_BALANCING
+  only when filterByResources is EMPTY (and the org has smart scheduling + the policy carries the assignment
+  FK). On that path SmartSchedulerServiceImpl.getLeastUtilizedResources caps the ordered resource pool via
+  subList(0, N); calculateResourceLimitAppointmentDistribution treats 0 as a LITERAL cap-of-zero (0 >= 0 →
+  limit=0), NOT "no limit" (null → default 10). So limit=0 → empty resource pool → empty candidates.
+  Read-only contract: HTTP 200, no exception. Captures the DISTINCT resource-id count across candidates as
+  limitZeroResourceCount (+ ...Http / ...ErrorCode). accountId is omitted (Decision 8 is a presentation cap,
+  not an account rule; an account would only add ResourcePreference noise). PREREQUISITE: both resource users
+  hold the Lightning Scheduler PSL + lightningSchedulerUserAccess (shared grant-ls-user-access Kick) or the
+  classic engine prunes the resources (removeResourcesWithoutPerm) → an all-0 dead read.
+url: "{{baseUrl}}{{versionPath}}/scheduling/getAppointmentCandidates"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "workType": { "id": "{{schedLimitWorkTypeId}}" },
+      "territoryIds": ["{{schedLimitTerritoryId}}"],
+      "schedulingPolicyId": "{{schedLimitPolicyId}}",
+      "resourceLimitApptDistribution": 0,
+      "startTime": "{{schedLimitReadStart}}",
+      "endTime": "{{schedLimitReadEnd}}"
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 0, 0, 0);
+      const e = new Date(s.getTime() + 60 * 60 * 1000);
+      pm.environment.set("schedLimitReadStart", s.toISOString());
+      pm.environment.set("schedLimitReadEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      // Success shape: { candidates: [ { startTime, endTime, resources:[...], ... }, ... ] }. The
+      // load-balancing cap trims the RESOURCE POOL before slot generation, so the observable size is the
+      // set of DISTINCT resources represented across candidates. Old candidates carry the resource under a
+      // few possible shapes/keys, so probe several; if none match, fall back to the candidate COUNT (with a
+      // 60m WorkType over the 11:00-11:30 window each resource yields exactly one candidate row, so the
+      // candidate count == the surviving-resource count). limit=0 → empty pool → 0; no-op → the full pool.
+      // Do NOT prejudge a crash: a 500 would show http=500 + errorCode. Characterize what the engine returns.
+      const data = pm.response.json() || {};
+      const candidates = (data.candidates || []);
+      const resourceIds = new Set();
+      candidates.forEach(c => {
+        const rs = c.resources || c.serviceResources || [];
+        rs.forEach(r => {
+          const id = (typeof r === "string") ? r
+                   : (r && (r.resourceId || r.id || r.serviceResourceId || r.serviceResource)) || null;
+          if (id) resourceIds.add(id);
+        });
+      });
+      const resourceCount = resourceIds.size > 0 ? resourceIds.size : candidates.length;
+      pm.environment.set("limitZeroResourceCount", String(resourceCount));
+      pm.environment.set("limitZeroCandidateCount", String(candidates.length));
+      pm.environment.set("limitZeroHttp", String(pm.response.code));
+      pm.environment.set("limitZeroErrorCode", data.errorCode || "");
+      console.log("OLD candidates limit=0 http=" + pm.response.code +
+                  " candidates=" + candidates.length + " distinctResources=" + resourceIds.size +
+                  " resourceCount=" + resourceCount + " errorCode=" + (data.errorCode || "") +
+                  " body=" + JSON.stringify(data).slice(0,400));
+    language: text/javascript
+order: 1000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-candidates-required/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-candidates-required/.resources/definition.yaml
@@ -1,0 +1,12 @@
+$kind: collection
+description: |-
+  OLD Scheduler getAppointmentCandidates over the required-helper fixture: A-only (the account requires B →
+  A filtered out of the pool → 0 candidates, characterized) vs B-required control (the account-required
+  worker → > 0 candidates). Captures oldCandidatesWithBReqCount / ...Http / ...ErrorCode/Message +
+  oldCandidatesBReqCount for the 1.4 read-decision diff. Runs under {{adminToken}}.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000120
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-candidates-required/10-get-candidates-a-only.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-candidates-required/10-get-candidates-a-only.request.yaml
@@ -1,0 +1,65 @@
+$kind: http-request
+description: >-
+  OLD Salesforce Scheduler REQUIRED-RESOURCES read (Decision 1.4): POST /scheduling/getAppointmentCandidates
+  over the required-helper fixture, tomorrow 11:00-11:30 UTC, with accountId set (so the classic engine
+  loads the Account's ResourcePreference) and the required-resources policy (schedReqPolicyId,
+  ShouldEnforceRequiredResource=true). filterByResources offers ONLY resourceA — but the Account's
+  ResourcePreference(Required) names resourceB, NOT resourceA. Per the classic engine (SchedulingServiceImpl
+  .getAppointmentCandidatesForTerritoryWorkTypes → loadAccountResourcePreferences populates
+  requiredServiceResourceIds={resourceB}; SchedulingDbUtil.checkResourcePrefs then FILTERS the candidate
+  pool to that required set), resourceA — not in {resourceB} — is dropped, so the pool goes EMPTY.
+  IMPORTANT SEMANTIC NOTE: on the OLD engine the account Required pref is a candidate-POOL FILTER (keep only
+  the account's required resources), NOT a "helper must satisfy a demand" satisfier — so this probe measures
+  what the OLD engine actually does with an account demand for a worker that is not the one offered.
+  KEY: the classic ServiceTerritory ALWAYS initializes serviceTerritoryMembers = ArrayListMultimap.create()
+  (scheduling-api ServiceTerritory ctor), so the pool-empty case cannot NPE the way the Unified engine does
+  (unified ServiceTerritory leaves serviceTerritoryMembers null → getAllServiceTerritoryMembers().values() NPE
+  → HTTP 500). So the expected OLD outcome is a CLEAN 0-candidate refuse (HTTP 200, empty candidates), which
+  DIVERGES from the 264 write-path CRASH. Response top-level field is "candidates". Captures
+  oldCandidatesWithBReqCount + oldCandidatesWithBReqHttp + oldCandidatesWithBReqErrorCode/Message.
+  PREREQUISITE: both resource users must hold the Lightning Scheduler PSL + lightningSchedulerUserAccess
+  (granted by the shared grant-ls-user-access Kick, revUp'd just before) or the classic engine prunes the
+  resources (removeResourcesWithoutPerm) → an all-0 dead read that would make the divergence read vacuously.
+url: "{{baseUrl}}{{versionPath}}/scheduling/getAppointmentCandidates"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "workType": { "id": "{{schedReqWorkTypeId}}" },
+      "territoryIds": ["{{schedReqTerritoryId}}"],
+      "accountId": "{{schedReqAccountId}}",
+      "schedulingPolicyId": "{{schedReqPolicyId}}",
+      "filterByResources": ["{{schedReqResourceAId}}"],
+      "startTime": "{{schedReqReadStart}}",
+      "endTime": "{{schedReqReadEnd}}"
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 0, 0, 0);
+      const e = new Date(s.getTime() + 60 * 60 * 1000);
+      pm.environment.set("schedReqReadStart", s.toISOString());
+      pm.environment.set("schedReqReadEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      // Success shape: { candidates: [ { startTime, endTime, resources:[...], territoryId }, ... ] }.
+      // Refuse/crash shape: { errorCode, message } (ErrorRepresentation). Capture the count without
+      // prejudging: a clean 0-candidate refuse is candidates=[] http=200; a crash would be http=500 +
+      // errorCode=INTERNAL_SERVER_ERROR. Do NOT force either — characterize what the OLD engine returns.
+      const data = pm.response.json() || {};
+      const candidates = (data.candidates || []);
+      pm.environment.set("oldCandidatesWithBReqCount", String(candidates.length));
+      pm.environment.set("oldCandidatesWithBReqHttp", String(pm.response.code));
+      pm.environment.set("oldCandidatesWithBReqErrorCode", data.errorCode || "");
+      pm.environment.set("oldCandidatesWithBReqErrorMessage", data.message || "");
+      console.log("OLD candidates A-only(acct-requires-B) http=" + pm.response.code +
+                  " candidates=" + candidates.length + " errorCode=" + (data.errorCode || "") +
+                  " body=" + JSON.stringify(data).slice(0,300));
+    language: text/javascript
+order: 1000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-candidates-required/20-get-candidates-b-required.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/get-candidates-required/20-get-candidates-b-required.request.yaml
@@ -1,0 +1,39 @@
+$kind: http-request
+description: >-
+  Control: OLD getAppointmentCandidates offering resourceB (the account-required worker) via
+  filterByResources, same account + required-resources policy + window (tomorrow 11:00-11:30 UTC).
+  resourceB IS on the Account's ResourcePreference(Required) list, so SchedulingDbUtil.checkResourcePrefs
+  KEEPS it in the pool; resourceB is available at the window (member OH + Shift 08-16) → candidates > 0.
+  Proves the fixture, the required-resources policy AND the Lightning-Scheduler grant are all LIVE — so the
+  A-only result in step 10 (0 candidates) reflects the account's required-resource pool FILTER excluding
+  resourceA, not a dead fixture / silently-failed grant / mis-set policy. Captures oldCandidatesBReqCount.
+  Response top-level field is "candidates". PREREQUISITE: resourceB's user must hold the Lightning Scheduler
+  PSL + lightningSchedulerUserAccess (shared grant-ls-user-access Kick) or this control also reads 0 (dead).
+url: "{{baseUrl}}{{versionPath}}/scheduling/getAppointmentCandidates"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "workType": { "id": "{{schedReqWorkTypeId}}" },
+      "territoryIds": ["{{schedReqTerritoryId}}"],
+      "accountId": "{{schedReqAccountId}}",
+      "schedulingPolicyId": "{{schedReqPolicyId}}",
+      "filterByResources": ["{{schedReqResourceBId}}"],
+      "startTime": "{{schedReqReadStart}}",
+      "endTime": "{{schedReqReadEnd}}"
+    }
+scripts:
+  - type: afterResponse
+    code: |-
+      const data = pm.response.json() || {};
+      const candidates = (data.candidates || []);
+      pm.environment.set("oldCandidatesBReqCount", String(candidates.length));
+      console.log("OLD candidates B-required(control) http=" + pm.response.code +
+                  " candidates=" + candidates.length);
+    language: text/javascript
+order: 2000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/grant-ls-user-access/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/grant-ls-user-access/.resources/definition.yaml
@@ -1,0 +1,13 @@
+$kind: collection
+description: |-
+  SHARED prerequisite grant for the OLD classic Scheduler read AND write paths: assign the Lightning
+  Scheduler PSL + Salesforce_Scheduler_Resource permission set (carrying the lightningSchedulerUserAccess
+  user-perm) to both double-book resource users. Consolidated here (DRY) so the read (getAppointmentSlots)
+  and write (service-appointments book) collections share ONE copy — they both revUp this Kick after the
+  fixture. Runs under {{adminToken}}.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000029
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/grant-ls-user-access/05-grant-ls-user-access.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/grant-ls-user-access/05-grant-ls-user-access.request.yaml
@@ -1,0 +1,52 @@
+$kind: http-request
+description: >-
+  SHARED PREREQUISITE part 1 of 2 for BOTH the OLD classic getAppointmentSlots read AND the classic
+  service-appointments book: resolve the ids needed to grant each double-book ServiceResource's backing
+  User the Lightning Scheduler access. Consolidated into its own Kick (grant-ls-user-access) so the read
+  and write collections share ONE copy — each revUps it right after the double-book fixture. Uses the Batch API
+  (/composite/batch — last path segment "batch", so it dodges the shared Kick's composite / composite-graph
+  response unmarshallers + success hooks, which expect query-shaped substep bodies and would choke on the
+  mixed grant response). Four independent GET queries → PSL id (LightningSchedulerPsl, by DeveloperName),
+  PS id (Salesforce_Scheduler_Resource, by Name — the standard perm set carrying the
+  lightningSchedulerUserAccess user-perm), and each resource's RelatedRecordId (the backing User). Captures
+  lsPslId / lsPsId / schedUserAId / schedUserBId for the assign batch (07). WHY THIS EXISTS: JDWP-confirmed
+  on the scheduler org, the classic slot-gen (SchedulingServiceImpl.getAppointmentSlotsForTerritories ->
+  removeResourcesWithoutPerm -> SchedulerCommonUtil.checkForUserPermission(users, lightningSchedulerUserAccess))
+  PRUNES every ServiceResource whose user lacks that user-perm — so without the grant BOTH reads return an
+  empty timeSlots (resourceA, though free 10-14, is dropped → dead read) and the book sees NO resources
+  (dead fixture). The check is skipped only under TestContext.isRunningTests(), which is why in-JVM
+  scheduling func tests never grant it; a REAL REST call (ReVoman) enforces it.
+url: "{{baseUrl}}{{versionPath}}/composite/batch"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "batchRequests": [
+        { "method": "GET", "url": "{{versionPath}}/query/?q=SELECT+Id+FROM+PermissionSetLicense+WHERE+DeveloperName='LightningSchedulerPsl'" },
+        { "method": "GET", "url": "{{versionPath}}/query/?q=SELECT+Id+FROM+PermissionSet+WHERE+Name='Salesforce_Scheduler_Resource'" },
+        { "method": "GET", "url": "{{versionPath}}/query/?q=SELECT+RelatedRecordId+FROM+ServiceResource+WHERE+Id='{{schedResourceAId}}'" },
+        { "method": "GET", "url": "{{versionPath}}/query/?q=SELECT+RelatedRecordId+FROM+ServiceResource+WHERE+Id='{{schedResourceBId}}'" }
+      ]
+    }
+scripts:
+  - type: afterResponse
+    code: |-
+      // Batch response: { results: [ { statusCode, result: { records: [...] } }, ... ] }. Pull the four
+      // ids the assign batch (07) needs. If any query came back empty the grant can't proceed — surface it
+      // via the log (the reads would then read 0 and the control assertion would catch a dead fixture).
+      const data = pm.response.json() || {};
+      const results = data.results || [];
+      const first = (i) => (((results[i] || {}).result || {}).records || [])[0] || {};
+      pm.environment.set("lsPslId", first(0).Id);
+      pm.environment.set("lsPsId", first(1).Id);
+      pm.environment.set("schedUserAId", first(2).RelatedRecordId);
+      pm.environment.set("schedUserBId", first(3).RelatedRecordId);
+      console.log("OLD grant part1 psl=" + first(0).Id + " ps=" + first(1).Id +
+                  " userA=" + first(2).RelatedRecordId + " userB=" + first(3).RelatedRecordId);
+    language: text/javascript
+order: 500

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/grant-ls-user-access/07-grant-ls-user-access-assign.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/grant-ls-user-access/07-grant-ls-user-access-assign.request.yaml
@@ -1,0 +1,39 @@
+$kind: http-request
+description: >-
+  PREREQUISITE part 2 of 2: assign the Lightning Scheduler PSL + Salesforce_Scheduler_Resource permission
+  set (which carries the lightningSchedulerUserAccess user-perm) to BOTH double-book resource users, using
+  the ids captured by 05. Batch API again (/composite/batch, dodges the composite unmarshallers) with four
+  INDEPENDENT assign POSTs (batch subrequests don't roll each other back). Idempotent: on a re-run against
+  a warm user each assign returns DUPLICATE_VALUE — harmless, and ignoreHTTPStatusUnsuccessful keeps the
+  step green; the invariant is only that both users END holding PSL + PS. After this the classic engine
+  stops pruning the resources, so the downstream read (getAppointmentSlots) or write (book) collection sees
+  real availability. Runs after the id-query (05, order 500) within this shared grant Kick (order 700 > 500);
+  the whole Kick is sequenced between the double-book fixture Kick and the read/write Kick by revUp order.
+url: "{{baseUrl}}{{versionPath}}/composite/batch"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "batchRequests": [
+        { "method": "POST", "url": "{{versionPath}}/sobjects/PermissionSetLicenseAssign", "richInput": { "AssigneeId": "{{schedUserAId}}", "PermissionSetLicenseId": "{{lsPslId}}" } },
+        { "method": "POST", "url": "{{versionPath}}/sobjects/PermissionSetLicenseAssign", "richInput": { "AssigneeId": "{{schedUserBId}}", "PermissionSetLicenseId": "{{lsPslId}}" } },
+        { "method": "POST", "url": "{{versionPath}}/sobjects/PermissionSetAssignment", "richInput": { "AssigneeId": "{{schedUserAId}}", "PermissionSetId": "{{lsPsId}}" } },
+        { "method": "POST", "url": "{{versionPath}}/sobjects/PermissionSetAssignment", "richInput": { "AssigneeId": "{{schedUserBId}}", "PermissionSetId": "{{lsPsId}}" } }
+      ]
+    }
+scripts:
+  - type: afterResponse
+    code: |-
+      // Log substep statuses. A 201 = freshly granted; a 400 DUPLICATE_VALUE = already granted (a warm
+      // re-run) — both leave the user holding the perm, so neither fails this step.
+      const data = pm.response.json() || {};
+      const results = data.results || [];
+      const statuses = results.map(r => r.statusCode).join(",");
+      console.log("OLD grant part2 assign statusCodes=" + statuses);
+    language: text/javascript
+order: 700

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-clean-two-resource/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-clean-two-resource/.resources/definition.yaml
@@ -1,0 +1,13 @@
+$kind: collection
+description: |-
+  OLD Scheduler CLEAN two-resource book for Decision 4z: POST /connect/scheduling/service-appointments with
+  resourceA (primary+required) + resourceB (required), both available at 11:00-11:30 → the SA books. A
+  follow-up query then reads the AssignedResource rows for that SA and identifies the PRIMARY AR id (the
+  target for the reschedule-analog delete/demote probes). Captures reschedCleanSaId / reschedCleanHttp /
+  reschedPrimaryArId / reschedSecondaryArId / reschedCleanArCount. Runs under {{adminToken}}.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-0000004z0040
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-clean-two-resource/10-book-clean.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-clean-two-resource/10-book-clean.request.yaml
@@ -1,0 +1,54 @@
+$kind: http-request
+description: >-
+  OLD Salesforce Scheduler CLEAN two-resource book: POST /connect/scheduling/service-appointments, tomorrow
+  11:00-11:30 UTC, with TWO assignedResources — resourceA (isRequiredResource=true, isPrimaryResource=true)
+  and resourceB (isRequiredResource=true, isPrimaryResource=false). BOTH are available at the window (member
+  OH + Shift 08-16), so the SA books (HTTP 2xx, serviceAppointmentId + assignedResourceIds returned). This
+  is the parity analog of the 264 SCHEDULE_TWO_RESOURCE_CLEAN act — a clean two-resource SA with exactly one
+  primary. Captures reschedCleanHttp + reschedCleanSaId (for the follow-up AssignedResource query, which
+  identifies the primary AR to delete/demote in the reschedule-analog probes).
+url: "{{baseUrl}}{{versionPath}}/connect/scheduling/service-appointments"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  x-revoman-ledger: "off"
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "serviceAppointment": {
+        "serviceTerritoryId": "{{schedTerritoryId}}",
+        "parentRecordId": "{{schedAccountId}}",
+        "workTypeId": "{{schedWorkTypeId}}",
+        "schedStartTime": "{{schedBookStart}}",
+        "schedEndTime": "{{schedBookEnd}}",
+        "extendedFields": [ { "name": "Status", "value": "Scheduled" } ]
+      },
+      "assignedResources": [
+        { "serviceResourceId": "{{schedResourceAId}}", "isRequiredResource": true, "isPrimaryResource": true },
+        { "serviceResourceId": "{{schedResourceBId}}", "isRequiredResource": true, "isPrimaryResource": false }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 0, 0, 0);
+      const e = new Date(s.getTime() + 30 * 60 * 1000);
+      pm.environment.set("schedBookStart", s.toISOString());
+      pm.environment.set("schedBookEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      // The Connect book API wraps its payload in a "result" node on success:
+      // { "result": { "serviceAppointmentId": "08p...", "assignedResourceIds": [...] } }. Dig the SA id
+      // out of result first, then the flatter shapes. (The assignedResourceIds order does NOT reliably
+      // map to primary/secondary, so the primary AR is resolved by the follow-up SOQL query in 20-…)
+      const data = pm.response.json() || {};
+      const result = data.result || data;
+      pm.environment.set("reschedCleanHttp", String(pm.response.code));
+      pm.environment.set("reschedCleanSaId", result.serviceAppointmentId || (result.serviceAppointment && result.serviceAppointment.id) || "");
+      console.log("OLD clean book http=" + pm.response.code + " body=" + JSON.stringify(data).slice(0,400));
+    language: text/javascript
+order: 1000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-clean-two-resource/20-query-assigned-resources.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-clean-two-resource/20-query-assigned-resources.request.yaml
@@ -1,0 +1,41 @@
+$kind: http-request
+description: >-
+  Follow-up read (Batch API, so it dodges the shared Kick's composite unmarshallers): SELECT the
+  AssignedResource rows for the clean SA just booked (reschedCleanSaId), with their IsPrimaryResource flag.
+  Identifies the PRIMARY AssignedResource id — the target the reschedule-analog delete/demote probes will
+  attempt to remove to leave the SA with NO primary. Captures reschedPrimaryArId (the AR where
+  IsPrimaryResource=true), reschedSecondaryArId (the other), and reschedCleanArCount (should be 2).
+url: "{{baseUrl}}{{versionPath}}/composite/batch"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "batchRequests": [
+        { "method": "GET", "url": "{{versionPath}}/query/?q=SELECT+Id,ServiceResourceId,IsPrimaryResource,IsRequiredResource+FROM+AssignedResource+WHERE+ServiceAppointmentId='{{reschedCleanSaId}}'+ORDER+BY+IsPrimaryResource+DESC" }
+      ]
+    }
+scripts:
+  - type: afterResponse
+    code: |-
+      // Batch response: { results: [ { statusCode, result: { records: [...] } } ] }. Pull the AR rows and
+      // split by IsPrimaryResource so the delete/demote probes target the PRIMARY AR deterministically
+      // (the assignedResourceIds save-order from the book response does NOT map to primary/secondary).
+      const data = pm.response.json() || {};
+      const results = data.results || [];
+      const records = (((results[0] || {}).result || {}).records || []);
+      const primary = records.filter(r => r.IsPrimaryResource === true);
+      const secondary = records.filter(r => r.IsPrimaryResource !== true);
+      pm.environment.set("reschedCleanArCount", String(records.length));
+      pm.environment.set("reschedPrimaryArId", (primary[0] || {}).Id || "");
+      pm.environment.set("reschedSecondaryArId", (secondary[0] || {}).Id || "");
+      console.log("OLD clean AR rows count=" + records.length +
+                  " primaryArId=" + ((primary[0] || {}).Id || "") +
+                  " secondaryArId=" + ((secondary[0] || {}).Id || "") +
+                  " body=" + JSON.stringify(records).slice(0,400));
+    language: text/javascript
+order: 1010

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-double-book-non-required/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-double-book-non-required/.resources/definition.yaml
@@ -1,0 +1,9 @@
+$kind: collection
+description: |-
+  OLD Scheduler book of the double-book fixture (see the request file). Runs under {{adminToken}}.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000030
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-double-book-non-required/10-book.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-double-book-non-required/10-book.request.yaml
@@ -1,0 +1,51 @@
+$kind: http-request
+description: >-
+  OLD Salesforce Scheduler book: POST /connect/scheduling/service-appointments, tomorrow 11:00-11:30 UTC,
+  with TWO assignedResources — resourceA (isRequiredResource=true, isPrimaryResource=true, free) and
+  resourceB (isRequiredResource=false, busy at 11:00). Per the object reference, a non-required resource
+  is "considered available for other appointments" — so the old engine should NOT availability-check B →
+  the SA books (HTTP 2xx, serviceAppointmentId returned). Captures oldWriteHelperHttp + oldWriteHelperSaId.
+url: "{{baseUrl}}{{versionPath}}/connect/scheduling/service-appointments"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  x-revoman-ledger: "off"
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "serviceAppointment": {
+        "serviceTerritoryId": "{{schedTerritoryId}}",
+        "parentRecordId": "{{schedAccountId}}",
+        "workTypeId": "{{schedWorkTypeId}}",
+        "schedStartTime": "{{schedBookStart}}",
+        "schedEndTime": "{{schedBookEnd}}",
+        "extendedFields": [ { "name": "Status", "value": "Scheduled" } ]
+      },
+      "assignedResources": [
+        { "serviceResourceId": "{{schedResourceAId}}", "isRequiredResource": true, "isPrimaryResource": true },
+        { "serviceResourceId": "{{schedResourceBId}}", "isRequiredResource": false, "isPrimaryResource": false }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 0, 0, 0);
+      const e = new Date(s.getTime() + 30 * 60 * 1000);
+      pm.environment.set("schedBookStart", s.toISOString());
+      pm.environment.set("schedBookEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      // The Connect book API wraps its payload in a "result" node on success:
+      // { "result": { "serviceAppointmentId": "08p...", "assignedResourceIds": [...] } }. On refusal it
+      // returns a top-level error array. Dig the SA id out of result first, then the flatter shapes.
+      const data = pm.response.json() || {};
+      const result = data.result || data;
+      pm.environment.set("oldWriteHelperHttp", String(pm.response.code));
+      pm.environment.set("oldWriteHelperSaId", result.serviceAppointmentId || (result.serviceAppointment && result.serviceAppointment.id) || "");
+      console.log("OLD book helper http=" + pm.response.code + " body=" + JSON.stringify(data).slice(0,300));
+    language: text/javascript
+order: 1000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-double-book-required-control/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-double-book-required-control/.resources/definition.yaml
@@ -1,0 +1,9 @@
+$kind: collection
+description: |-
+  OLD Scheduler book of the double-book fixture (see the request file). Runs under {{adminToken}}.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000031
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-double-book-required-control/10-book.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-double-book-required-control/10-book.request.yaml
@@ -1,0 +1,50 @@
+$kind: http-request
+description: >-
+  Control: OLD book with resourceB isRequiredResource=true (still busy at 11:00). A REQUIRED busy resource
+  IS availability-checked → the book is refused (non-2xx, no serviceAppointmentId). Isolates the helper
+  Success to the non-required flag. Captures oldWriteRequiredControlHttp + oldWriteRequiredControlSaId.
+url: "{{baseUrl}}{{versionPath}}/connect/scheduling/service-appointments"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  x-revoman-ledger: "off"
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "serviceAppointment": {
+        "serviceTerritoryId": "{{schedTerritoryId}}",
+        "parentRecordId": "{{schedAccountId}}",
+        "workTypeId": "{{schedWorkTypeId}}",
+        "schedStartTime": "{{schedBookStart}}",
+        "schedEndTime": "{{schedBookEnd}}",
+        "extendedFields": [ { "name": "Status", "value": "Scheduled" } ]
+      },
+      "assignedResources": [
+        { "serviceResourceId": "{{schedResourceAId}}", "isRequiredResource": true, "isPrimaryResource": true },
+        { "serviceResourceId": "{{schedResourceBId}}", "isRequiredResource": true, "isPrimaryResource": false }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 0, 0, 0);
+      const e = new Date(s.getTime() + 30 * 60 * 1000);
+      pm.environment.set("schedBookStart", s.toISOString());
+      pm.environment.set("schedBookEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      // The Connect book API wraps its payload in a "result" node on success:
+      // { "result": { "serviceAppointmentId": "08p...", "assignedResourceIds": [...] } }. On refusal it
+      // returns a top-level error array (here: 400 INTERNAL_ERROR "We couldn't find any resources...").
+      // Dig the SA id out of result first, then the flatter shapes; a refusal leaves it empty.
+      const data = pm.response.json() || {};
+      const result = data.result || data;
+      pm.environment.set("oldWriteRequiredControlHttp", String(pm.response.code));
+      pm.environment.set("oldWriteRequiredControlSaId", result.serviceAppointmentId || (result.serviceAppointment && result.serviceAppointment.id) || "");
+      console.log("OLD book required-control http=" + pm.response.code + " body=" + JSON.stringify(data).slice(0,300));
+    language: text/javascript
+order: 1000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-excluded-non-required/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-excluded-non-required/.resources/definition.yaml
@@ -1,0 +1,12 @@
+$kind: collection
+description: |-
+  OLD Scheduler book of the excluded-helper fixture: resourceA (required+primary, clean) + resourceB
+  (non-required helper, on the Account's Excluded ResourcePreference list). The classic book path does not
+  enforce account ResourcePreference(Excluded) and does not availability-check a non-required helper, so the
+  SA is expected to BOOK. Captures oldWriteHelperHttp + oldWriteHelperSaId. Runs under {{adminToken}}.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000042
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-excluded-non-required/10-book.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-excluded-non-required/10-book.request.yaml
@@ -1,0 +1,58 @@
+$kind: http-request
+description: >-
+  OLD Salesforce Scheduler WRITE probe: POST /connect/scheduling/service-appointments, tomorrow 11:00-11:30
+  UTC, parentRecordId = the excluded Account, with TWO assignedResources — resourceA
+  (isRequiredResource=true, isPrimaryResource=true, clean) and resourceB (isRequiredResource=false, on the
+  Account's Excluded ResourcePreference list). The classic book path (ServiceAppointmentServiceImpl.create →
+  ServiceAppointmentHelper.areResourcesAvailable → schedulingService.getAppointmentSlots) validates only
+  the REQUIRED/primary resources for time-slot availability and passes accountResourcePreferences=null, so
+  the account ResourcePreference(Excluded) is NEVER evaluated on the write path — and a NON-required helper
+  is not availability-checked either. So the OBSERVED outcome should be: the SA BOOKS (HTTP 2xx,
+  serviceAppointmentId returned) even though resourceB is excluded on the account — matching the 264 finding
+  that a non-required excluded helper escapes the fitness rule. Captures oldWriteHelperHttp +
+  oldWriteHelperSaId. (The book API wraps the SA id in a "result" node on success; a refusal returns a
+  top-level error array.)
+url: "{{baseUrl}}{{versionPath}}/connect/scheduling/service-appointments"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  x-revoman-ledger: "off"
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "serviceAppointment": {
+        "serviceTerritoryId": "{{schedTerritoryId}}",
+        "parentRecordId": "{{schedAccountId}}",
+        "workTypeId": "{{schedWorkTypeId}}",
+        "schedStartTime": "{{schedBookStart}}",
+        "schedEndTime": "{{schedBookEnd}}",
+        "extendedFields": [ { "name": "Status", "value": "Scheduled" } ]
+      },
+      "assignedResources": [
+        { "serviceResourceId": "{{schedResourceAId}}", "isRequiredResource": true, "isPrimaryResource": true },
+        { "serviceResourceId": "{{schedResourceBId}}", "isRequiredResource": false, "isPrimaryResource": false }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 0, 0, 0);
+      const e = new Date(s.getTime() + 30 * 60 * 1000);
+      pm.environment.set("schedBookStart", s.toISOString());
+      pm.environment.set("schedBookEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      // The Connect book API wraps its payload in a "result" node on success:
+      // { "result": { "serviceAppointmentId": "08p...", "assignedResourceIds": [...] } }. On refusal it
+      // returns a top-level error array. Dig the SA id out of result first, then the flatter shapes.
+      const data = pm.response.json() || {};
+      const result = data.result || data;
+      pm.environment.set("oldWriteHelperHttp", String(pm.response.code));
+      pm.environment.set("oldWriteHelperSaId", result.serviceAppointmentId || (result.serviceAppointment && result.serviceAppointment.id) || "");
+      console.log("OLD book excluded-helper http=" + pm.response.code + " body=" + JSON.stringify(data).slice(0,300));
+    language: text/javascript
+order: 1000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-missing-required-flag/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-missing-required-flag/.resources/definition.yaml
@@ -1,0 +1,13 @@
+$kind: collection
+description: |-
+  OLD Scheduler book (Decision 3 Act A) over the double-book fixture: a SINGLE assignedResource
+  (resourceA) that OMITS isRequiredResource (and isPrimaryResource) entirely. Characterizes the OLD
+  classic-engine outcome for the missing-flag payload (crash? clean refuse? books treating missing-as-
+  not-required?). Runs under {{adminToken}}. Reuses schedResourceAId / schedTerritoryId /
+  schedWorkTypeId / schedAccountId from the double-book fixture.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000310
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-missing-required-flag/10-book.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-missing-required-flag/10-book.request.yaml
@@ -1,0 +1,64 @@
+$kind: http-request
+description: >-
+  OLD Salesforce Scheduler book (Decision 3 Act A): POST /connect/scheduling/service-appointments,
+  tomorrow 11:00-11:30 UTC, over the double-book fixture's FREE resourceA (member OH + Confirmed Shift
+  10:00-14:00 cover the window, so availability does NOT confound the probe). ONE assignedResource that
+  OMITS isRequiredResource ENTIRELY (and isPrimaryResource) — the same missing-flag payload the 264
+  Unified schedule sends, where 264 CRASHES with a Boolean.booleanValue() NPE (INTERNAL_SERVER_ERROR,
+  HTTP 500) because common.api.soap.Entity.getField("IsRequiredResource") returns null. This act asks
+  the parity question WITHOUT prejudging it: does the OLD classic engine ALSO crash when the flag is
+  omitted, or does it degrade gracefully (clean refusal / treats missing-as-false and books)? Captures
+  oldMissingFlagHttp + oldMissingFlagSaId + oldMissingFlagErrorCode + oldMissingFlagErrorMessage so the
+  normalizer can classify BOOKED/REFUSED/CRASHED. Carries ignoreHTTPStatusUnsuccessful so a legit non-2xx
+  (a refusal or a 500) is not a step failure — the outcome is characterized, not forced.
+url: "{{baseUrl}}{{versionPath}}/connect/scheduling/service-appointments"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  x-revoman-ledger: "off"
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "serviceAppointment": {
+        "serviceTerritoryId": "{{schedTerritoryId}}",
+        "parentRecordId": "{{schedAccountId}}",
+        "workTypeId": "{{schedWorkTypeId}}",
+        "schedStartTime": "{{schedBookStart}}",
+        "schedEndTime": "{{schedBookEnd}}",
+        "extendedFields": [ { "name": "Status", "value": "Scheduled" } ]
+      },
+      "assignedResources": [
+        { "serviceResourceId": "{{schedResourceAId}}" }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 0, 0, 0);
+      const e = new Date(s.getTime() + 30 * 60 * 1000);
+      pm.environment.set("schedBookStart", s.toISOString());
+      pm.environment.set("schedBookEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      // The Connect book API wraps its payload in a "result" node on success:
+      // { "result": { "serviceAppointmentId": "08p...", ... } }. On refusal/crash it returns a top-level
+      // error array [{errorCode,message}] or an ErrorRepresentation {errorCode,message}. Dig the SA id out
+      // of result first; capture http + errorCode + message so the normalizer can classify
+      // BOOKED/REFUSED/CRASHED and the divergence-vs-264-crash can be asserted verbatim.
+      const data = pm.response.json() || {};
+      const result = data.result || data;
+      const arr = Array.isArray(data) ? data : null;
+      pm.environment.set("oldMissingFlagHttp", String(pm.response.code));
+      pm.environment.set("oldMissingFlagSaId", result.serviceAppointmentId || (result.serviceAppointment && result.serviceAppointment.id) || "");
+      let ec = data.errorCode || null;
+      let msg = data.message || null;
+      if (arr && arr.length) { ec = arr[0].errorCode; msg = arr[0].message; }
+      pm.environment.set("oldMissingFlagErrorCode", ec || "");
+      pm.environment.set("oldMissingFlagErrorMessage", msg || "");
+      console.log("OLD book missing-flag http=" + pm.response.code + " body=" + JSON.stringify(data).slice(0,400));
+    language: text/javascript
+order: 1000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-one-primary-control/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-one-primary-control/.resources/definition.yaml
@@ -1,0 +1,13 @@
+$kind: collection
+description: |-
+  OLD Scheduler book of the two-primary fixture (Decision 4 CONTROL): POST /connect/scheduling/service-appointments
+  with TWO assignedResources but EXACTLY ONE primary — resourceA isPrimaryResource=true, resourceB
+  isPrimaryResource=false (both required, both free). Expect a BOOKING (18-char 08p serviceAppointmentId).
+  Isolates the two-primary REFUSAL to the second primary flag (the fixture and both resources are live and
+  bookable). Runs under {{adminToken}}.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000042
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-one-primary-control/10-book.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-one-primary-control/10-book.request.yaml
@@ -1,0 +1,52 @@
+$kind: http-request
+description: >-
+  CONTROL for Decision 4: OLD Salesforce Scheduler book, tomorrow 11:00-11:30 UTC, with TWO assignedResources
+  but EXACTLY ONE primary — resourceA (isRequiredResource=true, isPrimaryResource=true) + resourceB
+  (isRequiredResource=true, isPrimaryResource=FALSE). Both are fully AVAILABLE at the window, so the
+  one-primary constraint is satisfied and availability passes → the SA BOOKS (HTTP 2xx, 18-char 08p
+  serviceAppointmentId). Isolates the two-primary REFUSAL to the second primary flag (proves the fixture and
+  both resources are live and bookable). Captures twoPrimaryControlHttp + twoPrimaryControlSaId.
+url: "{{baseUrl}}{{versionPath}}/connect/scheduling/service-appointments"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  x-revoman-ledger: "off"
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "serviceAppointment": {
+        "serviceTerritoryId": "{{schedTerritoryId}}",
+        "parentRecordId": "{{schedAccountId}}",
+        "workTypeId": "{{schedWorkTypeId}}",
+        "schedStartTime": "{{schedBookStart}}",
+        "schedEndTime": "{{schedBookEnd}}",
+        "extendedFields": [ { "name": "Status", "value": "Scheduled" } ]
+      },
+      "assignedResources": [
+        { "serviceResourceId": "{{schedResourceAId}}", "isRequiredResource": true, "isPrimaryResource": true },
+        { "serviceResourceId": "{{schedResourceBId}}", "isRequiredResource": true, "isPrimaryResource": false }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 0, 0, 0);
+      const e = new Date(s.getTime() + 30 * 60 * 1000);
+      pm.environment.set("schedBookStart", s.toISOString());
+      pm.environment.set("schedBookEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      // The Connect book API wraps its payload in a "result" node on success: { "result": {
+      // "serviceAppointmentId": "08p...", ... } }. On refusal it returns a top-level error array. Dig the SA
+      // id out of result first, then the flatter shapes.
+      const data = pm.response.json() || {};
+      const result = data.result || data;
+      pm.environment.set("twoPrimaryControlHttp", String(pm.response.code));
+      pm.environment.set("twoPrimaryControlSaId", result.serviceAppointmentId || (result.serviceAppointment && result.serviceAppointment.id) || "");
+      console.log("OLD book one-primary control http=" + pm.response.code + " body=" + JSON.stringify(data).slice(0,300));
+    language: text/javascript
+order: 1000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-primary-not-required/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-primary-not-required/.resources/definition.yaml
@@ -1,0 +1,11 @@
+$kind: collection
+description: |-
+  OLD Scheduler Decision-5 probe book (see the request file): a single AssignedResource
+  isPrimaryResource=true + isRequiredResource=false over a FREE window → the persist-time
+  LightningSchedulerAssignedResourceValidator rejects it (REFUSED). Runs under {{adminToken}}.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000051
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-primary-not-required/10-book.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-primary-not-required/10-book.request.yaml
@@ -1,0 +1,72 @@
+$kind: http-request
+description: >-
+  OLD Salesforce Scheduler Decision-5 PROBE: POST /connect/scheduling/service-appointments, tomorrow
+  11:00-11:30 UTC, with a SINGLE assignedResource — resourceA marked isPrimaryResource=true BUT
+  isRequiredResource=false. This is the exact Decision-5 contradiction. The window is FREE for resourceA
+  (member OH + Shift 10-14 cover it), so availability passes; the classic book path inserts the
+  AssignedResource row, which fires the SAVE-TIME LightningSchedulerAssignedResourceValidator (the SAME
+  fieldservice-impl validator 264 hits) → the insert is REJECTED ("Only an required service resource can
+  be set as a primary service resource.") → the whole book is refused (non-2xx, no serviceAppointmentId).
+  Captures oldWriteHelperHttp + oldWriteHelperSaId + oldWriteHelperErrorCode + oldWriteHelperErrorMessage.
+url: "{{baseUrl}}{{versionPath}}/connect/scheduling/service-appointments"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  x-revoman-ledger: "off"
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "serviceAppointment": {
+        "serviceTerritoryId": "{{schedTerritoryId}}",
+        "parentRecordId": "{{schedAccountId}}",
+        "workTypeId": "{{schedWorkTypeId}}",
+        "schedStartTime": "{{schedBookStart}}",
+        "schedEndTime": "{{schedBookEnd}}",
+        "extendedFields": [ { "name": "Status", "value": "Scheduled" } ]
+      },
+      "assignedResources": [
+        { "serviceResourceId": "{{schedResourceAId}}", "isRequiredResource": false, "isPrimaryResource": true }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 0, 0, 0);
+      const e = new Date(s.getTime() + 30 * 60 * 1000);
+      pm.environment.set("schedBookStart", s.toISOString());
+      pm.environment.set("schedBookEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      // The Connect book API wraps its payload in a "result" node on success:
+      // { "result": { "serviceAppointmentId": "08p...", ... } }. On the Decision-5 reject it returns a
+      // top-level error array (the LightningSchedulerAssignedResourceValidator INVALID_FIELD). Dig the SA
+      // id out of result first (a refusal leaves it empty), and characterize the observed error envelope
+      // (errorCode + message) faithfully — the PARITY is on the OUTCOME (both REFUSE), and the OLD
+      // validator message is captured as-observed (it may differ from the 264 schedulingStatus envelope).
+      const data = pm.response.json() || {};
+      const result = data.result || data;
+      pm.environment.set("oldWriteHelperHttp", String(pm.response.code));
+      pm.environment.set("oldWriteHelperSaId", result.serviceAppointmentId || (result.serviceAppointment && result.serviceAppointment.id) || "");
+      // Top-level error array shape: [{ errorCode, message }]. Also probe the appointments[].errors shape.
+      let errCode = "";
+      let errMsg = "";
+      if (Array.isArray(data) && data.length > 0) {
+        errCode = data[0].errorCode || "";
+        errMsg = data[0].message || "";
+      } else if (data.appointments && data.appointments[0] && Array.isArray(data.appointments[0].errors) && data.appointments[0].errors.length > 0) {
+        errCode = data.appointments[0].errors[0].errorCode || data.appointments[0].errors[0].statusCode || "";
+        errMsg = data.appointments[0].errors[0].message || "";
+      } else if (data.errors && data.errors[0]) {
+        errCode = data.errors[0].errorCode || data.errors[0].statusCode || "";
+        errMsg = data.errors[0].message || "";
+      }
+      pm.environment.set("oldWriteHelperErrorCode", errCode);
+      pm.environment.set("oldWriteHelperErrorMessage", errMsg);
+      pm.environment.set("oldWriteHelperSchedulingStatus", (result && result.schedulingStatus) || "");
+      console.log("OLD Decision-5 probe http=" + pm.response.code + " errCode=" + errCode + " body=" + JSON.stringify(data).slice(0,400));
+    language: text/javascript
+order: 1000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-primary-required-control/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-primary-required-control/.resources/definition.yaml
@@ -1,0 +1,11 @@
+$kind: collection
+description: |-
+  OLD Scheduler Decision-5 control book (see the request file): the SAME single resourceA over the SAME
+  free window as a valid required-primary (isPrimaryResource=true + isRequiredResource=true) → BOOKED.
+  Runs under {{adminToken}}.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000052
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-primary-required-control/10-book.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-primary-required-control/10-book.request.yaml
@@ -1,0 +1,50 @@
+$kind: http-request
+description: >-
+  Control: OLD Salesforce Scheduler book with the SAME single resourceA over the SAME free window, but now
+  isPrimaryResource=true + isRequiredResource=true (a valid required-primary). This satisfies the
+  LightningSchedulerAssignedResourceValidator (a primary IS required) → the AssignedResource insert
+  succeeds and the SA BOOKS (HTTP 2xx, serviceAppointmentId returned). Isolates the probe's refusal to the
+  isRequiredResource=false flag alone. Captures oldWriteRequiredControlHttp + oldWriteRequiredControlSaId.
+url: "{{baseUrl}}{{versionPath}}/connect/scheduling/service-appointments"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  x-revoman-ledger: "off"
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "serviceAppointment": {
+        "serviceTerritoryId": "{{schedTerritoryId}}",
+        "parentRecordId": "{{schedAccountId}}",
+        "workTypeId": "{{schedWorkTypeId}}",
+        "schedStartTime": "{{schedBookStart}}",
+        "schedEndTime": "{{schedBookEnd}}",
+        "extendedFields": [ { "name": "Status", "value": "Scheduled" } ]
+      },
+      "assignedResources": [
+        { "serviceResourceId": "{{schedResourceAId}}", "isRequiredResource": true, "isPrimaryResource": true }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 0, 0, 0);
+      const e = new Date(s.getTime() + 30 * 60 * 1000);
+      pm.environment.set("schedBookStart", s.toISOString());
+      pm.environment.set("schedBookEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      // The Connect book API wraps its payload in a "result" node on success:
+      // { "result": { "serviceAppointmentId": "08p...", ... } }. Dig the SA id out of result first, then
+      // the flatter shapes. A valid required-primary books → non-empty SA id.
+      const data = pm.response.json() || {};
+      const result = data.result || data;
+      pm.environment.set("oldWriteRequiredControlHttp", String(pm.response.code));
+      pm.environment.set("oldWriteRequiredControlSaId", result.serviceAppointmentId || (result.serviceAppointment && result.serviceAppointment.id) || "");
+      console.log("OLD Decision-5 control http=" + pm.response.code + " body=" + JSON.stringify(data).slice(0,300));
+    language: text/javascript
+order: 1000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-promise-available/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-promise-available/.resources/definition.yaml
@@ -1,0 +1,12 @@
+$kind: collection
+description: |-
+  OLD Scheduler-org Decision 2 WRITE (AVAILABLE window): POST /connect/scheduling/service-appointments
+  booking resourceA (single required+primary) into the AVAILABLE window tomorrow 11:00-11:30. The read
+  offered slots here; the write keeps the promise → Success (18-char 08p serviceAppointmentId). Captures
+  oldPromiseWriteAvailSaId / oldPromiseWriteAvailHttp. RevUps after the shared grant-ls-user-access Kick.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000213
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-promise-available/10-book-promise-available.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-promise-available/10-book-promise-available.request.yaml
@@ -1,0 +1,51 @@
+$kind: http-request
+description: >-
+  OLD Salesforce Scheduler book (Decision 2, AVAILABLE window): POST /connect/scheduling/service-appointments
+  booking resourceA (single assignedResource, isRequiredResource=true + isPrimaryResource=true) into the
+  AVAILABLE window tomorrow 11:00-11:30 UTC. resourceA is available there (window inside member OH ∪ Shift =
+  08-16), so the write's re-check of the shared cheap availability check passes → the SA books (HTTP 2xx,
+  18-char 08p serviceAppointmentId). This is the WRITE half of the read↔write promise on the available
+  window: read-offers-slot ⟺ write-succeeds. Captures oldPromiseWriteAvailHttp + oldPromiseWriteAvailSaId.
+url: "{{baseUrl}}{{versionPath}}/connect/scheduling/service-appointments"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  x-revoman-ledger: "off"
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "serviceAppointment": {
+        "serviceTerritoryId": "{{schedTerritoryId}}",
+        "parentRecordId": "{{schedAccountId}}",
+        "workTypeId": "{{schedWorkTypeId}}",
+        "schedStartTime": "{{schedPromiseBookAvailStart}}",
+        "schedEndTime": "{{schedPromiseBookAvailEnd}}",
+        "extendedFields": [ { "name": "Status", "value": "Scheduled" } ]
+      },
+      "assignedResources": [
+        { "serviceResourceId": "{{schedResourceAId}}", "isRequiredResource": true, "isPrimaryResource": true }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 0, 0, 0);
+      const e = new Date(s.getTime() + 30 * 60 * 1000);
+      pm.environment.set("schedPromiseBookAvailStart", s.toISOString());
+      pm.environment.set("schedPromiseBookAvailEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      // The Connect book API wraps its payload in a "result" node on success:
+      // { "result": { "serviceAppointmentId": "08p...", ... } }. On refusal it returns a top-level error
+      // array. Dig the SA id out of result first, then the flatter shapes.
+      const data = pm.response.json() || {};
+      const result = data.result || data;
+      pm.environment.set("oldPromiseWriteAvailHttp", String(pm.response.code));
+      pm.environment.set("oldPromiseWriteAvailSaId", result.serviceAppointmentId || (result.serviceAppointment && result.serviceAppointment.id) || "");
+      console.log("OLD promise book-avail http=" + pm.response.code + " body=" + JSON.stringify(data).slice(0,300));
+    language: text/javascript
+order: 1000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-promise-unavailable/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-promise-unavailable/.resources/definition.yaml
@@ -1,0 +1,14 @@
+$kind: collection
+description: |-
+  OLD Scheduler-org Decision 2 WRITE (UNAVAILABLE window): POST /connect/scheduling/service-appointments
+  booking resourceA (single required+primary) into the UNAVAILABLE window tomorrow 17:00-17:30 (outside its
+  hours). The read hid this window; the write keeps the promise → refused (non-2xx, no serviceAppointmentId),
+  the only blocker being the shared cheap availability check. Captures oldPromiseWriteUnavailSaId /
+  oldPromiseWriteUnavailHttp / oldPromiseWriteUnavailErrorCode / oldPromiseWriteUnavailErrorMessage. RevUps
+  after the shared grant-ls-user-access Kick.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000214
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-promise-unavailable/10-book-promise-unavailable.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-promise-unavailable/10-book-promise-unavailable.request.yaml
@@ -1,0 +1,60 @@
+$kind: http-request
+description: >-
+  OLD Salesforce Scheduler book (Decision 2, UNAVAILABLE window): POST
+  /connect/scheduling/service-appointments booking resourceA (single assignedResource,
+  isRequiredResource=true + isPrimaryResource=true) into the UNAVAILABLE window tomorrow 17:00-17:30 UTC.
+  Same single required+primary resource as the available book — only the window differs. resourceA is NOT
+  available there (window outside member OH ∪ Shift = 08-16), so the write's re-check of the shared cheap
+  availability check FAILS → the book is refused (non-2xx, no serviceAppointmentId). This is the WRITE
+  half of the read↔write promise on the unavailable window: read-hides-slot ⟺ write-refused. Uses a UNIQUE
+  step name (10-book-promise-unavailable) so it never collides with the available book's step across the
+  run. Captures oldPromiseWriteUnavailHttp + oldPromiseWriteUnavailSaId (empty on refusal) +
+  oldPromiseWriteUnavailErrorCode + oldPromiseWriteUnavailErrorMessage.
+url: "{{baseUrl}}{{versionPath}}/connect/scheduling/service-appointments"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  x-revoman-ledger: "off"
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "serviceAppointment": {
+        "serviceTerritoryId": "{{schedTerritoryId}}",
+        "parentRecordId": "{{schedAccountId}}",
+        "workTypeId": "{{schedWorkTypeId}}",
+        "schedStartTime": "{{schedPromiseBookUnavailStart}}",
+        "schedEndTime": "{{schedPromiseBookUnavailEnd}}",
+        "extendedFields": [ { "name": "Status", "value": "Scheduled" } ]
+      },
+      "assignedResources": [
+        { "serviceResourceId": "{{schedResourceAId}}", "isRequiredResource": true, "isPrimaryResource": true }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(17, 0, 0, 0);
+      const e = new Date(s.getTime() + 30 * 60 * 1000);
+      pm.environment.set("schedPromiseBookUnavailStart", s.toISOString());
+      pm.environment.set("schedPromiseBookUnavailEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      // The Connect book API wraps its payload in a "result" node on success:
+      // { "result": { "serviceAppointmentId": "08p...", ... } }. On refusal it returns a top-level error
+      // array. Dig the SA id out of result first (empty here — a refusal), and pull the error envelope.
+      const data = pm.response.json() || {};
+      const result = data.result || data;
+      pm.environment.set("oldPromiseWriteUnavailHttp", String(pm.response.code));
+      pm.environment.set("oldPromiseWriteUnavailSaId", result.serviceAppointmentId || (result.serviceAppointment && result.serviceAppointment.id) || "");
+      let ec = null, msg = null;
+      if (Array.isArray(data) && data.length) { ec = data[0].errorCode; msg = data[0].message; }
+      else if (data.errorCode) { ec = data.errorCode; msg = data.message; }
+      pm.environment.set("oldPromiseWriteUnavailErrorCode", ec);
+      pm.environment.set("oldPromiseWriteUnavailErrorMessage", msg);
+      console.log("OLD promise book-unavail http=" + pm.response.code + " body=" + JSON.stringify(data).slice(0,300));
+    language: text/javascript
+order: 1000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-required-non-required/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-required-non-required/.resources/definition.yaml
@@ -1,0 +1,13 @@
+$kind: collection
+description: |-
+  OLD Scheduler book of the required-helper fixture (Decision 1.4 write arm): resourceA required+primary
+  (clean, but NOT the account-required worker) + resourceB as a NON-required helper (even though the
+  Account's ResourcePreference(Required) demands resourceB). Characterizes the OLD write outcome
+  (BOOKED/REFUSED/CRASHED) against the 264 write CRASH. Captures oldWriteReqHelperHttp / ...SaId /
+  ...ErrorCode. Runs under {{adminToken}}.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000130
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-required-non-required/10-book-non-required-helper.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-required-non-required/10-book-non-required-helper.request.yaml
@@ -1,0 +1,66 @@
+$kind: http-request
+description: >-
+  OLD Salesforce Scheduler book (Decision 1.4 write arm): POST /connect/scheduling/service-appointments,
+  tomorrow 11:00-11:30 UTC, over the required-helper fixture. TWO assignedResources — resourceA
+  (isRequiredResource=true, isPrimaryResource=true, clean+free, but NOT the account-required worker) and
+  resourceB (isRequiredResource=false — the NON-required helper — even though the Account's
+  ResourcePreference(Required) demands resourceB). This is the OLD-engine analogue of the 264 write that
+  CRASHES (serviceTerritoryMembers NPE, HTTP 500). LIVE-OBSERVED on the scheduler org (v67): the OLD classic
+  book path REFUSES cleanly — HTTP 400 errorCode=INTERNAL_ERROR, message "We couldn't find any resources for
+  your request. Specify a different schedStartTime and schedEndTime and try again." (the same clean-refusal
+  shape as the 1.5 required-control) — NOT a 500 crash and NOT a booking. So the OLD write consults the
+  account-required-resource enforcement during its internal slot-gen and cannot satisfy the account's demand
+  for resourceB when resourceB is only a non-required helper → no resources found → refuse. This DIVERGES
+  from the 264 write CRASH. Characterized faithfully, no verdict forced. Captures oldWriteReqHelperHttp +
+  oldWriteReqHelperSaId + oldWriteReqHelperErrorCode + oldWriteReqHelperErrorMessage.
+url: "{{baseUrl}}{{versionPath}}/connect/scheduling/service-appointments"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  x-revoman-ledger: "off"
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "serviceAppointment": {
+        "serviceTerritoryId": "{{schedReqTerritoryId}}",
+        "parentRecordId": "{{schedReqAccountId}}",
+        "workTypeId": "{{schedReqWorkTypeId}}",
+        "schedStartTime": "{{schedReqBookStart}}",
+        "schedEndTime": "{{schedReqBookEnd}}",
+        "extendedFields": [ { "name": "Status", "value": "Scheduled" } ]
+      },
+      "assignedResources": [
+        { "serviceResourceId": "{{schedReqResourceAId}}", "isRequiredResource": true, "isPrimaryResource": true },
+        { "serviceResourceId": "{{schedReqResourceBId}}", "isRequiredResource": false, "isPrimaryResource": false }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 0, 0, 0);
+      const e = new Date(s.getTime() + 30 * 60 * 1000);
+      pm.environment.set("schedReqBookStart", s.toISOString());
+      pm.environment.set("schedReqBookEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      // The Connect book API wraps its payload in a "result" node on success:
+      // { "result": { "serviceAppointmentId": "08p...", ... } }. On refusal/crash it returns a top-level
+      // error array [{errorCode,message}] or an ErrorRepresentation {errorCode,message}. Dig the SA id out
+      // of result first; capture http + errorCode so the normalizer can classify BOOKED/REFUSED/CRASHED.
+      const data = pm.response.json() || {};
+      const result = data.result || data;
+      const arr = Array.isArray(data) ? data : null;
+      pm.environment.set("oldWriteReqHelperHttp", String(pm.response.code));
+      pm.environment.set("oldWriteReqHelperSaId", result.serviceAppointmentId || (result.serviceAppointment && result.serviceAppointment.id) || "");
+      let ec = data.errorCode || null;
+      let msg = data.message || null;
+      if (arr && arr.length) { ec = arr[0].errorCode; msg = arr[0].message; }
+      pm.environment.set("oldWriteReqHelperErrorCode", ec || "");
+      pm.environment.set("oldWriteReqHelperErrorMessage", msg || "");
+      console.log("OLD book req-helper http=" + pm.response.code + " body=" + JSON.stringify(data).slice(0,300));
+    language: text/javascript
+order: 1000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-single-required-no-primary/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-single-required-no-primary/.resources/definition.yaml
@@ -1,0 +1,13 @@
+$kind: collection
+description: |-
+  OLD Scheduler book (Decision 3 Act B, doc L142 control) over the double-book fixture: a SINGLE
+  assignedResource (resourceA) with isRequiredResource=true and NO isPrimaryResource — MUST be a valid
+  Schedule (isPrimaryResource is multi-resource-only plumbing, NOT the Decision-1 variable). Runs under
+  {{adminToken}}. Reuses schedResourceAId / schedTerritoryId / schedWorkTypeId / schedAccountId from the
+  double-book fixture.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000320
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-single-required-no-primary/10-book.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-single-required-no-primary/10-book.request.yaml
@@ -1,0 +1,61 @@
+$kind: http-request
+description: >-
+  OLD Salesforce Scheduler book (Decision 3 Act B, doc L142 control): POST
+  /connect/scheduling/service-appointments, tomorrow 11:00-11:30 UTC, over the double-book fixture's FREE
+  resourceA. ONE assignedResource with isRequiredResource=true and NO isPrimaryResource field — this MUST
+  be a valid Schedule (isPrimaryResource is multi-resource-only plumbing, NOT the Decision-1 variable), so
+  it proves the fixture + grant are live and isolates the Act-A missing-flag outcome to the OMITTED
+  isRequiredResource, not to a dead/unavailable resourceA. Same policy/fixture/window as Act A; only the
+  assignedResource differs (adds isRequiredResource=true). Expected: BOOKED (08p SA id). Captures
+  oldSingleRequiredNoPrimaryHttp + oldSingleRequiredNoPrimarySaId + oldSingleRequiredNoPrimaryErrorCode +
+  oldSingleRequiredNoPrimaryErrorMessage. Carries ignoreHTTPStatusUnsuccessful.
+url: "{{baseUrl}}{{versionPath}}/connect/scheduling/service-appointments"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  x-revoman-ledger: "off"
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "serviceAppointment": {
+        "serviceTerritoryId": "{{schedTerritoryId}}",
+        "parentRecordId": "{{schedAccountId}}",
+        "workTypeId": "{{schedWorkTypeId}}",
+        "schedStartTime": "{{schedBookStart}}",
+        "schedEndTime": "{{schedBookEnd}}",
+        "extendedFields": [ { "name": "Status", "value": "Scheduled" } ]
+      },
+      "assignedResources": [
+        { "serviceResourceId": "{{schedResourceAId}}", "isRequiredResource": true }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 0, 0, 0);
+      const e = new Date(s.getTime() + 30 * 60 * 1000);
+      pm.environment.set("schedBookStart", s.toISOString());
+      pm.environment.set("schedBookEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      // The Connect book API wraps its payload in a "result" node on success:
+      // { "result": { "serviceAppointmentId": "08p...", ... } }. On refusal it returns a top-level error
+      // array [{errorCode,message}] or an ErrorRepresentation {errorCode,message}. Capture SA id + http +
+      // errorCode so the normalizer classifies BOOKED (expected).
+      const data = pm.response.json() || {};
+      const result = data.result || data;
+      const arr = Array.isArray(data) ? data : null;
+      pm.environment.set("oldSingleRequiredNoPrimaryHttp", String(pm.response.code));
+      pm.environment.set("oldSingleRequiredNoPrimarySaId", result.serviceAppointmentId || (result.serviceAppointment && result.serviceAppointment.id) || "");
+      let ec = data.errorCode || null;
+      let msg = data.message || null;
+      if (arr && arr.length) { ec = arr[0].errorCode; msg = arr[0].message; }
+      pm.environment.set("oldSingleRequiredNoPrimaryErrorCode", ec || "");
+      pm.environment.set("oldSingleRequiredNoPrimaryErrorMessage", msg || "");
+      console.log("OLD book single-required-no-primary http=" + pm.response.code + " body=" + JSON.stringify(data).slice(0,400));
+    language: text/javascript
+order: 1000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-skills-non-required/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-skills-non-required/.resources/definition.yaml
@@ -1,0 +1,12 @@
+$kind: collection
+description: |-
+  OLD Scheduler book of the skills-helper fixture: A (required+primary, skilled) + B (non-required helper,
+  skill-less). The non-required + non-primary helper escapes the old engine's skill fitness check (the
+  multi path skill-checks the primary only), so the SA books Success — parity with 264's non-required
+  helper-escapes. Runs under {{adminToken}}. See the request file.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000060
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-skills-non-required/10-book.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-skills-non-required/10-book.request.yaml
@@ -1,0 +1,54 @@
+$kind: http-request
+description: >-
+  OLD Salesforce Scheduler book: POST /connect/scheduling/service-appointments, tomorrow 11:00-11:30 UTC,
+  with TWO assignedResources — resourceA (isRequiredResource=true, isPrimaryResource=true, skilled) and
+  resourceB (isRequiredResource=false, isPrimaryResource=false, skill-less). resourceB LACKS the
+  WorkType's required ServiceResourceSkill, but as a NON-required + NON-primary helper it is not
+  skill-fitness-checked by the old engine (per the object reference a non-required resource is
+  "considered available for other appointments"; and the old multi path skill-checks the primary only) →
+  the SA books (HTTP 2xx, serviceAppointmentId returned). This is the OLD-side write analogue of 264's
+  non-required helper-escapes. Captures oldWriteHelperHttp + oldWriteHelperSaId.
+url: "{{baseUrl}}{{versionPath}}/connect/scheduling/service-appointments"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  x-revoman-ledger: "off"
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "serviceAppointment": {
+        "serviceTerritoryId": "{{schedTerritoryId}}",
+        "parentRecordId": "{{schedAccountId}}",
+        "workTypeId": "{{schedWorkTypeId}}",
+        "schedStartTime": "{{schedBookStart}}",
+        "schedEndTime": "{{schedBookEnd}}",
+        "extendedFields": [ { "name": "Status", "value": "Scheduled" } ]
+      },
+      "assignedResources": [
+        { "serviceResourceId": "{{schedResourceAId}}", "isRequiredResource": true, "isPrimaryResource": true },
+        { "serviceResourceId": "{{schedResourceBId}}", "isRequiredResource": false, "isPrimaryResource": false }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 0, 0, 0);
+      const e = new Date(s.getTime() + 30 * 60 * 1000);
+      pm.environment.set("schedBookStart", s.toISOString());
+      pm.environment.set("schedBookEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      // The Connect book API wraps its payload in a "result" node on success:
+      // { "result": { "serviceAppointmentId": "08p...", "assignedResourceIds": [...] } }. On refusal it
+      // returns a top-level error array. Dig the SA id out of result first, then the flatter shapes.
+      const data = pm.response.json() || {};
+      const result = data.result || data;
+      pm.environment.set("oldWriteHelperHttp", String(pm.response.code));
+      pm.environment.set("oldWriteHelperSaId", result.serviceAppointmentId || (result.serviceAppointment && result.serviceAppointment.id) || "");
+      console.log("OLD book skills-helper http=" + pm.response.code + " body=" + JSON.stringify(data).slice(0,300));
+    language: text/javascript
+order: 1000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-territory-non-required/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-territory-non-required/.resources/definition.yaml
@@ -1,0 +1,9 @@
+$kind: collection
+description: |-
+  OLD Scheduler book of the territory-helper fixture (see the request file). Runs under {{adminToken}}.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000130
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-territory-non-required/10-book.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-territory-non-required/10-book.request.yaml
@@ -1,0 +1,53 @@
+$kind: http-request
+description: >-
+  OLD Salesforce Scheduler book: POST /connect/scheduling/service-appointments, tomorrow 11:30-12:30 UTC (a
+  window that STRADDLES the resourceB membership end at noon), with TWO assignedResources — resourceA
+  (isRequiredResource=true, isPrimaryResource=true, clean, membership covers the whole window) and resourceB
+  (isRequiredResource=false, membership ends at noon → out of territory over the afternoon). Per the object
+  reference, a non-required resource is "considered available for other appointments" — so the old engine
+  should NOT territory/membership-check B → the SA books (HTTP 2xx, serviceAppointmentId returned). Captures
+  oldWriteHelperHttp + oldWriteHelperSaId.
+url: "{{baseUrl}}{{versionPath}}/connect/scheduling/service-appointments"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  x-revoman-ledger: "off"
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "serviceAppointment": {
+        "serviceTerritoryId": "{{schedTerritoryId}}",
+        "parentRecordId": "{{schedAccountId}}",
+        "workTypeId": "{{schedWorkTypeId}}",
+        "schedStartTime": "{{schedBookStart}}",
+        "schedEndTime": "{{schedBookEnd}}",
+        "extendedFields": [ { "name": "Status", "value": "Scheduled" } ]
+      },
+      "assignedResources": [
+        { "serviceResourceId": "{{schedResourceAId}}", "isRequiredResource": true, "isPrimaryResource": true },
+        { "serviceResourceId": "{{schedResourceBId}}", "isRequiredResource": false, "isPrimaryResource": false }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 30, 0, 0);
+      const e = new Date(s.getTime() + 60 * 60 * 1000);
+      pm.environment.set("schedBookStart", s.toISOString());
+      pm.environment.set("schedBookEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      // The Connect book API wraps its payload in a "result" node on success:
+      // { "result": { "serviceAppointmentId": "08p...", "assignedResourceIds": [...] } }. On refusal it
+      // returns a top-level error array. Dig the SA id out of result first, then the flatter shapes.
+      const data = pm.response.json() || {};
+      const result = data.result || data;
+      pm.environment.set("oldWriteHelperHttp", String(pm.response.code));
+      pm.environment.set("oldWriteHelperSaId", result.serviceAppointmentId || (result.serviceAppointment && result.serviceAppointment.id) || "");
+      console.log("OLD book helper (territory) http=" + pm.response.code + " body=" + JSON.stringify(data).slice(0,300));
+    language: text/javascript
+order: 1000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-territory-required-control/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-territory-required-control/.resources/definition.yaml
@@ -1,0 +1,9 @@
+$kind: collection
+description: |-
+  OLD Scheduler book of the territory-helper fixture (see the request file). Runs under {{adminToken}}.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000131
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-territory-required-control/10-book.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-territory-required-control/10-book.request.yaml
@@ -1,0 +1,52 @@
+$kind: http-request
+description: >-
+  Control: OLD book with resourceB isRequiredResource=true (still out of territory — membership ends at noon,
+  window straddles noon). A REQUIRED resource IS territory/membership-checked → the book is refused (non-2xx,
+  no serviceAppointmentId). Isolates the helper Success to the non-required flag. Captures
+  oldWriteRequiredControlHttp + oldWriteRequiredControlSaId.
+url: "{{baseUrl}}{{versionPath}}/connect/scheduling/service-appointments"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  x-revoman-ledger: "off"
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "serviceAppointment": {
+        "serviceTerritoryId": "{{schedTerritoryId}}",
+        "parentRecordId": "{{schedAccountId}}",
+        "workTypeId": "{{schedWorkTypeId}}",
+        "schedStartTime": "{{schedBookStart}}",
+        "schedEndTime": "{{schedBookEnd}}",
+        "extendedFields": [ { "name": "Status", "value": "Scheduled" } ]
+      },
+      "assignedResources": [
+        { "serviceResourceId": "{{schedResourceAId}}", "isRequiredResource": true, "isPrimaryResource": true },
+        { "serviceResourceId": "{{schedResourceBId}}", "isRequiredResource": true, "isPrimaryResource": false }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 30, 0, 0);
+      const e = new Date(s.getTime() + 60 * 60 * 1000);
+      pm.environment.set("schedBookStart", s.toISOString());
+      pm.environment.set("schedBookEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      // The Connect book API wraps its payload in a "result" node on success:
+      // { "result": { "serviceAppointmentId": "08p...", "assignedResourceIds": [...] } }. On refusal it
+      // returns a top-level error array (here: the resource is out of territory over the afternoon of the
+      // straddle-noon window). Dig the SA id out of result first, then the flatter shapes; a refusal leaves
+      // it empty.
+      const data = pm.response.json() || {};
+      const result = data.result || data;
+      pm.environment.set("oldWriteRequiredControlHttp", String(pm.response.code));
+      pm.environment.set("oldWriteRequiredControlSaId", result.serviceAppointmentId || (result.serviceAppointment && result.serviceAppointment.id) || "");
+      console.log("OLD book required-control (territory) http=" + pm.response.code + " body=" + JSON.stringify(data).slice(0,300));
+    language: text/javascript
+order: 1000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-two-primary/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-two-primary/.resources/definition.yaml
@@ -1,0 +1,12 @@
+$kind: collection
+description: |-
+  OLD Scheduler book of the two-primary fixture (Decision 4 probe): POST /connect/scheduling/service-appointments
+  with TWO assignedResources BOTH isPrimaryResource=true (+ both required, both free). Expect a REFUSAL (no
+  serviceAppointmentId) — the old save-time LightningSchedulerAssignedResourceValidator enforces "at most one
+  primary AssignedResource per ServiceAppointment" (AssignedResourceSaveOnlyOnePrimary). Runs under {{adminToken}}.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000041
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-two-primary/10-book.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-two-primary/10-book.request.yaml
@@ -1,0 +1,65 @@
+$kind: http-request
+description: >-
+  OLD Salesforce Scheduler book (Decision 4 probe): POST /connect/scheduling/service-appointments, tomorrow
+  11:00-11:30 UTC, with TWO assignedResources BOTH isPrimaryResource=true (+ both isRequiredResource=true,
+  both fully AVAILABLE at the window). Multi-resource scheduling requires EXACTLY one primary. On the OLD
+  side the save-time LightningSchedulerAssignedResourceValidator enforces "at most one primary
+  AssignedResource per ServiceAppointment" (rule AssignedResourceSaveOnlyOnePrimary) on the AssignedResource
+  save → expect a REFUSAL (no serviceAppointmentId, non-2xx). NOTE the WHERE differs from 264: 264 rejects at
+  INPUT validation (ScheduleCommonValidator.validatePrimaryResourceConstraints, pre-persist, INVALID_INPUT /
+  HTTP 400); the OLD engine rejects at SAVE/persist time (a field-integrity/persist error), which is a
+  documented WHERE difference — the PARITY is on the OUTCOME (both refuse two primaries, no booking). Captures
+  the actual code/message faithfully into twoPrimaryOldHttp / twoPrimaryOldSaId / twoPrimaryOldErrorCode /
+  twoPrimaryOldErrorMessage.
+url: "{{baseUrl}}{{versionPath}}/connect/scheduling/service-appointments"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  x-revoman-ledger: "off"
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "serviceAppointment": {
+        "serviceTerritoryId": "{{schedTerritoryId}}",
+        "parentRecordId": "{{schedAccountId}}",
+        "workTypeId": "{{schedWorkTypeId}}",
+        "schedStartTime": "{{schedBookStart}}",
+        "schedEndTime": "{{schedBookEnd}}",
+        "extendedFields": [ { "name": "Status", "value": "Scheduled" } ]
+      },
+      "assignedResources": [
+        { "serviceResourceId": "{{schedResourceAId}}", "isRequiredResource": true, "isPrimaryResource": true },
+        { "serviceResourceId": "{{schedResourceBId}}", "isRequiredResource": true, "isPrimaryResource": true }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 0, 0, 0);
+      const e = new Date(s.getTime() + 30 * 60 * 1000);
+      pm.environment.set("schedBookStart", s.toISOString());
+      pm.environment.set("schedBookEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      // On success the Connect book API wraps its payload in a "result" node: { "result": {
+      // "serviceAppointmentId": "08p...", ... } }. On refusal/crash it returns a top-level error array
+      // [{errorCode,message}] or an ErrorRepresentation {errorCode,message}. Dig the SA id out of result
+      // first (a refusal leaves it empty); capture http + errorCode + message faithfully (the OLD reject
+      // may be a persist/field-integrity error, not INVALID_INPUT — that's the WHERE difference).
+      const data = pm.response.json() || {};
+      const result = data.result || data;
+      const arr = Array.isArray(data) ? data : null;
+      pm.environment.set("twoPrimaryOldHttp", String(pm.response.code));
+      pm.environment.set("twoPrimaryOldSaId", result.serviceAppointmentId || (result.serviceAppointment && result.serviceAppointment.id) || "");
+      let ec = data.errorCode || null;
+      let msg = data.message || null;
+      if (arr && arr.length) { ec = arr[0].errorCode; msg = arr[0].message; }
+      pm.environment.set("twoPrimaryOldErrorCode", ec || "");
+      pm.environment.set("twoPrimaryOldErrorMessage", msg || "");
+      console.log("OLD book two-primary http=" + pm.response.code + " body=" + JSON.stringify(data).slice(0,400));
+    language: text/javascript
+order: 1000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-workloc-non-required/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-workloc-non-required/.resources/definition.yaml
@@ -1,0 +1,11 @@
+$kind: collection
+description: |-
+  OLD Scheduler book with the Secondary-member resourceB as a NON-required helper, UNDER THE PRIMARY-ONLY
+  policy. Non-required resources are not eligibility-checked, so resourceB's Secondary WorkingLocations role
+  escapes → the SA books Success. Captures oldWriteHelperHttp + oldWriteHelperSaId for the 1d write diff.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000130
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-workloc-non-required/10-book.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-workloc-non-required/10-book.request.yaml
@@ -1,0 +1,55 @@
+$kind: http-request
+description: >-
+  OLD Salesforce Scheduler book: POST /connect/scheduling/service-appointments, tomorrow 11:00-12:00 UTC,
+  UNDER THE PRIMARY-ONLY policy (schedulingPolicyId=schedWlPrimaryOnlyPolicyId), with TWO assignedResources
+  — resourceA (isRequiredResource=true, isPrimaryResource=true, Primary member, free) and resourceB
+  (isRequiredResource=false, Secondary member, free). resourceB violates exactly ONE rule: its territory
+  ROLE is Secondary under a primary-only policy (WorkingLocations). Per the object reference a non-required
+  resource is "considered available for other appointments", so the old engine only availability/eligibility
+  -checks REQUIRED resources → resourceB's Secondary role is never evaluated → the SA books (HTTP 2xx,
+  serviceAppointmentId returned). Captures oldWriteHelperHttp + oldWriteHelperSaId.
+url: "{{baseUrl}}{{versionPath}}/connect/scheduling/service-appointments"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  x-revoman-ledger: "off"
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "serviceAppointment": {
+        "serviceTerritoryId": "{{schedWlTerritoryId}}",
+        "parentRecordId": "{{schedWlAccountId}}",
+        "workTypeId": "{{schedWlWorkTypeId}}",
+        "schedStartTime": "{{schedWlBookStart}}",
+        "schedEndTime": "{{schedWlBookEnd}}",
+        "extendedFields": [ { "name": "Status", "value": "Scheduled" } ]
+      },
+      "schedulingPolicyId": "{{schedWlPrimaryOnlyPolicyId}}",
+      "assignedResources": [
+        { "serviceResourceId": "{{schedWlResourceAId}}", "isRequiredResource": true, "isPrimaryResource": true },
+        { "serviceResourceId": "{{schedWlResourceBId}}", "isRequiredResource": false, "isPrimaryResource": false }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 0, 0, 0);
+      const e = new Date(s.getTime() + 30 * 60 * 1000);
+      pm.environment.set("schedWlBookStart", s.toISOString());
+      pm.environment.set("schedWlBookEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      // The Connect book API wraps its payload in a "result" node on success:
+      // { "result": { "serviceAppointmentId": "08p...", "assignedResourceIds": [...] } }. On refusal it
+      // returns a top-level error array. Dig the SA id out of result first, then the flatter shapes.
+      const data = pm.response.json() || {};
+      const result = data.result || data;
+      pm.environment.set("oldWriteHelperHttp", String(pm.response.code));
+      pm.environment.set("oldWriteHelperSaId", result.serviceAppointmentId || (result.serviceAppointment && result.serviceAppointment.id) || "");
+      console.log("OLD workloc book helper http=" + pm.response.code + " body=" + JSON.stringify(data).slice(0,300));
+    language: text/javascript
+order: 1000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-workloc-required-control/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-workloc-required-control/.resources/definition.yaml
@@ -1,0 +1,12 @@
+$kind: collection
+description: |-
+  Control: OLD Scheduler book with the Secondary-member resourceB flipped to isRequiredResource=true, UNDER
+  THE PRIMARY-ONLY policy. A required Secondary member is filtered out of the candidate pool by the
+  primary-only STM filter → the book is refused. Isolates the helper Success to the non-required flag.
+  Captures oldWriteRequiredControlHttp + oldWriteRequiredControlSaId for the 1d write diff.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000140
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-workloc-required-control/10-book.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/booking/service-appointments-workloc-required-control/10-book.request.yaml
@@ -1,0 +1,54 @@
+$kind: http-request
+description: >-
+  Control: OLD book with resourceB isRequiredResource=true (still the Secondary member under the
+  PRIMARY-ONLY policy), same window (tomorrow 11:00-12:00 UTC). A REQUIRED resource IS eligibility/
+  availability-checked → the primary-only STM filter has already removed the Secondary resourceB from the
+  candidate pool → no A∩B slot at 11:00 → the book is refused (non-2xx, no serviceAppointmentId). Isolates
+  the helper Success to the non-required flag: same Secondary resource, only the isRequiredResource flag
+  flips. Captures oldWriteRequiredControlHttp + oldWriteRequiredControlSaId.
+url: "{{baseUrl}}{{versionPath}}/connect/scheduling/service-appointments"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  x-revoman-ledger: "off"
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "serviceAppointment": {
+        "serviceTerritoryId": "{{schedWlTerritoryId}}",
+        "parentRecordId": "{{schedWlAccountId}}",
+        "workTypeId": "{{schedWlWorkTypeId}}",
+        "schedStartTime": "{{schedWlBookStart}}",
+        "schedEndTime": "{{schedWlBookEnd}}",
+        "extendedFields": [ { "name": "Status", "value": "Scheduled" } ]
+      },
+      "schedulingPolicyId": "{{schedWlPrimaryOnlyPolicyId}}",
+      "assignedResources": [
+        { "serviceResourceId": "{{schedWlResourceAId}}", "isRequiredResource": true, "isPrimaryResource": true },
+        { "serviceResourceId": "{{schedWlResourceBId}}", "isRequiredResource": true, "isPrimaryResource": false }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(11, 0, 0, 0);
+      const e = new Date(s.getTime() + 30 * 60 * 1000);
+      pm.environment.set("schedWlBookStart", s.toISOString());
+      pm.environment.set("schedWlBookEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      // The Connect book API wraps its payload in a "result" node on success:
+      // { "result": { "serviceAppointmentId": "08p...", "assignedResourceIds": [...] } }. On refusal it
+      // returns a top-level error array (here: the Secondary resource is not an eligible candidate under
+      // the primary-only policy). Dig the SA id out of result first; a refusal leaves it empty.
+      const data = pm.response.json() || {};
+      const result = data.result || data;
+      pm.environment.set("oldWriteRequiredControlHttp", String(pm.response.code));
+      pm.environment.set("oldWriteRequiredControlSaId", result.serviceAppointmentId || (result.serviceAppointment && result.serviceAppointment.id) || "");
+      console.log("OLD workloc book required-control http=" + pm.response.code + " body=" + JSON.stringify(data).slice(0,300));
+    language: text/javascript
+order: 1000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/double-book/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/double-book/.resources/definition.yaml
@@ -1,0 +1,12 @@
+$kind: collection
+description: |-
+  OLD Scheduler-org double-book data graph (clone of the WFS Unified fixture, retargeted to the scheduler
+  org and admin session). Territory OH 08-16; resourceA member OH + Shift 10-14 (covers 11:00-11:30);
+  resourceB member OH + Shift 12-14 (does NOT cover 11:00 → busy at the window). Standard objects, so the
+  same graph books on the scheduler org. Sets sched{Territory,WorkType,Account,ResourceA,ResourceB}Id.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000010
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/double-book/create-double-book-graph.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/double-book/create-double-book-graph.request.yaml
@@ -1,0 +1,347 @@
+$kind: http-request
+description: >-
+  OLD scheduler-org double-book data graph (clone of WFS Unified fixture, retargeted to scheduler org
+  and adminToken). Builds the double-book data graph in one composite/graph call as {{adminToken}}.
+  Territory OH 08-16, member OH 10-14 (Mon-Sun), a WorkType (OnSite, 30m) + STWT, an Account. TWO
+  User-backed ServiceResources on DISTINCT users (ServiceResource is DB-unique on (RelatedRecordId,
+  ResourceType)): the graph MINTS two FRESH timestamped users per run up front (refUserA/refUserB, on
+  the org's Standard User profile 00exx000000n0KyAAI) and points resourceA/resourceB RelatedRecordId at
+  @{refUserA.id}/@{refUserB.id} — so the SR uniqueness key never collides (the proven WFS
+  create-case-worker pattern; fixed pre-existing users already owned a ResourceType='T' SR, which rolled
+  the whole graph back with DUPLICATE_VALUE). BOTH are PRIMARY
+  ServiceTerritoryMembers (TerritoryType=P) effective a month ago. Availability is the UNION of member OH
+  and Shift (AvailabilityRuleCheck: bookable iff the window fits OH ∪ Shift), so the two resources differ
+  in BOTH their member-OH and Shift windows:
+    - resourceA: member OH A 10:00-14:00 + Confirmed Shift 10:00-14:00 — COVERS the 11:00-11:30 booking
+      window → A is available.
+    - resourceB: member OH B 12:00-14:00 + Confirmed Shift 12:00-14:00 — the union (12:00-14:00) does NOT
+      contain 11:00-11:30 → B is UNAVAILABLE at the booked hour ("busy elsewhere"). Both its OH and Shift
+      start at noon, so 11:00 is outside its availability.
+  Because availability is checked ONLY for required resources, B-as-helper (non-required) is never
+  availability-checked → the SA books Success even though B has no shift at 11:00 (the Decision-1
+  double-book-allowed claim); B-as-required puts B in the slot-gen intersection → no A∩B slot at 11:00 →
+  SlotNotAvailable (the busy-proof control). Sets schedTerritoryId / schedWorkTypeId /
+  schedAccountId / schedResourceAId / schedResourceBId. No competing SA / SA-status seed
+  needed — the Shift-coverage gap is the proven availability mechanism (mirrors UnifiedBookingEnforce).
+url: "{{baseUrl}}{{versionPath}}/composite/graph"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: json
+  content: |-
+    {
+      "graphs": [
+        {
+          "graphId": "doubleBookNonRequired",
+          "compositeRequest": [
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/User",
+              "referenceId": "refUserA",
+              "body": {
+                "Username": "{{schedUserAName}}",
+                "ProfileId": "00exx000000n0KyAAI",
+                "Alias": "sres-a",
+                "Email": "{{schedUserAName}}",
+                "EmailEncodingKey": "ISO-8859-1",
+                "LastName": "ResourceA",
+                "FirstName": "DblBook",
+                "LanguageLocaleKey": "en_US",
+                "LocaleSidKey": "en_US",
+                "TimeZoneSidKey": "Asia/Kolkata"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/User",
+              "referenceId": "refUserB",
+              "body": {
+                "Username": "{{schedUserBName}}",
+                "ProfileId": "00exx000000n0KyAAI",
+                "Alias": "sres-b",
+                "Email": "{{schedUserBName}}",
+                "EmailEncodingKey": "ISO-8859-1",
+                "LastName": "ResourceB",
+                "FirstName": "DblBook",
+                "LanguageLocaleKey": "en_US",
+                "LocaleSidKey": "en_US",
+                "TimeZoneSidKey": "Asia/Kolkata"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refTerritoryOh",
+              "body": { "Name": "DblBook Territory OH {{$timestamp}}", "TimeZone": "GMT" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refMemberOhA",
+              "body": { "Name": "DblBook Member OH A {{$timestamp}}", "TimeZone": "GMT" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refMemberOhB",
+              "body": { "Name": "DblBook Member OH B {{$timestamp}}", "TimeZone": "GMT" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsMon",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Monday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsTue",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Tuesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsWed",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Wednesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsThu",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Thursday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsFri",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Friday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsSat",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Saturday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsSun",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Sunday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsMon",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Monday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsTue",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Tuesday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsWed",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Wednesday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsThu",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Thursday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsFri",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Friday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsSat",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Saturday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsSun",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Sunday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberBtsMon",
+              "body": { "OperatingHoursId": "@{refMemberOhB.id}", "DayOfWeek": "Monday", "Type": "Normal", "StartTime": "12:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberBtsTue",
+              "body": { "OperatingHoursId": "@{refMemberOhB.id}", "DayOfWeek": "Tuesday", "Type": "Normal", "StartTime": "12:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberBtsWed",
+              "body": { "OperatingHoursId": "@{refMemberOhB.id}", "DayOfWeek": "Wednesday", "Type": "Normal", "StartTime": "12:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberBtsThu",
+              "body": { "OperatingHoursId": "@{refMemberOhB.id}", "DayOfWeek": "Thursday", "Type": "Normal", "StartTime": "12:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberBtsFri",
+              "body": { "OperatingHoursId": "@{refMemberOhB.id}", "DayOfWeek": "Friday", "Type": "Normal", "StartTime": "12:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberBtsSat",
+              "body": { "OperatingHoursId": "@{refMemberOhB.id}", "DayOfWeek": "Saturday", "Type": "Normal", "StartTime": "12:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberBtsSun",
+              "body": { "OperatingHoursId": "@{refMemberOhB.id}", "DayOfWeek": "Sunday", "Type": "Normal", "StartTime": "12:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritory",
+              "referenceId": "refTerritory",
+              "body": { "Name": "DblBook Territory {{$timestamp}}", "OperatingHoursId": "@{refTerritoryOh.id}", "IsActive": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/WorkType",
+              "referenceId": "refWorkType",
+              "body": { "Name": "DblBook WorkType {{$timestamp}}", "DurationType": "Minutes", "EstimatedDuration": 30 }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryWorkType",
+              "referenceId": "refStwt",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "WorkTypeId": "@{refWorkType.id}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceResource",
+              "referenceId": "refResourceA",
+              "body": { "Name": "DblBook Resource A {{$timestamp}}", "RelatedRecordId": "@{refUserA.id}", "ResourceType": "T", "IsActive": true, "IsPrimary": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceResource",
+              "referenceId": "refResourceB",
+              "body": { "Name": "DblBook Resource B {{$timestamp}}", "RelatedRecordId": "@{refUserB.id}", "ResourceType": "T", "IsActive": true, "IsPrimary": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryMember",
+              "referenceId": "refStmA",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "ServiceResourceId": "@{refResourceA.id}", "TerritoryType": "P", "OperatingHoursId": "@{refMemberOhA.id}", "EffectiveStartDate": "{{doubleBookStmEffectiveStart}}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryMember",
+              "referenceId": "refStmB",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "ServiceResourceId": "@{refResourceB.id}", "TerritoryType": "P", "OperatingHoursId": "@{refMemberOhB.id}", "EffectiveStartDate": "{{doubleBookStmEffectiveStart}}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Shift",
+              "referenceId": "refShiftA",
+              "body": { "ServiceResourceId": "@{refResourceA.id}", "ServiceTerritoryId": "@{refTerritory.id}", "StartTime": "{{doubleBookShiftAStart}}", "EndTime": "{{doubleBookShiftAEnd}}", "TimeSlotType": "Normal", "Status": "Confirmed" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Shift",
+              "referenceId": "refShiftB",
+              "body": { "ServiceResourceId": "@{refResourceB.id}", "ServiceTerritoryId": "@{refTerritory.id}", "StartTime": "{{doubleBookShiftBStart}}", "EndTime": "{{doubleBookShiftBEnd}}", "TimeSlotType": "Normal", "Status": "Confirmed" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAccount",
+              "body": { "Name": "DblBook Account {{$timestamp}}" }
+            }
+          ]
+        }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      // Mint FRESH timestamped users per run so the two ServiceResource rows never collide on the
+      // (RelatedRecordId, ResourceType) DB-unique key (the proven WFS create-case-worker pattern —
+      // fixed pre-existing users already own a ResourceType='T' SR → both inserts DUPLICATE_VALUE and
+      // the whole graph rolls back). The graph creates these users up front (refUserA/refUserB) and the
+      // ServiceResources point RelatedRecordId at @{refUserA.id}/@{refUserB.id}.
+      pm.environment.set("schedUserAName", pm.variables.replaceIn("sched-res-a-{{$timestamp}}@revoman.org"));
+      pm.environment.set("schedUserBName", pm.variables.replaceIn("sched-res-b-{{$timestamp}}@revoman.org"));
+      // STM effective from a month ago (open-ended) so the Shifts validate.
+      const monthAgo = new Date();
+      monthAgo.setUTCMonth(monthAgo.getUTCMonth() - 1);
+      pm.environment.set("doubleBookStmEffectiveStart", monthAgo.toISOString());
+      // Availability is the UNION of member OH and Shift (AvailabilityRuleCheck: bookable iff the window
+      // fits OH ∪ Shift). So to make resourceB unavailable at 11:00 BOTH its member OH and its Shift must
+      // exclude 11:00 — covering only the Shift gap is not enough when member OH still spans the window.
+      // resourceA: member OH A 10:00-14:00 + Shift 10:00-14:00 → COVERS 11:00-11:30, A is available there.
+      const shiftAStart = new Date();
+      shiftAStart.setUTCDate(shiftAStart.getUTCDate() + 1);
+      shiftAStart.setUTCHours(10, 0, 0, 0);
+      const shiftAEnd = new Date(shiftAStart.getTime());
+      shiftAEnd.setUTCHours(14, 0, 0, 0);
+      pm.environment.set("doubleBookShiftAStart", shiftAStart.toISOString());
+      pm.environment.set("doubleBookShiftAEnd", shiftAEnd.toISOString());
+      // resourceB: member OH B 12:00-14:00 + Shift 12:00-14:00 → the union is 12:00-14:00, which does NOT
+      // contain the 11:00-11:30 window, so resourceB is UNAVAILABLE at the booked hour ("busy elsewhere").
+      // Because availability is checked ONLY for required resources, B-as-helper (non-required) is never
+      // availability-checked and the SA books Success; B-as-required makes the A∩B slot intersection empty
+      // at 11:00 → SlotNotAvailable. Same proven OH/Shift availability mechanism as UnifiedBookingEnforce
+      // (which books outside member OH to force the Availability rejection).
+      const shiftBStart = new Date();
+      shiftBStart.setUTCDate(shiftBStart.getUTCDate() + 1);
+      shiftBStart.setUTCHours(12, 0, 0, 0);
+      const shiftBEnd = new Date(shiftBStart.getTime());
+      shiftBEnd.setUTCHours(14, 0, 0, 0);
+      pm.environment.set("doubleBookShiftBStart", shiftBStart.toISOString());
+      pm.environment.set("doubleBookShiftBEnd", shiftBEnd.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      const jsonData = pm.response.json();
+      const responses = jsonData.graphs[0].graphResponse.compositeResponse;
+      // A rolled-back graph turns EVERY step's httpStatusCode to 400 (PROCESSING_HALTED for the
+      // bystanders, the real errorCode on the offending step), so this per-step check reliably fails
+      // the step on any rollback — e.g. a ServiceResource (RelatedRecordId, ResourceType)
+      // DUPLICATE_VALUE — instead of the graph passing vacuously. (This scheduler org's composite/graph
+      // response at v67 carries NO graph-level isSuccessful flag, so the per-step status IS the signal.)
+      responses.forEach((r) => {
+        if (r.httpStatusCode < 200 || r.httpStatusCode >= 300) {
+          throw new Error("Composite step " + r.referenceId + " failed: " + JSON.stringify(r.body));
+        }
+      });
+      const byRef = {};
+      responses.forEach(r => { byRef[r.referenceId] = r.body && r.body.id; });
+      pm.environment.set("schedTerritoryId", byRef["refTerritory"]);
+      pm.environment.set("schedWorkTypeId", byRef["refWorkType"]);
+      pm.environment.set("schedAccountId", byRef["refAccount"]);
+      pm.environment.set("schedResourceAId", byRef["refResourceA"]);
+      pm.environment.set("schedResourceBId", byRef["refResourceB"]);
+      pm.environment.set("schedMemberOhAId", byRef["refMemberOhA"]);
+      pm.environment.set("schedMemberOhBId", byRef["refMemberOhB"]);
+      pm.environment.set("schedTerritoryOhId", byRef["refTerritoryOh"]);
+      pm.environment.set("schedShiftAId", byRef["refShiftA"]);
+      pm.environment.set("schedShiftBId", byRef["refShiftB"]);
+      pm.environment.set("schedStwtId", byRef["refStwt"]);
+    language: text/javascript
+order: 500

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/excluded-helper/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/excluded-helper/.resources/definition.yaml
@@ -1,0 +1,14 @@
+$kind: collection
+description: |-
+  OLD Scheduler-org EXCLUDED-helper data graph (clone of the WFS Unified excluded-non-required fixture,
+  retargeted to the scheduler org + admin session + scheduler-org schema without SchedulingMethod).
+  Territory OH 08-16; BOTH resourceA and resourceB member OH + Shift 08-16 (both fully available at
+  11:00-11:30). resourceB's ONLY defect is an account ResourcePreference(Excluded) linking refAccount to
+  resourceB. Sets sched{Territory,WorkType,Account,ResourceA,ResourceB,ResourcePref}Id. Runs under
+  {{adminToken}}.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000040
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/excluded-helper/create-excluded-helper-graph.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/excluded-helper/create-excluded-helper-graph.request.yaml
@@ -1,0 +1,287 @@
+$kind: http-request
+description: >-
+  OLD scheduler-org EXCLUDED-helper data graph (clone of the WFS Unified excluded-non-required fixture,
+  retargeted to the scheduler org + adminToken, and to the scheduler-org schema which lacks the
+  SchedulingMethod field on TimeSlot/Shift — kept removed, per the double-book clone). Builds the graph in
+  one composite/graph call as {{adminToken}}. Territory OH 08-16 (Mon-Sun), member OH 08-16 (Mon-Sun), a
+  WorkType (30m) + STWT, an Account. TWO User-backed ServiceResources on DISTINCT fresh timestamped users
+  (ServiceResource is DB-unique on (RelatedRecordId, ResourceType); the graph MINTS two FRESH users per run
+  — refUserA/refUserB on the scheduler org Standard User profile 00exx000000n0KyAAI — so the SR uniqueness
+  key never collides; the proven double-book pattern). BOTH are PRIMARY ServiceTerritoryMembers
+  (TerritoryType=P) effective a month ago, and BOTH get a Confirmed Shift 08-16 tomorrow.
+    - resourceA: member OH 08-16 + Confirmed Shift 08-16 — COVERS the 11:00-11:30 booking window → A is
+      fully available AND clean (not on any block-list).
+    - resourceB: member OH 08-16 + Confirmed Shift 08-16 — ALSO fully available at 11:00 (availability is
+      NOT the variable here; unlike 1.5 there is no busy gap). resourceB's ONLY defect is that it is on the
+      ACCOUNT's block-list via an account-scoped ResourcePreference(Excluded) linking refAccount→resourceB.
+  This isolates the ExcludedResources rule as the single thing in play on resourceB. Because the classic
+  engine enforces account ResourcePreference(Excluded) ONLY on the getAppointmentCandidates read path
+  (SchedulingServiceImpl.getAppointmentCandidates → loadAccountResourcePreferences → SchedulingDbUtil
+  .checkResourcePrefs prunes the excluded SR), and NOT on the direct getAppointmentSlots or the classic
+  service-appointments book path (both pass accountResourcePreferences=null → checkResourcePrefs
+  short-circuits true), the read probe uses getAppointmentCandidates (with accountId) and the write probe
+  uses service-appointments. Sets schedTerritoryId / schedWorkTypeId / schedAccountId / schedResourceAId /
+  schedResourceBId / schedResourcePrefId.
+url: "{{baseUrl}}{{versionPath}}/composite/graph"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: json
+  content: |-
+    {
+      "graphs": [
+        {
+          "graphId": "excludedHelper",
+          "compositeRequest": [
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/User",
+              "referenceId": "refUserA",
+              "body": {
+                "Username": "{{schedUserAName}}",
+                "ProfileId": "00exx000000n0KyAAI",
+                "Alias": "sxre-a",
+                "Email": "{{schedUserAName}}",
+                "EmailEncodingKey": "ISO-8859-1",
+                "LastName": "ResourceA",
+                "FirstName": "Excluded",
+                "LanguageLocaleKey": "en_US",
+                "LocaleSidKey": "en_US",
+                "TimeZoneSidKey": "Asia/Kolkata"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/User",
+              "referenceId": "refUserB",
+              "body": {
+                "Username": "{{schedUserBName}}",
+                "ProfileId": "00exx000000n0KyAAI",
+                "Alias": "sxre-b",
+                "Email": "{{schedUserBName}}",
+                "EmailEncodingKey": "ISO-8859-1",
+                "LastName": "ResourceB",
+                "FirstName": "Excluded",
+                "LanguageLocaleKey": "en_US",
+                "LocaleSidKey": "en_US",
+                "TimeZoneSidKey": "Asia/Kolkata"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refTerritoryOh",
+              "body": { "Name": "EXCL Territory OH {{$timestamp}}", "TimeZone": "GMT" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refMemberOh",
+              "body": { "Name": "EXCL Member OH {{$timestamp}}", "TimeZone": "GMT" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsMon",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Monday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsTue",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Tuesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsWed",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Wednesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsThu",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Thursday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsFri",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Friday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsSat",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Saturday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsSun",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Sunday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsMon",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Monday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsTue",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Tuesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsWed",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Wednesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsThu",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Thursday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsFri",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Friday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsSat",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Saturday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsSun",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Sunday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritory",
+              "referenceId": "refTerritory",
+              "body": { "Name": "EXCL Territory {{$timestamp}}", "OperatingHoursId": "@{refTerritoryOh.id}", "IsActive": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/WorkType",
+              "referenceId": "refWorkType",
+              "body": { "Name": "EXCL WorkType {{$timestamp}}", "DurationType": "Minutes", "EstimatedDuration": 30 }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryWorkType",
+              "referenceId": "refStwt",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "WorkTypeId": "@{refWorkType.id}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceResource",
+              "referenceId": "refResourceA",
+              "body": { "Name": "EXCL Resource A {{$timestamp}}", "RelatedRecordId": "@{refUserA.id}", "ResourceType": "T", "IsActive": true, "IsPrimary": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceResource",
+              "referenceId": "refResourceB",
+              "body": { "Name": "EXCL Resource B {{$timestamp}}", "RelatedRecordId": "@{refUserB.id}", "ResourceType": "T", "IsActive": true, "IsPrimary": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryMember",
+              "referenceId": "refStmA",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "ServiceResourceId": "@{refResourceA.id}", "TerritoryType": "P", "OperatingHoursId": "@{refMemberOh.id}", "EffectiveStartDate": "{{excludedStmEffectiveStart}}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryMember",
+              "referenceId": "refStmB",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "ServiceResourceId": "@{refResourceB.id}", "TerritoryType": "P", "OperatingHoursId": "@{refMemberOh.id}", "EffectiveStartDate": "{{excludedStmEffectiveStart}}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Shift",
+              "referenceId": "refShiftA",
+              "body": { "ServiceResourceId": "@{refResourceA.id}", "ServiceTerritoryId": "@{refTerritory.id}", "StartTime": "{{excludedShiftStart}}", "EndTime": "{{excludedShiftEnd}}", "TimeSlotType": "Normal", "Status": "Confirmed" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Shift",
+              "referenceId": "refShiftB",
+              "body": { "ServiceResourceId": "@{refResourceB.id}", "ServiceTerritoryId": "@{refTerritory.id}", "StartTime": "{{excludedShiftStart}}", "EndTime": "{{excludedShiftEnd}}", "TimeSlotType": "Normal", "Status": "Confirmed" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAccount",
+              "body": { "Name": "EXCL Account {{$timestamp}}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ResourcePreference",
+              "referenceId": "refResourcePref",
+              "body": { "RelatedRecordId": "@{refAccount.id}", "ServiceResourceId": "@{refResourceB.id}", "PreferenceType": "Excluded" }
+            }
+          ]
+        }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      // Mint FRESH timestamped users per run so the two ServiceResource rows never collide on the
+      // (RelatedRecordId, ResourceType) DB-unique key (the proven double-book create-user pattern).
+      pm.environment.set("schedUserAName", pm.variables.replaceIn("sched-excl-a-{{$timestamp}}@revoman.org"));
+      pm.environment.set("schedUserBName", pm.variables.replaceIn("sched-excl-b-{{$timestamp}}@revoman.org"));
+      // STM effective from a month ago (open-ended) so the Shifts validate (Shift must fit the membership).
+      const monthAgo = new Date();
+      monthAgo.setUTCMonth(monthAgo.getUTCMonth() - 1);
+      pm.environment.set("excludedStmEffectiveStart", monthAgo.toISOString());
+      // Confirmed Shift covering tomorrow 08:00-16:00 UTC for BOTH resources so BOTH are fully available at
+      // the 11:00-11:30 window. Availability is NOT the variable in 1a (unlike 1.5's busy gap) — resourceB's
+      // ONLY defect is the account ResourcePreference(Excluded). Both member OH and Shift span the window so
+      // WorkingTerritories + Availability pass for both, isolating ExcludedResources on resourceB.
+      const shiftStart = new Date();
+      shiftStart.setUTCDate(shiftStart.getUTCDate() + 1);
+      shiftStart.setUTCHours(8, 0, 0, 0);
+      const shiftEnd = new Date(shiftStart.getTime());
+      shiftEnd.setUTCHours(16, 0, 0, 0);
+      pm.environment.set("excludedShiftStart", shiftStart.toISOString());
+      pm.environment.set("excludedShiftEnd", shiftEnd.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      const jsonData = pm.response.json();
+      const responses = jsonData.graphs[0].graphResponse.compositeResponse;
+      // A rolled-back graph turns EVERY step's httpStatusCode to 400, so this per-step check fails the step
+      // on any rollback (e.g. a ServiceResource (RelatedRecordId, ResourceType) DUPLICATE_VALUE) instead of
+      // passing vacuously. (This scheduler org's composite/graph response at v67 carries NO graph-level
+      // isSuccessful flag, so the per-step status IS the signal.)
+      responses.forEach((r) => {
+        if (r.httpStatusCode < 200 || r.httpStatusCode >= 300) {
+          throw new Error("Composite step " + r.referenceId + " failed: " + JSON.stringify(r.body));
+        }
+      });
+      const byRef = {};
+      responses.forEach(r => { byRef[r.referenceId] = r.body && r.body.id; });
+      pm.environment.set("schedTerritoryId", byRef["refTerritory"]);
+      pm.environment.set("schedWorkTypeId", byRef["refWorkType"]);
+      pm.environment.set("schedAccountId", byRef["refAccount"]);
+      pm.environment.set("schedResourceAId", byRef["refResourceA"]);
+      pm.environment.set("schedResourceBId", byRef["refResourceB"]);
+      pm.environment.set("schedResourcePrefId", byRef["refResourcePref"]);
+      pm.environment.set("schedMemberOhId", byRef["refMemberOh"]);
+      pm.environment.set("schedTerritoryOhId", byRef["refTerritoryOh"]);
+      pm.environment.set("schedShiftAId", byRef["refShiftA"]);
+      pm.environment.set("schedShiftBId", byRef["refShiftB"]);
+      pm.environment.set("schedStwtId", byRef["refStwt"]);
+    language: text/javascript
+order: 500

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/limit-helper/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/limit-helper/.resources/definition.yaml
@@ -1,0 +1,16 @@
+$kind: collection
+description: |-
+  OLD Scheduler-org Decision 8 (resourceLimitApptDistribution cap) fixture. Three ordered steps under
+  {{adminToken}}: (300) an AppointmentAssignmentPolicy(loadBalancing) SETUP object in its own txn — the
+  classic-engine analogue of the 264 SchedulingObjective(LoadBalancing); (400) an AppointmentSchedulingPolicy
+  SETUP object with its AppointmentAssignmentPolicy FK set to that record (the non-null FK is what flips the
+  classic engine onto the load-balancing candidates path where the cap lives); (500) the non-setup data graph
+  — a clean 2-resource fixture (both member + Confirmed Shift 08-16, both available at 11:00-11:30). Setup and
+  data are split across transactions to avoid MIXED_DML. Sets schedLimit{AssignmentPolicy,Policy,Territory,
+  WorkType,Account,ResourceA,ResourceB}Id (+ schedResourceAId/schedResourceBId aliases for the shared grant).
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000130
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/limit-helper/00-create-assignment-policy.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/limit-helper/00-create-assignment-policy.request.yaml
@@ -1,0 +1,43 @@
+$kind: http-request
+description: >-
+  Decision 8 (resourceLimitApptDistribution cap) old-side fixture, part 1 of 3. Creates the
+  AppointmentAssignmentPolicy (a SETUP object, keyPrefix 0mT) in ITS OWN transaction — this is the OLD
+  classic-engine ANALOGUE of the 264 SchedulingObjective(LoadBalancing): it is the record whose FK on the
+  AppointmentSchedulingPolicy flips the classic engine onto the load-balancing (smart-scheduling) path where
+  the resourceLimitApptDistribution cap lives (SmartSchedulerServiceImpl.getServiceResourceByResourceLimitApptDistribution
+  → getLeastUtilizedResources → subList(0, N); JDWP/source-confirmed scheduling-impl). PolicyType=loadBalancing
+  is the only AssignmentPolicyType value; PolicyApplicableDuration=ParameterBased + UtilizationFactor=
+  TotalAppointmentDuration are the required static-enum fields (getPolicyMetadata reads them). Setup objects
+  throw MIXED_DML_OPERATION if inserted in the same composite/graph as the non-setup data (Account /
+  ServiceResource / TimeSlot / Shift), so this stands alone, BEFORE the scheduling policy (which
+  FK-references it) and the data graph. Captures schedLimitAssignmentPolicyId. If the org lacks smart
+  scheduling (SsAppointmentDistribution pref + AppointmentDistribution perm) the create still succeeds but
+  the FK is ignored on read — the test characterizes that as an OLD-vs-264 config nuance.
+url: "{{baseUrl}}{{versionPath}}/sobjects/AppointmentAssignmentPolicy"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "DeveloperName": "LimitLoadBalancing{{$timestamp}}",
+      "MasterLabel": "Limit LoadBalancing {{$timestamp}}",
+      "PolicyType": "loadBalancing",
+      "PolicyApplicableDuration": "ParameterBased",
+      "UtilizationFactor": "TotalAppointmentDuration"
+    }
+scripts:
+  - type: afterResponse
+    code: |-
+      // /sobjects insert returns { id, success, errors:[...] }. Capture the id if it persisted; do NOT hard-fail
+      // if the org lacks smart scheduling (the create can 400 with an access/INVALID_TYPE — in that case the FK
+      // stays null and the classic engine never takes the load-balancing path; the test characterizes that).
+      const data = pm.response.json() || {};
+      pm.environment.set("schedLimitAssignmentPolicyId", data.id || "");
+      console.log("OLD AppointmentAssignmentPolicy(loadBalancing) create http=" + pm.response.code +
+                  " id=" + (data.id || "") + " body=" + JSON.stringify(data).slice(0,300));
+    language: text/javascript
+order: 300

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/limit-helper/05-create-scheduling-policy.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/limit-helper/05-create-scheduling-policy.request.yaml
@@ -1,0 +1,37 @@
+$kind: http-request
+description: >-
+  Decision 8 old-side fixture, part 2 of 3. Creates the AppointmentSchedulingPolicy (a SETUP object) in ITS
+  OWN transaction, SEPARATE from the non-setup data graph (MIXED_DML). The AppointmentAssignmentPolicy FK —
+  the trigger for the classic load-balancing path — is NOT set here (it is attempted in a follow-up PATCH,
+  step 06, so a schema that lacks the column, i.e. an org WITHOUT smart scheduling, does not roll back this
+  create). ShouldUsePrimaryMembers + the two Shift flags true so availability = member OH ∪ Shift (same
+  mechanism as the double-book / required-helper fixtures). Captures schedLimitPolicyId. Whether the
+  load-balancing FK actually attaches is recorded by step 06 as schedLimitCapConstructible.
+url: "{{baseUrl}}{{versionPath}}/sobjects/AppointmentSchedulingPolicy"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "DeveloperName": "LimitPolicy{{$timestamp}}",
+      "MasterLabel": "Limit Policy {{$timestamp}}",
+      "AppointmentStartTimeInterval": "15",
+      "ShouldUsePrimaryMembers": true,
+      "IsSvcTerritoryMemberShiftUsed": true,
+      "IsSvcTerrOpHoursWithShiftsUsed": true
+    }
+scripts:
+  - type: afterResponse
+    code: |-
+      const data = pm.response.json() || {};
+      if (!data.id) {
+        throw new Error("AppointmentSchedulingPolicy insert failed: " + JSON.stringify(data));
+      }
+      pm.environment.set("schedLimitPolicyId", data.id);
+      console.log("OLD limit scheduling policy created id=" + data.id);
+    language: text/javascript
+order: 400

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/limit-helper/06-attach-assignment-policy.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/limit-helper/06-attach-assignment-policy.request.yaml
@@ -1,0 +1,43 @@
+$kind: http-request
+description: >-
+  Decision 8 old-side fixture, part 2b of 3 — the load-balancing ATTACH probe. Attempts to PATCH the
+  AppointmentAssignmentPolicy(loadBalancing) FK (from step 300) onto the AppointmentSchedulingPolicy (from
+  step 400). This FK is the ENTIRE trigger for the classic load-balancing candidates path
+  (SchedulingServiceImpl.getAppointmentCandidatesForTerritoryWorkTypes → getSmartPolicy returns
+  LOAD_BALANCING iff the constraint carries a non-empty appointmentAssignmentPolicy), and the FK COLUMN is
+  exposed on AppointmentSchedulingPolicy ONLY when the org has smart scheduling enabled
+  (SchedulingDbUtil reads it only under orgHasSmartSchedulingEnabled() = SsAppointmentDistribution pref +
+  AppointmentDistribution perm). So this PATCH is the live probe of that org gate:
+    - 2xx → the FK attached → the org HAS smart scheduling → the OLD cap is CONSTRUCTIBLE (schedLimitCapConstructible=true).
+    - 400 INVALID_FIELD "No such column 'AppointmentAssignmentPolicy'" → the column is absent → the org LACKS
+      smart scheduling → the classic engine never takes the load-balancing branch → the cap is a NO-OP on
+      this org (schedLimitCapConstructible=false). This is a faithful OLD-vs-264 configuration nuance, NOT a
+      test defect. Ignore-HTTP-status so the 400 does not fail the step.
+url: "{{baseUrl}}{{versionPath}}/sobjects/AppointmentSchedulingPolicy/{{schedLimitPolicyId}}"
+method: PATCH
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "AppointmentAssignmentPolicy": "{{schedLimitAssignmentPolicyId}}"
+    }
+scripts:
+  - type: afterResponse
+    code: |-
+      // A successful sobjects PATCH returns 204 No Content (empty body). A rejected one returns 400 with
+      // [{"errorCode":"INVALID_FIELD", ...}]. Record whether the load-balancing FK attached.
+      const code = pm.response.code;
+      const constructible = (code >= 200 && code < 300);
+      pm.environment.set("schedLimitCapConstructible", constructible ? "true" : "false");
+      let ec = "";
+      try { const d = pm.response.json(); if (Array.isArray(d) && d.length) ec = d[0].errorCode || ""; } catch (e) {}
+      pm.environment.set("schedLimitAttachHttp", String(code));
+      pm.environment.set("schedLimitAttachErrorCode", ec);
+      console.log("OLD attach load-balancing FK http=" + code + " constructible=" + constructible +
+                  " errorCode=" + ec);
+    language: text/javascript
+order: 450

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/limit-helper/10-create-limit-helper-graph.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/limit-helper/10-create-limit-helper-graph.request.yaml
@@ -1,0 +1,271 @@
+$kind: http-request
+description: >-
+  Decision 8 old-side fixture, part 3 of 3 — the data graph. A clean 2-resource fixture so a cap of 0
+  (empty) vs a positive limit (>0) shows a difference on the load-balancing candidates read. Clone of the
+  required-helper graph MINUS the account ResourcePreference (Decision 8 is a pure presentation cap, not an
+  account rule): Territory OH 08-16 (Mon-Sun), a WorkType (OnSite, 60m) + STWT, an Account. TWO User-backed
+  ServiceResources on DISTINCT FRESH timestamped users (ServiceResource is DB-unique on
+  (RelatedRecordId, ResourceType) → mint fresh users per run, the proven WFS create-case-worker pattern):
+    - resourceA: member OH 08-16 + Confirmed Shift 08-16 → COVERS the 11:00-11:30 window → available.
+    - resourceB: member OH 08-16 + Confirmed Shift 08-16 → ALSO available at the window.
+  BOTH resources being available + members (TerritoryType='P') is deliberate: with NO filterByResources on the
+  read, the classic engine treats the whole territory pool as candidates, then the load-balancing branch
+  applies resourceLimitApptDistribution as a subList(0, N) cap over that ordered pool. limit=0 → empty;
+  limit=50 (> 2) → both returned. No SchedulingMethod field (this org's schema lacks it → INVALID_FIELD).
+  Sets schedLimitTerritoryId / schedLimitWorkTypeId / schedLimitAccountId / schedLimitResourceAId /
+  schedLimitResourceBId (+ schedResourceAId/schedResourceBId aliases for the shared grant-ls Kick).
+url: "{{baseUrl}}{{versionPath}}/composite/graph"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: json
+  content: |-
+    {
+      "graphs": [
+        {
+          "graphId": "limitHelper",
+          "compositeRequest": [
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/User",
+              "referenceId": "refUserA",
+              "body": {
+                "Username": "{{schedLimitUserAName}}",
+                "ProfileId": "00exx000000n0KyAAI",
+                "Alias": "lim-a",
+                "Email": "{{schedLimitUserAName}}",
+                "EmailEncodingKey": "ISO-8859-1",
+                "LastName": "ResourceA",
+                "FirstName": "LimitHelper",
+                "LanguageLocaleKey": "en_US",
+                "LocaleSidKey": "en_US",
+                "TimeZoneSidKey": "Asia/Kolkata"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/User",
+              "referenceId": "refUserB",
+              "body": {
+                "Username": "{{schedLimitUserBName}}",
+                "ProfileId": "00exx000000n0KyAAI",
+                "Alias": "lim-b",
+                "Email": "{{schedLimitUserBName}}",
+                "EmailEncodingKey": "ISO-8859-1",
+                "LastName": "ResourceB",
+                "FirstName": "LimitHelper",
+                "LanguageLocaleKey": "en_US",
+                "LocaleSidKey": "en_US",
+                "TimeZoneSidKey": "Asia/Kolkata"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refTerritoryOh",
+              "body": { "Name": "LimitHelper Territory OH {{$timestamp}}", "TimeZone": "GMT" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refMemberOh",
+              "body": { "Name": "LimitHelper Member OH {{$timestamp}}", "TimeZone": "GMT" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsMon",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Monday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsTue",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Tuesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsWed",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Wednesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsThu",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Thursday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsFri",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Friday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsSat",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Saturday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsSun",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Sunday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsMon",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Monday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsTue",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Tuesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsWed",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Wednesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsThu",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Thursday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsFri",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Friday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsSat",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Saturday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsSun",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Sunday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritory",
+              "referenceId": "refTerritory",
+              "body": { "Name": "LimitHelper Territory {{$timestamp}}", "OperatingHoursId": "@{refTerritoryOh.id}", "IsActive": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/WorkType",
+              "referenceId": "refWorkType",
+              "body": { "Name": "LimitHelper WorkType {{$timestamp}}", "DurationType": "Minutes", "EstimatedDuration": 60 }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryWorkType",
+              "referenceId": "refStwt",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "WorkTypeId": "@{refWorkType.id}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceResource",
+              "referenceId": "refResourceA",
+              "body": { "Name": "LimitHelper Resource A {{$timestamp}}", "RelatedRecordId": "@{refUserA.id}", "ResourceType": "T", "IsActive": true, "IsPrimary": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceResource",
+              "referenceId": "refResourceB",
+              "body": { "Name": "LimitHelper Resource B {{$timestamp}}", "RelatedRecordId": "@{refUserB.id}", "ResourceType": "T", "IsActive": true, "IsPrimary": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryMember",
+              "referenceId": "refStmA",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "ServiceResourceId": "@{refResourceA.id}", "TerritoryType": "P", "OperatingHoursId": "@{refMemberOh.id}", "EffectiveStartDate": "{{limitHelperStmEffectiveStart}}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryMember",
+              "referenceId": "refStmB",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "ServiceResourceId": "@{refResourceB.id}", "TerritoryType": "P", "OperatingHoursId": "@{refMemberOh.id}", "EffectiveStartDate": "{{limitHelperStmEffectiveStart}}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Shift",
+              "referenceId": "refShiftA",
+              "body": { "ServiceResourceId": "@{refResourceA.id}", "ServiceTerritoryId": "@{refTerritory.id}", "StartTime": "{{limitHelperShiftStart}}", "EndTime": "{{limitHelperShiftEnd}}", "TimeSlotType": "Normal", "Status": "Confirmed" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Shift",
+              "referenceId": "refShiftB",
+              "body": { "ServiceResourceId": "@{refResourceB.id}", "ServiceTerritoryId": "@{refTerritory.id}", "StartTime": "{{limitHelperShiftStart}}", "EndTime": "{{limitHelperShiftEnd}}", "TimeSlotType": "Normal", "Status": "Confirmed" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAccount",
+              "body": { "Name": "LimitHelper Account {{$timestamp}}" }
+            }
+          ]
+        }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      // Mint FRESH timestamped users per run so the two ServiceResource rows never collide on the
+      // (RelatedRecordId, ResourceType) DB-unique key (the proven WFS create-case-worker pattern).
+      pm.environment.set("schedLimitUserAName", pm.variables.replaceIn("sched-limit-a-{{$timestamp}}@revoman.org"));
+      pm.environment.set("schedLimitUserBName", pm.variables.replaceIn("sched-limit-b-{{$timestamp}}@revoman.org"));
+      // STM effective from a month ago (open-ended) so the Shifts validate (Shift must fit the membership).
+      const monthAgo = new Date();
+      monthAgo.setUTCMonth(monthAgo.getUTCMonth() - 1);
+      pm.environment.set("limitHelperStmEffectiveStart", monthAgo.toISOString());
+      // Confirmed Shift covering tomorrow 08:00-16:00 UTC for BOTH resources so BOTH are available at the
+      // 11:00-11:30 read window (availability = member OH 08-16 ∪ Shift 08-16). Both available so the ONLY
+      // variable across the two probes is resourceLimitApptDistribution (0 vs 50).
+      const shiftStart = new Date();
+      shiftStart.setUTCDate(shiftStart.getUTCDate() + 1);
+      shiftStart.setUTCHours(8, 0, 0, 0);
+      const shiftEnd = new Date(shiftStart.getTime());
+      shiftEnd.setUTCHours(16, 0, 0, 0);
+      pm.environment.set("limitHelperShiftStart", shiftStart.toISOString());
+      pm.environment.set("limitHelperShiftEnd", shiftEnd.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      const jsonData = pm.response.json();
+      const responses = jsonData.graphs[0].graphResponse.compositeResponse;
+      // A rolled-back graph turns EVERY step's httpStatusCode to 400 (PROCESSING_HALTED for the bystanders,
+      // the real errorCode on the offending step), so this per-step check reliably fails the step on any
+      // rollback instead of the graph passing vacuously.
+      responses.forEach((r) => {
+        if (r.httpStatusCode < 200 || r.httpStatusCode >= 300) {
+          throw new Error("Composite step " + r.referenceId + " failed: " + JSON.stringify(r.body));
+        }
+      });
+      const byRef = {};
+      responses.forEach(r => { byRef[r.referenceId] = r.body && r.body.id; });
+      pm.environment.set("schedLimitTerritoryId", byRef["refTerritory"]);
+      pm.environment.set("schedLimitWorkTypeId", byRef["refWorkType"]);
+      pm.environment.set("schedLimitAccountId", byRef["refAccount"]);
+      pm.environment.set("schedLimitResourceAId", byRef["refResourceA"]);
+      pm.environment.set("schedLimitResourceBId", byRef["refResourceB"]);
+      // Publish under the shared grant Kick's expected names (schedResourceAId/schedResourceBId) so the reused
+      // OLD_GRANT_LS_ACCESS_CONFIG (which queries ServiceResource.RelatedRecordId by those ids) grants the
+      // Lightning-Scheduler user-access to BOTH resource users unchanged.
+      pm.environment.set("schedResourceAId", byRef["refResourceA"]);
+      pm.environment.set("schedResourceBId", byRef["refResourceB"]);
+      pm.environment.set("schedLimitStwtId", byRef["refStwt"]);
+    language: text/javascript
+order: 500

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/primary-not-required-helper/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/primary-not-required-helper/.resources/definition.yaml
@@ -1,0 +1,12 @@
+$kind: collection
+description: |-
+  OLD Scheduler-org Decision-5 (primary-not-required) data graph (clone of the double-book fixture shape,
+  simplified to a SINGLE fully-available resource). Runs under {{adminToken}}. Territory OH 08-16;
+  resourceA member OH + Confirmed Shift 10-14 (covers the 11:00-11:30 window → FREE). Standard objects, so
+  the same graph books on the scheduler org. Sets sched{Territory,WorkType,Account,ResourceA}Id.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000050
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/primary-not-required-helper/create-primary-not-required-graph.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/primary-not-required-helper/create-primary-not-required-graph.request.yaml
@@ -1,0 +1,236 @@
+$kind: http-request
+description: >-
+  OLD scheduler-org Decision-5 data graph (clone of the double-book fixture shape, simplified to a SINGLE
+  fully-available resource). Builds the graph in one composite/graph call as {{adminToken}}. Territory OH
+  08-16 (Mon-Sun), one WorkType (OnSite, 30m) + STWT, an Account, and ONE User-backed ServiceResource
+  (resourceA) that is a PRIMARY ServiceTerritoryMember (TerritoryType=P) effective a month ago with member
+  OH 10:00-14:00 + a Confirmed Shift 10:00-14:00 — so resourceA is FULLY AVAILABLE over the 11:00-11:30
+  booking window. Decision 5 is a PERSIST-time rule, not an availability rule: the window is free so the
+  availability check passes and the LightningSchedulerAssignedResourceValidator reject (a primary must be
+  required) is what surfaces. Only ONE resource is needed — the probe books that single resource as
+  isPrimaryResource=true + isRequiredResource=false (the contradiction), the control flips it to
+  isRequiredResource=true (books Success).
+
+  Mints ONE fresh timestamped User per run (refUserA on the org's Standard User profile 00exx000000n0KyAAI)
+  and points resourceA.RelatedRecordId at @{refUserA.id} so the SR uniqueness key (RelatedRecordId,
+  ResourceType) never collides across runs (the proven WFS create-case-worker pattern; fixed pre-existing
+  users already own a ResourceType='T' SR → DUPLICATE_VALUE rolls the whole graph back). No SchedulingMethod
+  field anywhere (the scheduler org's TimeSlot/Shift schema lacks it → INVALID_FIELD). Sets
+  schedTerritoryId / schedWorkTypeId / schedAccountId / schedResourceAId.
+url: "{{baseUrl}}{{versionPath}}/composite/graph"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: json
+  content: |-
+    {
+      "graphs": [
+        {
+          "graphId": "primaryNotRequired",
+          "compositeRequest": [
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/User",
+              "referenceId": "refUserA",
+              "body": {
+                "Username": "{{schedUserAName}}",
+                "ProfileId": "00exx000000n0KyAAI",
+                "Alias": "spnr-a",
+                "Email": "{{schedUserAName}}",
+                "EmailEncodingKey": "ISO-8859-1",
+                "LastName": "ResourceA",
+                "FirstName": "PrimNotReq",
+                "LanguageLocaleKey": "en_US",
+                "LocaleSidKey": "en_US",
+                "TimeZoneSidKey": "Asia/Kolkata"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refTerritoryOh",
+              "body": { "Name": "PrimNotReq Territory OH {{$timestamp}}", "TimeZone": "GMT" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refMemberOhA",
+              "body": { "Name": "PrimNotReq Member OH A {{$timestamp}}", "TimeZone": "GMT" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsMon",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Monday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsTue",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Tuesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsWed",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Wednesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsThu",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Thursday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsFri",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Friday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsSat",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Saturday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsSun",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Sunday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsMon",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Monday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsTue",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Tuesday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsWed",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Wednesday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsThu",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Thursday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsFri",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Friday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsSat",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Saturday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsSun",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Sunday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritory",
+              "referenceId": "refTerritory",
+              "body": { "Name": "PrimNotReq Territory {{$timestamp}}", "OperatingHoursId": "@{refTerritoryOh.id}", "IsActive": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/WorkType",
+              "referenceId": "refWorkType",
+              "body": { "Name": "PrimNotReq WorkType {{$timestamp}}", "DurationType": "Minutes", "EstimatedDuration": 30 }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryWorkType",
+              "referenceId": "refStwt",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "WorkTypeId": "@{refWorkType.id}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceResource",
+              "referenceId": "refResourceA",
+              "body": { "Name": "PrimNotReq Resource A {{$timestamp}}", "RelatedRecordId": "@{refUserA.id}", "ResourceType": "T", "IsActive": true, "IsPrimary": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryMember",
+              "referenceId": "refStmA",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "ServiceResourceId": "@{refResourceA.id}", "TerritoryType": "P", "OperatingHoursId": "@{refMemberOhA.id}", "EffectiveStartDate": "{{primNotReqStmEffectiveStart}}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Shift",
+              "referenceId": "refShiftA",
+              "body": { "ServiceResourceId": "@{refResourceA.id}", "ServiceTerritoryId": "@{refTerritory.id}", "StartTime": "{{primNotReqShiftAStart}}", "EndTime": "{{primNotReqShiftAEnd}}", "TimeSlotType": "Normal", "Status": "Confirmed" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAccount",
+              "body": { "Name": "PrimNotReq Account {{$timestamp}}" }
+            }
+          ]
+        }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      // Mint a FRESH timestamped user per run so the ServiceResource row never collides on the
+      // (RelatedRecordId, ResourceType) DB-unique key (the proven WFS create-case-worker pattern).
+      pm.environment.set("schedUserAName", pm.variables.replaceIn("sched-pnr-a-{{$timestamp}}@revoman.org"));
+      // STM effective from a month ago (open-ended) so the Shift validates.
+      const monthAgo = new Date();
+      monthAgo.setUTCMonth(monthAgo.getUTCMonth() - 1);
+      pm.environment.set("primNotReqStmEffectiveStart", monthAgo.toISOString());
+      // resourceA: member OH A 10:00-14:00 + Confirmed Shift 10:00-14:00 → COVERS 11:00-11:30 (the booking
+      // window is FREE for resourceA). Availability is the UNION of member OH and Shift; both span the
+      // window so resourceA passes the availability check and the persist-time primary-must-be-required
+      // reject (Decision 5) is the sole discriminator.
+      const shiftAStart = new Date();
+      shiftAStart.setUTCDate(shiftAStart.getUTCDate() + 1);
+      shiftAStart.setUTCHours(10, 0, 0, 0);
+      const shiftAEnd = new Date(shiftAStart.getTime());
+      shiftAEnd.setUTCHours(14, 0, 0, 0);
+      pm.environment.set("primNotReqShiftAStart", shiftAStart.toISOString());
+      pm.environment.set("primNotReqShiftAEnd", shiftAEnd.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      const jsonData = pm.response.json();
+      const responses = jsonData.graphs[0].graphResponse.compositeResponse;
+      // A rolled-back graph turns EVERY step's httpStatusCode to 400 (PROCESSING_HALTED for the
+      // bystanders, the real errorCode on the offending step), so this per-step check reliably fails the
+      // step on any rollback instead of the graph passing vacuously.
+      responses.forEach((r) => {
+        if (r.httpStatusCode < 200 || r.httpStatusCode >= 300) {
+          throw new Error("Composite step " + r.referenceId + " failed: " + JSON.stringify(r.body));
+        }
+      });
+      const byRef = {};
+      responses.forEach(r => { byRef[r.referenceId] = r.body && r.body.id; });
+      pm.environment.set("schedTerritoryId", byRef["refTerritory"]);
+      pm.environment.set("schedWorkTypeId", byRef["refWorkType"]);
+      pm.environment.set("schedAccountId", byRef["refAccount"]);
+      pm.environment.set("schedResourceAId", byRef["refResourceA"]);
+      pm.environment.set("schedMemberOhAId", byRef["refMemberOhA"]);
+      pm.environment.set("schedTerritoryOhId", byRef["refTerritoryOh"]);
+      pm.environment.set("schedShiftAId", byRef["refShiftA"]);
+      pm.environment.set("schedStwtId", byRef["refStwt"]);
+    language: text/javascript
+order: 500

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/promise-helper/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/promise-helper/.resources/definition.yaml
@@ -1,0 +1,17 @@
+$kind: collection
+description: |-
+  OLD Scheduler-org SINGLE-resource "slot promise" fixture (Decision 2). Clone of the double-book graph
+  reduced to ONE User-backed ServiceResource (resourceA) that is fully AVAILABLE across the standard
+  business day: Territory OH 08-16 + member OH A 08-16 + Confirmed Shift 08-16 tomorrow. The availability
+  UNION (member OH ∪ Shift = 08-16) CONTAINS the AVAILABLE window (tomorrow 11:00-11:30) and EXCLUDES the
+  UNAVAILABLE window (tomorrow 17:00-17:30). Mints ONE fresh timestamped user per run (refUserA on the
+  org's Standard User profile 00exx000000n0KyAAI) so the ServiceResource (RelatedRecordId, ResourceType)
+  DB-unique key never collides. Sets sched{Territory,WorkType,Account,ResourceA}Id; also sets
+  schedResourceBId = schedResourceAId so the SHARED grant-ls-user-access Kick (which grants BOTH resource
+  users) runs unchanged over the single resource (idempotent double-grant of resourceA's user).
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000210
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/promise-helper/create-promise-helper-graph.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/promise-helper/create-promise-helper-graph.request.yaml
@@ -1,0 +1,239 @@
+$kind: http-request
+description: >-
+  OLD scheduler-org SINGLE-resource "slot promise" data graph (Decision 2), built in one composite/graph
+  call as {{adminToken}}. Reduced clone of the double-book fixture: ONE User-backed ServiceResource
+  (resourceA) fully AVAILABLE across the business day so the AVAILABLE window is inside its hours and the
+  UNAVAILABLE window is outside — the two windows are the read↔write promise probe. Territory OH 08-16
+  (Mon-Sun); member OH A 08-16 (Mon-Sun); Confirmed Shift 08-16 tomorrow. Availability is the UNION of
+  member OH and Shift (AvailabilityRuleCheck: bookable iff the window fits OH ∪ Shift), so resourceA's
+  union 08-16:
+    - CONTAINS the AVAILABLE window tomorrow 11:00-11:30 → read offers slots, book Succeeds.
+    - EXCLUDES the UNAVAILABLE window tomorrow 17:00-17:30 → read offers 0 slots, book Refused.
+  Mints ONE FRESH timestamped user per run (refUserA on the org's Standard User profile 00exx000000n0KyAAI)
+  so the ServiceResource (RelatedRecordId, ResourceType) DB-unique key never collides. resourceA is a
+  PRIMARY ServiceTerritoryMember (TerritoryType=P) effective a month ago. Sets schedTerritoryId /
+  schedWorkTypeId / schedAccountId / schedResourceAId, AND schedResourceBId = schedResourceAId so the shared
+  grant-ls-user-access Kick runs unchanged (it grants BOTH resource users; here both point at resourceA's
+  user → idempotent). No SchedulingMethod field on TimeSlot/Shift (this org's schema lacks it → INVALID_FIELD).
+url: "{{baseUrl}}{{versionPath}}/composite/graph"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: json
+  content: |-
+    {
+      "graphs": [
+        {
+          "graphId": "promiseHelper",
+          "compositeRequest": [
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/User",
+              "referenceId": "refUserA",
+              "body": {
+                "Username": "{{schedUserAName}}",
+                "ProfileId": "00exx000000n0KyAAI",
+                "Alias": "sres-a",
+                "Email": "{{schedUserAName}}",
+                "EmailEncodingKey": "ISO-8859-1",
+                "LastName": "ResourceA",
+                "FirstName": "Promise",
+                "LanguageLocaleKey": "en_US",
+                "LocaleSidKey": "en_US",
+                "TimeZoneSidKey": "Asia/Kolkata"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refTerritoryOh",
+              "body": { "Name": "Promise Territory OH {{$timestamp}}", "TimeZone": "GMT" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refMemberOhA",
+              "body": { "Name": "Promise Member OH A {{$timestamp}}", "TimeZone": "GMT" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsMon",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Monday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsTue",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Tuesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsWed",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Wednesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsThu",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Thursday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsFri",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Friday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsSat",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Saturday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsSun",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Sunday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsMon",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Monday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsTue",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Tuesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsWed",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Wednesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsThu",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Thursday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsFri",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Friday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsSat",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Saturday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsSun",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Sunday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritory",
+              "referenceId": "refTerritory",
+              "body": { "Name": "Promise Territory {{$timestamp}}", "OperatingHoursId": "@{refTerritoryOh.id}", "IsActive": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/WorkType",
+              "referenceId": "refWorkType",
+              "body": { "Name": "Promise WorkType {{$timestamp}}", "DurationType": "Minutes", "EstimatedDuration": 30 }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryWorkType",
+              "referenceId": "refStwt",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "WorkTypeId": "@{refWorkType.id}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceResource",
+              "referenceId": "refResourceA",
+              "body": { "Name": "Promise Resource A {{$timestamp}}", "RelatedRecordId": "@{refUserA.id}", "ResourceType": "T", "IsActive": true, "IsPrimary": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryMember",
+              "referenceId": "refStmA",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "ServiceResourceId": "@{refResourceA.id}", "TerritoryType": "P", "OperatingHoursId": "@{refMemberOhA.id}", "EffectiveStartDate": "{{promiseStmEffectiveStart}}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Shift",
+              "referenceId": "refShiftA",
+              "body": { "ServiceResourceId": "@{refResourceA.id}", "ServiceTerritoryId": "@{refTerritory.id}", "StartTime": "{{promiseShiftAStart}}", "EndTime": "{{promiseShiftAEnd}}", "TimeSlotType": "Normal", "Status": "Confirmed" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAccount",
+              "body": { "Name": "Promise Account {{$timestamp}}" }
+            }
+          ]
+        }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      // Mint a FRESH timestamped user per run so the single ServiceResource row never collides on the
+      // (RelatedRecordId, ResourceType) DB-unique key (the proven WFS create-case-worker pattern).
+      pm.environment.set("schedUserAName", pm.variables.replaceIn("sched-promise-a-{{$timestamp}}@revoman.org"));
+      // STM effective from a month ago (open-ended) so the Shift validates.
+      const monthAgo = new Date();
+      monthAgo.setUTCMonth(monthAgo.getUTCMonth() - 1);
+      pm.environment.set("promiseStmEffectiveStart", monthAgo.toISOString());
+      // resourceA: member OH A 08:00-16:00 + Confirmed Shift 08:00-16:00 tomorrow → the availability UNION
+      // (08-16) CONTAINS the AVAILABLE window tomorrow 11:00-11:30 and EXCLUDES the UNAVAILABLE window
+      // tomorrow 17:00-17:30. The single resource being available/unavailable at each window is the whole
+      // Decision 2 probe: read offers slots ⟺ write Succeeds only where the shared cheap availability check
+      // passes.
+      const shiftAStart = new Date();
+      shiftAStart.setUTCDate(shiftAStart.getUTCDate() + 1);
+      shiftAStart.setUTCHours(8, 0, 0, 0);
+      const shiftAEnd = new Date(shiftAStart.getTime());
+      shiftAEnd.setUTCHours(16, 0, 0, 0);
+      pm.environment.set("promiseShiftAStart", shiftAStart.toISOString());
+      pm.environment.set("promiseShiftAEnd", shiftAEnd.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      const jsonData = pm.response.json();
+      const responses = jsonData.graphs[0].graphResponse.compositeResponse;
+      // A rolled-back graph turns EVERY step's httpStatusCode to 400 (PROCESSING_HALTED for bystanders,
+      // the real errorCode on the offender), so this per-step check reliably fails on any rollback instead
+      // of passing vacuously (this org's v67 composite/graph response carries no graph-level isSuccessful).
+      responses.forEach((r) => {
+        if (r.httpStatusCode < 200 || r.httpStatusCode >= 300) {
+          throw new Error("Composite step " + r.referenceId + " failed: " + JSON.stringify(r.body));
+        }
+      });
+      const byRef = {};
+      responses.forEach(r => { byRef[r.referenceId] = r.body && r.body.id; });
+      pm.environment.set("schedTerritoryId", byRef["refTerritory"]);
+      pm.environment.set("schedWorkTypeId", byRef["refWorkType"]);
+      pm.environment.set("schedAccountId", byRef["refAccount"]);
+      pm.environment.set("schedResourceAId", byRef["refResourceA"]);
+      // Point resourceB at resourceA so the shared grant-ls-user-access Kick (which queries + grants BOTH
+      // resource users) runs unchanged over this single-resource fixture — a harmless, idempotent double
+      // grant of resourceA's user.
+      pm.environment.set("schedResourceBId", byRef["refResourceA"]);
+      pm.environment.set("schedMemberOhAId", byRef["refMemberOhA"]);
+      pm.environment.set("schedTerritoryOhId", byRef["refTerritoryOh"]);
+      pm.environment.set("schedShiftAId", byRef["refShiftA"]);
+      pm.environment.set("schedStwtId", byRef["refStwt"]);
+    language: text/javascript
+order: 500

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/required-helper/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/required-helper/.resources/definition.yaml
@@ -1,0 +1,14 @@
+$kind: collection
+description: |-
+  OLD Scheduler-org REQUIRED-RESOURCES (Decision 1.4) data graph (clone of the WFS Unified
+  required-non-required fixture, retargeted to the scheduler org + admin session). Territory OH 08-16;
+  BOTH resourceA and resourceB member OH + Shift 08-16 (both available at 11:00-11:30). An Account
+  ResourcePreference(Required) names resourceB ONLY, and an AppointmentSchedulingPolicy with
+  ShouldEnforceRequiredResource=true makes the classic engine honor it. Sets
+  schedReq{Territory,WorkType,Account,ResourceA,ResourceB,Policy}Id.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000110
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/required-helper/00-create-scheduling-policy.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/required-helper/00-create-scheduling-policy.request.yaml
@@ -1,0 +1,45 @@
+$kind: http-request
+description: >-
+  Creates the required-resources AppointmentSchedulingPolicy in ITS OWN transaction, SEPARATE from the data
+  graph (create-required-helper-graph, order 500). AppointmentSchedulingPolicy is a SETUP object, so
+  inserting it in the same composite/graph transaction as the non-setup data (Account / ServiceResource /
+  TimeSlot / ResourcePreference / Shift) throws MIXED_DML_OPERATION and rolls the whole graph back — hence
+  this standalone insert (mirrors how the WFS side creates its SchedulingPolicy in a separate Kick). The
+  policy sets ShouldEnforceRequiredResource=true (NON org-default) so the classic engine
+  (SchedulingDbUtil.buildSchedulingPolicyConstraint → shouldEnforceRequiredResource=true →
+  loadAccountResourcePreferences populates the account's requiredServiceResourceIds → checkResourcePrefs
+  filters the candidate pool to the account's required set). ShouldUsePrimaryMembers + the two Shift flags
+  true so availability = member OH ∪ Shift (same mechanism as the double-book fixture). Captures schedReqPolicyId.
+url: "{{baseUrl}}{{versionPath}}/sobjects/AppointmentSchedulingPolicy"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+  ignoreHTTPStatusUnsuccessful: "true"
+body:
+  type: json
+  content: |-
+    {
+      "DeveloperName": "ReqHelperPolicy{{$timestamp}}",
+      "MasterLabel": "ReqHelper Policy {{$timestamp}}",
+      "AppointmentStartTimeInterval": "15",
+      "ShouldEnforceRequiredResource": true,
+      "ShouldUsePrimaryMembers": true,
+      "IsSvcTerritoryMemberShiftUsed": true,
+      "IsSvcTerrOpHoursWithShiftsUsed": true
+    }
+scripts:
+  - type: afterResponse
+    code: |-
+      // /sobjects insert returns { id, success, errors:[...] }. Fail loudly if the policy did not persist
+      // (a null schedReqPolicyId → loadSchedulingPolicy falls back to the org-default policy, which likely
+      // has ShouldEnforceRequiredResource=false → the account pref would NOT be enforced → the whole 1.4
+      // probe would silently characterize the wrong thing).
+      const data = pm.response.json() || {};
+      if (!data.id) {
+        throw new Error("AppointmentSchedulingPolicy insert failed: " + JSON.stringify(data));
+      }
+      pm.environment.set("schedReqPolicyId", data.id);
+      console.log("OLD required-resources policy created id=" + data.id);
+    language: text/javascript
+order: 400

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/required-helper/create-required-helper-graph.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/required-helper/create-required-helper-graph.request.yaml
@@ -1,0 +1,289 @@
+$kind: http-request
+description: >-
+  OLD scheduler-org REQUIRED-RESOURCES (Decision 1.4) data graph — the account demands a SPECIFIC worker.
+  Clone of the WFS Unified required-non-required fixture, retargeted to the scheduler org + adminToken.
+  Territory OH 08-16 (Mon-Sun), a WorkType (OnSite, 60m) + STWT, an Account. TWO User-backed
+  ServiceResources on DISTINCT FRESH timestamped users (ServiceResource is DB-unique on
+  (RelatedRecordId, ResourceType) → mint fresh users per run, the proven WFS create-case-worker pattern;
+  fixed pre-existing users already own a ResourceType='T' SR and roll the whole graph back with
+  DUPLICATE_VALUE):
+    - resourceA (required+primary in the write, clean): member OH 08-16 + Confirmed Shift 08-16 → COVERS
+      the 11:00-11:30 window → A is available. A is NOT the account-required worker.
+    - resourceB (the NON-required helper): member OH 08-16 + Confirmed Shift 08-16 → ALSO available at the
+      window. B being available is deliberate — availability must NOT be the confound; the ONLY rule in
+      play is RequiredResources (the account demands B), so B is present and bookable but is offered/assigned
+      only as a helper.
+  An Account ResourcePreference(PreferenceType=Required) links the Account to resourceB ONLY, putting
+  resourceB (and NOT resourceA) on the Account's REQUIRED-resource preference list. Finally an
+  AppointmentSchedulingPolicy with ShouldEnforceRequiredResource=true (NON org-default) so the classic
+  engine (SchedulingDbUtil.buildSchedulingPolicyConstraint reads ShouldEnforceRequiredResource → true →
+  loadAccountResourcePreferences populates requiredServiceResourceIds={resourceB} → SchedulingDbUtil
+  .checkResourcePrefs filters the candidate pool to the account's required set). ShouldUsePrimaryMembers +
+  the two Shift flags true so availability = member OH ∪ Shift (same mechanism as the double-book fixture).
+  Sets schedReqTerritoryId / schedReqWorkTypeId / schedReqAccountId / schedReqResourceAId /
+  schedReqResourceBId / schedReqPolicyId.
+url: "{{baseUrl}}{{versionPath}}/composite/graph"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: json
+  content: |-
+    {
+      "graphs": [
+        {
+          "graphId": "requiredHelper",
+          "compositeRequest": [
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/User",
+              "referenceId": "refUserA",
+              "body": {
+                "Username": "{{schedReqUserAName}}",
+                "ProfileId": "00exx000000n0KyAAI",
+                "Alias": "rres-a",
+                "Email": "{{schedReqUserAName}}",
+                "EmailEncodingKey": "ISO-8859-1",
+                "LastName": "ResourceA",
+                "FirstName": "ReqHelper",
+                "LanguageLocaleKey": "en_US",
+                "LocaleSidKey": "en_US",
+                "TimeZoneSidKey": "Asia/Kolkata"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/User",
+              "referenceId": "refUserB",
+              "body": {
+                "Username": "{{schedReqUserBName}}",
+                "ProfileId": "00exx000000n0KyAAI",
+                "Alias": "rres-b",
+                "Email": "{{schedReqUserBName}}",
+                "EmailEncodingKey": "ISO-8859-1",
+                "LastName": "ResourceB",
+                "FirstName": "ReqHelper",
+                "LanguageLocaleKey": "en_US",
+                "LocaleSidKey": "en_US",
+                "TimeZoneSidKey": "Asia/Kolkata"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refTerritoryOh",
+              "body": { "Name": "ReqHelper Territory OH {{$timestamp}}", "TimeZone": "GMT" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refMemberOh",
+              "body": { "Name": "ReqHelper Member OH {{$timestamp}}", "TimeZone": "GMT" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsMon",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Monday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsTue",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Tuesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsWed",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Wednesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsThu",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Thursday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsFri",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Friday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsSat",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Saturday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsSun",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Sunday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsMon",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Monday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsTue",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Tuesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsWed",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Wednesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsThu",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Thursday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsFri",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Friday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsSat",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Saturday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsSun",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Sunday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritory",
+              "referenceId": "refTerritory",
+              "body": { "Name": "ReqHelper Territory {{$timestamp}}", "OperatingHoursId": "@{refTerritoryOh.id}", "IsActive": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/WorkType",
+              "referenceId": "refWorkType",
+              "body": { "Name": "ReqHelper WorkType {{$timestamp}}", "DurationType": "Minutes", "EstimatedDuration": 60 }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryWorkType",
+              "referenceId": "refStwt",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "WorkTypeId": "@{refWorkType.id}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceResource",
+              "referenceId": "refResourceA",
+              "body": { "Name": "ReqHelper Resource A {{$timestamp}}", "RelatedRecordId": "@{refUserA.id}", "ResourceType": "T", "IsActive": true, "IsPrimary": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceResource",
+              "referenceId": "refResourceB",
+              "body": { "Name": "ReqHelper Resource B {{$timestamp}}", "RelatedRecordId": "@{refUserB.id}", "ResourceType": "T", "IsActive": true, "IsPrimary": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryMember",
+              "referenceId": "refStmA",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "ServiceResourceId": "@{refResourceA.id}", "TerritoryType": "P", "OperatingHoursId": "@{refMemberOh.id}", "EffectiveStartDate": "{{requiredHelperStmEffectiveStart}}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryMember",
+              "referenceId": "refStmB",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "ServiceResourceId": "@{refResourceB.id}", "TerritoryType": "P", "OperatingHoursId": "@{refMemberOh.id}", "EffectiveStartDate": "{{requiredHelperStmEffectiveStart}}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Shift",
+              "referenceId": "refShiftA",
+              "body": { "ServiceResourceId": "@{refResourceA.id}", "ServiceTerritoryId": "@{refTerritory.id}", "StartTime": "{{requiredHelperShiftStart}}", "EndTime": "{{requiredHelperShiftEnd}}", "TimeSlotType": "Normal", "Status": "Confirmed" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Shift",
+              "referenceId": "refShiftB",
+              "body": { "ServiceResourceId": "@{refResourceB.id}", "ServiceTerritoryId": "@{refTerritory.id}", "StartTime": "{{requiredHelperShiftStart}}", "EndTime": "{{requiredHelperShiftEnd}}", "TimeSlotType": "Normal", "Status": "Confirmed" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAccount",
+              "body": { "Name": "ReqHelper Account {{$timestamp}}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ResourcePreference",
+              "referenceId": "refResourcePref",
+              "body": { "RelatedRecordId": "@{refAccount.id}", "ServiceResourceId": "@{refResourceB.id}", "PreferenceType": "Required" }
+            }
+          ]
+        }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      // Mint FRESH timestamped users per run so the two ServiceResource rows never collide on the
+      // (RelatedRecordId, ResourceType) DB-unique key (the proven WFS create-case-worker pattern).
+      pm.environment.set("schedReqUserAName", pm.variables.replaceIn("sched-req-a-{{$timestamp}}@revoman.org"));
+      pm.environment.set("schedReqUserBName", pm.variables.replaceIn("sched-req-b-{{$timestamp}}@revoman.org"));
+      // STM effective from a month ago (open-ended) so the Shifts validate (Shift must fit the membership).
+      const monthAgo = new Date();
+      monthAgo.setUTCMonth(monthAgo.getUTCMonth() - 1);
+      pm.environment.set("requiredHelperStmEffectiveStart", monthAgo.toISOString());
+      // Confirmed Shift covering tomorrow 08:00-16:00 UTC for BOTH resources so BOTH are available at the
+      // 11:00-11:30 booking/read window (availability = member OH 08-16 ∪ Shift 08-16). Availability is
+      // deliberately NOT the blocker here — the ONLY rule in play is RequiredResources (the account demands
+      // resourceB), so a candidate/booking failure isolates the required-resource pool filter, not a shift gap.
+      const shiftStart = new Date();
+      shiftStart.setUTCDate(shiftStart.getUTCDate() + 1);
+      shiftStart.setUTCHours(8, 0, 0, 0);
+      const shiftEnd = new Date(shiftStart.getTime());
+      shiftEnd.setUTCHours(16, 0, 0, 0);
+      pm.environment.set("requiredHelperShiftStart", shiftStart.toISOString());
+      pm.environment.set("requiredHelperShiftEnd", shiftEnd.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      const jsonData = pm.response.json();
+      const responses = jsonData.graphs[0].graphResponse.compositeResponse;
+      // A rolled-back graph turns EVERY step's httpStatusCode to 400 (PROCESSING_HALTED for the bystanders,
+      // the real errorCode on the offending step), so this per-step check reliably fails the step on any
+      // rollback (e.g. a ServiceResource (RelatedRecordId, ResourceType) DUPLICATE_VALUE) instead of the
+      // graph passing vacuously. (This scheduler org's composite/graph response carries NO graph-level
+      // isSuccessful flag, so the per-step status IS the signal.)
+      responses.forEach((r) => {
+        if (r.httpStatusCode < 200 || r.httpStatusCode >= 300) {
+          throw new Error("Composite step " + r.referenceId + " failed: " + JSON.stringify(r.body));
+        }
+      });
+      const byRef = {};
+      responses.forEach(r => { byRef[r.referenceId] = r.body && r.body.id; });
+      pm.environment.set("schedReqTerritoryId", byRef["refTerritory"]);
+      pm.environment.set("schedReqWorkTypeId", byRef["refWorkType"]);
+      pm.environment.set("schedReqAccountId", byRef["refAccount"]);
+      pm.environment.set("schedReqResourceAId", byRef["refResourceA"]);
+      pm.environment.set("schedReqResourceBId", byRef["refResourceB"]);
+      // Also publish under the shared grant Kick's expected names (schedResourceAId/schedResourceBId) so the
+      // reused OLD_GRANT_LS_ACCESS_CONFIG (which queries ServiceResource.RelatedRecordId by those ids) grants
+      // the Lightning-Scheduler user-access to BOTH required-helper resource users unchanged.
+      pm.environment.set("schedResourceAId", byRef["refResourceA"]);
+      pm.environment.set("schedResourceBId", byRef["refResourceB"]);
+      pm.environment.set("schedReqResourcePrefId", byRef["refResourcePref"]);
+      pm.environment.set("schedReqStwtId", byRef["refStwt"]);
+    language: text/javascript
+order: 500

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/reschedule-helper/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/reschedule-helper/.resources/definition.yaml
@@ -1,0 +1,14 @@
+$kind: collection
+description: |-
+  OLD Scheduler-org CLEAN two-resource data graph for Decision 4z (reschedule leaves no primary). A clone
+  of the double-book fixture retargeted so BOTH resourceA and resourceB are FULLY AVAILABLE over the
+  11:00-11:30 window (member OH + Confirmed Shift 08-16 for both), so the clean two-resource booking
+  succeeds and yields two AssignedResource rows to probe. resourceA is the primary+required worker;
+  resourceB is a required secondary. Standard objects, books on the scheduler org under {{adminToken}}.
+  Sets sched{Territory,WorkType,Account,ResourceA,ResourceB}Id.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-0000004z0010
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/reschedule-helper/create-reschedule-helper-graph.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/reschedule-helper/create-reschedule-helper-graph.request.yaml
@@ -1,0 +1,311 @@
+$kind: http-request
+description: >-
+  OLD scheduler-org CLEAN two-resource data graph for Decision 4z (reschedule leaves no primary). Clone of
+  the double-book fixture retargeted so BOTH resources are AVAILABLE over the 11:00-11:30 booking window,
+  so a clean two-resource ServiceAppointment books and yields two AssignedResource rows to probe. Builds
+  the graph in one composite/graph call as {{adminToken}}: Territory OH 08-16 (Mon-Sun), a WorkType
+  (OnSite, 30m) + STWT, an Account, and TWO User-backed ServiceResources on DISTINCT freshly-minted
+  timestamped users (refUserA/refUserB, Standard User profile 00exx000000n0KyAAI) so the SR uniqueness key
+  (RelatedRecordId, ResourceType) never collides. BOTH are PRIMARY ServiceTerritoryMembers
+  (TerritoryType=P) effective a month ago, and BOTH get member OH 08-16 + a Confirmed Shift 08-16 — so both
+  fully COVER the 11:00-11:30 window (availability = member OH ∪ Shift). This is the parity analog of the
+  264 SCHEDULE_TWO_RESOURCE_CLEAN act: a clean two-resource booking where A is primary+required and B is a
+  required secondary. Sets schedTerritoryId / schedWorkTypeId / schedAccountId / schedResourceAId /
+  schedResourceBId.
+url: "{{baseUrl}}{{versionPath}}/composite/graph"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: json
+  content: |-
+    {
+      "graphs": [
+        {
+          "graphId": "rescheduleHelperClean",
+          "compositeRequest": [
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/User",
+              "referenceId": "refUserA",
+              "body": {
+                "Username": "{{schedUserAName}}",
+                "ProfileId": "00exx000000n0KyAAI",
+                "Alias": "sres-a",
+                "Email": "{{schedUserAName}}",
+                "EmailEncodingKey": "ISO-8859-1",
+                "LastName": "ResourceA",
+                "FirstName": "Resched",
+                "LanguageLocaleKey": "en_US",
+                "LocaleSidKey": "en_US",
+                "TimeZoneSidKey": "Asia/Kolkata"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/User",
+              "referenceId": "refUserB",
+              "body": {
+                "Username": "{{schedUserBName}}",
+                "ProfileId": "00exx000000n0KyAAI",
+                "Alias": "sres-b",
+                "Email": "{{schedUserBName}}",
+                "EmailEncodingKey": "ISO-8859-1",
+                "LastName": "ResourceB",
+                "FirstName": "Resched",
+                "LanguageLocaleKey": "en_US",
+                "LocaleSidKey": "en_US",
+                "TimeZoneSidKey": "Asia/Kolkata"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refTerritoryOh",
+              "body": { "Name": "Resched Territory OH {{$timestamp}}", "TimeZone": "GMT" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refMemberOhA",
+              "body": { "Name": "Resched Member OH A {{$timestamp}}", "TimeZone": "GMT" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refMemberOhB",
+              "body": { "Name": "Resched Member OH B {{$timestamp}}", "TimeZone": "GMT" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsMon",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Monday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsTue",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Tuesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsWed",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Wednesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsThu",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Thursday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsFri",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Friday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsSat",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Saturday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsSun",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Sunday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsMon",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Monday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsTue",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Tuesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsWed",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Wednesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsThu",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Thursday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsFri",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Friday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsSat",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Saturday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsSun",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Sunday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberBtsMon",
+              "body": { "OperatingHoursId": "@{refMemberOhB.id}", "DayOfWeek": "Monday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberBtsTue",
+              "body": { "OperatingHoursId": "@{refMemberOhB.id}", "DayOfWeek": "Tuesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberBtsWed",
+              "body": { "OperatingHoursId": "@{refMemberOhB.id}", "DayOfWeek": "Wednesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberBtsThu",
+              "body": { "OperatingHoursId": "@{refMemberOhB.id}", "DayOfWeek": "Thursday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberBtsFri",
+              "body": { "OperatingHoursId": "@{refMemberOhB.id}", "DayOfWeek": "Friday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberBtsSat",
+              "body": { "OperatingHoursId": "@{refMemberOhB.id}", "DayOfWeek": "Saturday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberBtsSun",
+              "body": { "OperatingHoursId": "@{refMemberOhB.id}", "DayOfWeek": "Sunday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritory",
+              "referenceId": "refTerritory",
+              "body": { "Name": "Resched Territory {{$timestamp}}", "OperatingHoursId": "@{refTerritoryOh.id}", "IsActive": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/WorkType",
+              "referenceId": "refWorkType",
+              "body": { "Name": "Resched WorkType {{$timestamp}}", "DurationType": "Minutes", "EstimatedDuration": 30 }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryWorkType",
+              "referenceId": "refStwt",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "WorkTypeId": "@{refWorkType.id}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceResource",
+              "referenceId": "refResourceA",
+              "body": { "Name": "Resched Resource A {{$timestamp}}", "RelatedRecordId": "@{refUserA.id}", "ResourceType": "T", "IsActive": true, "IsPrimary": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceResource",
+              "referenceId": "refResourceB",
+              "body": { "Name": "Resched Resource B {{$timestamp}}", "RelatedRecordId": "@{refUserB.id}", "ResourceType": "T", "IsActive": true, "IsPrimary": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryMember",
+              "referenceId": "refStmA",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "ServiceResourceId": "@{refResourceA.id}", "TerritoryType": "P", "OperatingHoursId": "@{refMemberOhA.id}", "EffectiveStartDate": "{{reschedStmEffectiveStart}}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryMember",
+              "referenceId": "refStmB",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "ServiceResourceId": "@{refResourceB.id}", "TerritoryType": "P", "OperatingHoursId": "@{refMemberOhB.id}", "EffectiveStartDate": "{{reschedStmEffectiveStart}}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Shift",
+              "referenceId": "refShiftA",
+              "body": { "ServiceResourceId": "@{refResourceA.id}", "ServiceTerritoryId": "@{refTerritory.id}", "StartTime": "{{reschedShiftStart}}", "EndTime": "{{reschedShiftEnd}}", "TimeSlotType": "Normal", "Status": "Confirmed" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Shift",
+              "referenceId": "refShiftB",
+              "body": { "ServiceResourceId": "@{refResourceB.id}", "ServiceTerritoryId": "@{refTerritory.id}", "StartTime": "{{reschedShiftStart}}", "EndTime": "{{reschedShiftEnd}}", "TimeSlotType": "Normal", "Status": "Confirmed" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAccount",
+              "body": { "Name": "Resched Account {{$timestamp}}" }
+            }
+          ]
+        }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      // Mint FRESH timestamped users per run so the two ServiceResource rows never collide on the
+      // (RelatedRecordId, ResourceType) DB-unique key (the proven WFS create-case-worker pattern).
+      pm.environment.set("schedUserAName", pm.variables.replaceIn("sched-resched-a-{{$timestamp}}@revoman.org"));
+      pm.environment.set("schedUserBName", pm.variables.replaceIn("sched-resched-b-{{$timestamp}}@revoman.org"));
+      // STM effective from a month ago (open-ended) so the Shifts validate.
+      const monthAgo = new Date();
+      monthAgo.setUTCMonth(monthAgo.getUTCMonth() - 1);
+      pm.environment.set("reschedStmEffectiveStart", monthAgo.toISOString());
+      // BOTH resources: member OH 08-16 + Confirmed Shift 08-16 → both fully COVER the 11:00-11:30 booking
+      // window (availability = member OH ∪ Shift). So the clean two-resource booking (A primary+required,
+      // B required) succeeds and yields two AssignedResource rows to probe for the reschedule delete/demote.
+      const shiftStart = new Date();
+      shiftStart.setUTCDate(shiftStart.getUTCDate() + 1);
+      shiftStart.setUTCHours(8, 0, 0, 0);
+      const shiftEnd = new Date(shiftStart.getTime());
+      shiftEnd.setUTCHours(16, 0, 0, 0);
+      pm.environment.set("reschedShiftStart", shiftStart.toISOString());
+      pm.environment.set("reschedShiftEnd", shiftEnd.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      const jsonData = pm.response.json();
+      const responses = jsonData.graphs[0].graphResponse.compositeResponse;
+      // A rolled-back graph turns EVERY step's httpStatusCode to 400 (PROCESSING_HALTED for the
+      // bystanders, the real errorCode on the offending step), so this per-step check reliably fails the
+      // step on any rollback instead of the graph passing vacuously.
+      responses.forEach((r) => {
+        if (r.httpStatusCode < 200 || r.httpStatusCode >= 300) {
+          throw new Error("Composite step " + r.referenceId + " failed: " + JSON.stringify(r.body));
+        }
+      });
+      const byRef = {};
+      responses.forEach(r => { byRef[r.referenceId] = r.body && r.body.id; });
+      pm.environment.set("schedTerritoryId", byRef["refTerritory"]);
+      pm.environment.set("schedWorkTypeId", byRef["refWorkType"]);
+      pm.environment.set("schedAccountId", byRef["refAccount"]);
+      pm.environment.set("schedResourceAId", byRef["refResourceA"]);
+      pm.environment.set("schedResourceBId", byRef["refResourceB"]);
+    language: text/javascript
+order: 500

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/sharing-split-helper/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/sharing-split-helper/.resources/definition.yaml
@@ -1,0 +1,27 @@
+$kind: collection
+description: |-
+  OLD Decision-9 fixture. On the scheduler org a non-admin persona CANNOT insert ServiceTerritory / STM
+  (CANNOT_INSERT_UPDATE_ACTIVATE_ENTITY — LIVE-OBSERVED), so ownership is split to still put the SHARING
+  GATE on a manager-owned row. The collection binds {{adminToken}}; the ONE manager-owned step overrides to
+  {{oldD9ManagerToken}} per-request:
+    - 10 (admin) composite/graph: territory OperatingHours + 08-16 TimeSlots (Mon-Sun), a ServiceTerritory,
+      a 30m WorkType (NO SchedulingMethod — the scheduler org schema lacks it) + STWT, a member OH + 08-16
+      TimeSlots, an Account. Sets oldD9TerritoryId / oldD9WorkTypeId / oldD9AccountId / oldD9MemberOhId.
+    - 15 (MANAGER, per-request auth) a single ServiceResource (ResourceType=T, IsPrimary) on the
+      admin-created resource-owner user ({{oldD9ResourceUserId}}) → the manager OWNS it (OwnerId=manager),
+      making it the Private sharing-gate parent (ServiceResource OWD=Private; STM is ControlledByParent).
+      Sets oldD9ResourceId.
+    - 20 (admin) the STM (TerritoryType=P, effective ~30 days ago) on the manager-owned resource + a
+      Confirmed Shift (08:00-16:00 tomorrow, NO SchedulingMethod). Admin creates these because a non-admin
+      can't insert STM and can't reference the admin-owned Private ServiceTerritory on the Shift
+      (INSUFFICIENT_ACCESS_ON_CROSS_REFERENCE — LIVE-OBSERVED). The Shift read is full-access on the classic
+      engine so its owner is immaterial; the gate is the manager-owned ServiceResource/STM user-mode read.
+      Sets oldD9ShiftId.
+  Drives both get-appointment-slots-sharing acts: the case-worker (no sharing on the manager-owned Private
+  resource/STM) reads zero slots (the classic user-mode STM gate); ADMIN reads > 0 (fixture live).
+auth:
+  - id: b9020202-0000-4000-8000-0000000000b2
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/sharing-split-helper/10-create-graph.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/sharing-split-helper/10-create-graph.request.yaml
@@ -1,0 +1,90 @@
+$kind: http-request
+description: >-
+  OLD Decision-9 fixture skeleton, created by ADMIN (a non-admin persona cannot insert ServiceTerritory on
+  this org). Territory OH 08-16 (Mon-Sun TimeSlots), a ServiceTerritory, a 30m WorkType (NO SchedulingMethod
+  — the scheduler org schema lacks it) + STWT, a member OH 08-16 (Mon-Sun), and an Account. The
+  sharing-sensitive ServiceResource is created by the MANAGER in step 15; the STM + Shift on it by admin in
+  step 20. Availability is member OH ∪ Shift; both span 08-16 so the tomorrow 11:00-11:30 window is bookable.
+url: "{{baseUrl}}{{versionPath}}/composite/graph"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: json
+  content: |-
+    {
+      "graphs": [
+        {
+          "graphId": "oldD9skeleton",
+          "compositeRequest": [
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refTerritoryOh",
+              "body": { "Name": "OldD9 Territory OH {{$timestamp}}", "TimeZone": "GMT" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refMemberOh",
+              "body": { "Name": "OldD9 Member OH {{$timestamp}}", "TimeZone": "GMT" }
+            },
+            { "method": "POST", "url": "{{versionPath}}/sobjects/TimeSlot", "referenceId": "refTerrTsMon", "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Monday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" } },
+            { "method": "POST", "url": "{{versionPath}}/sobjects/TimeSlot", "referenceId": "refTerrTsTue", "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Tuesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" } },
+            { "method": "POST", "url": "{{versionPath}}/sobjects/TimeSlot", "referenceId": "refTerrTsWed", "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Wednesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" } },
+            { "method": "POST", "url": "{{versionPath}}/sobjects/TimeSlot", "referenceId": "refTerrTsThu", "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Thursday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" } },
+            { "method": "POST", "url": "{{versionPath}}/sobjects/TimeSlot", "referenceId": "refTerrTsFri", "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Friday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" } },
+            { "method": "POST", "url": "{{versionPath}}/sobjects/TimeSlot", "referenceId": "refTerrTsSat", "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Saturday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" } },
+            { "method": "POST", "url": "{{versionPath}}/sobjects/TimeSlot", "referenceId": "refTerrTsSun", "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Sunday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" } },
+            { "method": "POST", "url": "{{versionPath}}/sobjects/TimeSlot", "referenceId": "refMemTsMon", "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Monday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" } },
+            { "method": "POST", "url": "{{versionPath}}/sobjects/TimeSlot", "referenceId": "refMemTsTue", "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Tuesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" } },
+            { "method": "POST", "url": "{{versionPath}}/sobjects/TimeSlot", "referenceId": "refMemTsWed", "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Wednesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" } },
+            { "method": "POST", "url": "{{versionPath}}/sobjects/TimeSlot", "referenceId": "refMemTsThu", "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Thursday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" } },
+            { "method": "POST", "url": "{{versionPath}}/sobjects/TimeSlot", "referenceId": "refMemTsFri", "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Friday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" } },
+            { "method": "POST", "url": "{{versionPath}}/sobjects/TimeSlot", "referenceId": "refMemTsSat", "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Saturday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" } },
+            { "method": "POST", "url": "{{versionPath}}/sobjects/TimeSlot", "referenceId": "refMemTsSun", "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Sunday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" } },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritory",
+              "referenceId": "refTerritory",
+              "body": { "Name": "OldD9 Territory {{$timestamp}}", "OperatingHoursId": "@{refTerritoryOh.id}", "IsActive": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/WorkType",
+              "referenceId": "refWorkType",
+              "body": { "Name": "OldD9 WorkType {{$timestamp}}", "DurationType": "Minutes", "EstimatedDuration": 30 }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryWorkType",
+              "referenceId": "refStwt",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "WorkTypeId": "@{refWorkType.id}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAccount",
+              "body": { "Name": "OldD9 Account {{$timestamp}}" }
+            }
+          ]
+        }
+      ]
+    }
+scripts:
+  - type: afterResponse
+    code: |-
+      const responses = pm.response.json().graphs[0].graphResponse.compositeResponse;
+      responses.forEach((r) => {
+        if (r.httpStatusCode < 200 || r.httpStatusCode >= 300) {
+          throw new Error("OldD9 skeleton step " + r.referenceId + " failed: " + JSON.stringify(r.body));
+        }
+      });
+      const byRef = {};
+      responses.forEach(r => { byRef[r.referenceId] = r.body && r.body.id; });
+      pm.environment.set("oldD9TerritoryId", byRef["refTerritory"]);
+      pm.environment.set("oldD9WorkTypeId", byRef["refWorkType"]);
+      pm.environment.set("oldD9AccountId", byRef["refAccount"]);
+      pm.environment.set("oldD9MemberOhId", byRef["refMemberOh"]);
+    language: text/javascript
+order: 10000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/sharing-split-helper/15-create-resource-as-manager.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/sharing-split-helper/15-create-resource-as-manager.request.yaml
@@ -1,0 +1,32 @@
+$kind: http-request
+description: >-
+  OLD Decision-9 — the MANAGER persona creates the ServiceResource (per-request auth override to
+  {{oldD9ManagerToken}}, so the manager OWNS it — OwnerId=manager, LIVE-VERIFIED). This manager-owned
+  ServiceResource (OWD=Private) is the sharing-gate PARENT: the classic engine's user-mode STM read
+  (ShiftsDbUtil SystemMode.NONE) only returns the STM whose ServiceResource is shared to the running user,
+  so a case-worker without sharing on this resource reads zero slots. ResourceType=T, IsPrimary, on the
+  admin-created resource-owner user ({{oldD9ResourceUserId}}, which holds lightningSchedulerUserAccess).
+  Sets oldD9ResourceId.
+url: "{{baseUrl}}{{versionPath}}/sobjects/ServiceResource"
+method: POST
+headers:
+  Content-Type: application/json
+auth:
+  type: bearer
+  credentials:
+    token: "{{oldD9ManagerToken}}"
+body:
+  type: json
+  content: |-
+    {
+      "Name": "OldD9 Resource {{$timestamp}}",
+      "RelatedRecordId": "{{oldD9ResourceUserId}}",
+      "ResourceType": "T",
+      "IsActive": true,
+      "IsPrimary": true
+    }
+scripts:
+  - type: afterResponse
+    code: pm.environment.set("oldD9ResourceId", pm.response.json().id);
+    language: text/javascript
+order: 15000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/sharing-split-helper/20-create-stm-and-shift.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/sharing-split-helper/20-create-stm-and-shift.request.yaml
@@ -1,0 +1,48 @@
+$kind: http-request
+description: >-
+  OLD Decision-9 — ADMIN creates the STM + Confirmed Shift on the manager-owned ServiceResource, via
+  /composite/batch (independent subrequests; dodges the composite-graph unmarshallers). Admin creates them
+  because a non-admin persona cannot insert ServiceTerritoryMember and cannot reference the admin-owned
+  Private ServiceTerritory on a Shift (INSUFFICIENT_ACCESS_ON_CROSS_REFERENCE — both LIVE-OBSERVED). The STM
+  (TerritoryType=P, effective ~30 days ago) is ControlledByParent, so it inherits the manager-owned
+  ServiceResource's Private sharing — the actual user-mode gate. The Shift (08:00-16:00 tomorrow, NO
+  SchedulingMethod: the scheduler org schema lacks it) is read full-access by the classic engine, so its
+  owner is immaterial to the gate. Sets oldD9StmId / oldD9ShiftId.
+url: "{{baseUrl}}{{versionPath}}/composite/batch"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+body:
+  type: json
+  content: |-
+    {
+      "batchRequests": [
+        { "method": "POST", "url": "{{versionPath}}/sobjects/ServiceTerritoryMember", "richInput": { "ServiceTerritoryId": "{{oldD9TerritoryId}}", "ServiceResourceId": "{{oldD9ResourceId}}", "TerritoryType": "P", "OperatingHoursId": "{{oldD9MemberOhId}}", "EffectiveStartDate": "{{oldD9StmEffectiveStart}}" } },
+        { "method": "POST", "url": "{{versionPath}}/sobjects/Shift", "richInput": { "ServiceResourceId": "{{oldD9ResourceId}}", "ServiceTerritoryId": "{{oldD9TerritoryId}}", "StartTime": "{{oldD9ShiftStart}}", "EndTime": "{{oldD9ShiftEnd}}", "Status": "Confirmed", "TimeSlotType": "Normal" } }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      const monthAgo = new Date();
+      monthAgo.setUTCMonth(monthAgo.getUTCMonth() - 1);
+      pm.environment.set("oldD9StmEffectiveStart", monthAgo.toISOString());
+      const s = new Date(); s.setUTCDate(s.getUTCDate() + 1); s.setUTCHours(8,0,0,0);
+      const e = new Date(s.getTime()); e.setUTCHours(16,0,0,0);
+      pm.environment.set("oldD9ShiftStart", s.toISOString());
+      pm.environment.set("oldD9ShiftEnd", e.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      const data = pm.response.json() || {};
+      const results = data.results || [];
+      results.forEach((r, i) => {
+        if (r.statusCode < 200 || r.statusCode >= 300) {
+          throw new Error("OldD9 STM/Shift subrequest " + i + " failed: " + JSON.stringify(r.result));
+        }
+      });
+      pm.environment.set("oldD9StmId", (results[0].result || {}).id);
+      pm.environment.set("oldD9ShiftId", (results[1].result || {}).id);
+    language: text/javascript
+order: 20000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/skills-helper/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/skills-helper/.resources/definition.yaml
@@ -1,0 +1,16 @@
+$kind: collection
+description: |-
+  OLD Scheduler-org SKILLS-helper fixture (skills analogue of the double-book fixture, retargeted to the
+  scheduler org and admin session). The WorkType REQUIRES a master Skill (SkillRequirement); resourceA
+  holds a ServiceResourceSkill for it (skilled), resourceB holds NONE (unskilled). Territory OH 08-16;
+  BOTH resources get member OH + Confirmed Shift 08-16 covering tomorrow 11:00-11:30 — so Availability is
+  clean for BOTH and the ONLY dimension on which resourceB differs is its MISSING skill. Standard objects,
+  so the same graph builds on the scheduler org. NO SchedulingMethod field (this org's TimeSlot/Shift
+  schema lacks it → INVALID_FIELD). Sets sched{Territory,WorkType,Account,ResourceA,ResourceB}Id +
+  schedSkillId (from the preceding create-skill step).
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000040
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/skills-helper/05-create-skill.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/skills-helper/05-create-skill.request.yaml
@@ -1,0 +1,34 @@
+$kind: http-request
+description: >-
+  Creates the master Skill in its OWN transaction, BEFORE the main data graph. Skill (keyPrefix 0C5, the
+  LiveAgent setupEntity the scheduling FKs point at) is a SETUP object; the rest of the fixture (Account,
+  ServiceResource, ServiceTerritory, TimeSlots, Shifts, SkillRequirement, ServiceResourceSkill) are
+  NON-setup objects. Salesforce forbids setup + non-setup DML in the SAME transaction
+  (MIXED_DML_OPERATION), so the Skill cannot live inside the composite/graph that builds everything else —
+  it would roll the whole graph back. Runs under {{adminToken}} (the scheduler-org admin session), which
+  satisfies Skill.createAccess (CustomizeApplication || isDoingSysAdmin). Sets schedSkillId, which
+  create-skills-helper-graph then FK-references from SkillRequirement (RelatedRecordId=WorkType) and
+  resourceA's ServiceResourceSkill (both non-setup platform entities — FK-referencing a setup object is
+  not setup DML, so they stay inside the graph). Clone of the WFS create-skill step, retargeted to the
+  scheduler admin session.
+url: "{{baseUrl}}{{versionPath}}/sobjects/Skill"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: json
+  content: |-
+    {
+      "MasterLabel": "SchedSkill {{$timestamp}}",
+      "DeveloperName": "SchedSkill_{{$timestamp}}"
+    }
+scripts:
+  - type: afterResponse
+    code: |-
+      const jsonData = pm.response.json();
+      if (!jsonData.success) {
+        throw new Error("Skill create failed: " + JSON.stringify(jsonData.errors || jsonData));
+      }
+      pm.environment.set("schedSkillId", jsonData.id);
+    language: text/javascript
+order: 250

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/skills-helper/10-create-skills-helper-graph.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/skills-helper/10-create-skills-helper-graph.request.yaml
@@ -1,0 +1,307 @@
+$kind: http-request
+description: >-
+  OLD scheduler-org SKILLS-helper data graph (skills analogue of create-double-book-graph, retargeted to
+  the scheduler org + adminToken). Builds the graph in one composite/graph call as {{adminToken}}.
+  Territory OH 08-16 (Mon-Sun), a WorkType (OnSite, 30m) + STWT, an Account, and ONE SkillRequirement
+  linking the WorkType to the master Skill created in the preceding 05-create-skill step
+  ({{schedSkillId}}) — so the WorkType REQUIRES that skill. TWO User-backed ServiceResources on DISTINCT
+  users (ServiceResource is DB-unique on (RelatedRecordId, ResourceType)): the graph MINTS two FRESH
+  timestamped users per run up front (refUserA/refUserB, on the org's Standard User profile
+  00exx000000n0KyAAI) and points resourceA/resourceB RelatedRecordId at @{refUserA.id}/@{refUserB.id} — so
+  the SR uniqueness key never collides (the proven WFS create-case-worker pattern). BOTH are PRIMARY
+  ServiceTerritoryMembers (TerritoryType=P) effective a month ago, and — UNLIKE the double-book fixture —
+  BOTH carry the SAME wide member OH 08-16 and the SAME Confirmed Shift 08-16 covering tomorrow, so
+  Availability is CLEAN for BOTH resources at the 11:00-11:30 window. The ONLY dimension on which
+  resourceB differs is its MISSING skill:
+    - resourceA: gets a ServiceResourceSkill for {{schedSkillId}} (open-ended, month-ago effective) → it
+      HOLDS the WorkType's required skill → skilled + clean.
+    - resourceB: gets NO ServiceResourceSkill → it LACKS the required skill → the Skills rule is the ONLY
+      rule that can exclude it.
+  Because the old engine's MULTI-resource path skill-checks the PRIMARY resource ONLY
+  (MultiResourceTimeSlotProcessor48.shouldMatchSkills returns true iff serviceResourceId==primaryResourceId),
+  B-as-NON-primary-helper is never skill-checked on the multi path → it ESCAPES the Skills rule (parity
+  with 264's helper-escapes, via a different mechanism). The SINGLE-resource path skill-checks the lone
+  resource (SingleResourceTimeSlotProcessor inherits the default shouldMatchSkills), so naming skill-less
+  resourceB as the SOLE required resource EXCLUDES it → 0 slots (proving the old engine HAS the Skills
+  rule), while naming skilled resourceA alone offers slots. NO SchedulingMethod field (this org's
+  TimeSlot/Shift schema lacks it → INVALID_FIELD). Sets schedTerritoryId / schedWorkTypeId /
+  schedAccountId / schedResourceAId / schedResourceBId (schedSkillId comes from 05-create-skill).
+url: "{{baseUrl}}{{versionPath}}/composite/graph"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: json
+  content: |-
+    {
+      "graphs": [
+        {
+          "graphId": "skillsHelper",
+          "compositeRequest": [
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/User",
+              "referenceId": "refUserA",
+              "body": {
+                "Username": "{{schedUserAName}}",
+                "ProfileId": "00exx000000n0KyAAI",
+                "Alias": "sres-a",
+                "Email": "{{schedUserAName}}",
+                "EmailEncodingKey": "ISO-8859-1",
+                "LastName": "ResourceA",
+                "FirstName": "Skills",
+                "LanguageLocaleKey": "en_US",
+                "LocaleSidKey": "en_US",
+                "TimeZoneSidKey": "Asia/Kolkata"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/User",
+              "referenceId": "refUserB",
+              "body": {
+                "Username": "{{schedUserBName}}",
+                "ProfileId": "00exx000000n0KyAAI",
+                "Alias": "sres-b",
+                "Email": "{{schedUserBName}}",
+                "EmailEncodingKey": "ISO-8859-1",
+                "LastName": "ResourceB",
+                "FirstName": "Skills",
+                "LanguageLocaleKey": "en_US",
+                "LocaleSidKey": "en_US",
+                "TimeZoneSidKey": "Asia/Kolkata"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refTerritoryOh",
+              "body": { "Name": "Skills Territory OH {{$timestamp}}", "TimeZone": "GMT" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refMemberOh",
+              "body": { "Name": "Skills Member OH {{$timestamp}}", "TimeZone": "GMT" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsMon",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Monday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsTue",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Tuesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsWed",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Wednesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsThu",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Thursday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsFri",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Friday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsSat",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Saturday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsSun",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Sunday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsMon",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Monday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsTue",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Tuesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsWed",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Wednesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsThu",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Thursday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsFri",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Friday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsSat",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Saturday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsSun",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Sunday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritory",
+              "referenceId": "refTerritory",
+              "body": { "Name": "Skills Territory {{$timestamp}}", "OperatingHoursId": "@{refTerritoryOh.id}", "IsActive": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/WorkType",
+              "referenceId": "refWorkType",
+              "body": { "Name": "Skills WorkType {{$timestamp}}", "DurationType": "Minutes", "EstimatedDuration": 30 }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryWorkType",
+              "referenceId": "refStwt",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "WorkTypeId": "@{refWorkType.id}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/SkillRequirement",
+              "referenceId": "refSkillRequirement",
+              "body": { "RelatedRecordId": "@{refWorkType.id}", "SkillId": "{{schedSkillId}}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceResource",
+              "referenceId": "refResourceA",
+              "body": { "Name": "Skills Resource A {{$timestamp}}", "RelatedRecordId": "@{refUserA.id}", "ResourceType": "T", "IsActive": true, "IsPrimary": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceResource",
+              "referenceId": "refResourceB",
+              "body": { "Name": "Skills Resource B {{$timestamp}}", "RelatedRecordId": "@{refUserB.id}", "ResourceType": "T", "IsActive": true, "IsPrimary": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceResourceSkill",
+              "referenceId": "refResourceASkill",
+              "body": { "ServiceResourceId": "@{refResourceA.id}", "SkillId": "{{schedSkillId}}", "EffectiveStartDate": "{{skillsStmEffectiveStart}}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryMember",
+              "referenceId": "refStmA",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "ServiceResourceId": "@{refResourceA.id}", "TerritoryType": "P", "OperatingHoursId": "@{refMemberOh.id}", "EffectiveStartDate": "{{skillsStmEffectiveStart}}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryMember",
+              "referenceId": "refStmB",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "ServiceResourceId": "@{refResourceB.id}", "TerritoryType": "P", "OperatingHoursId": "@{refMemberOh.id}", "EffectiveStartDate": "{{skillsStmEffectiveStart}}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Shift",
+              "referenceId": "refShiftA",
+              "body": { "ServiceResourceId": "@{refResourceA.id}", "ServiceTerritoryId": "@{refTerritory.id}", "StartTime": "{{skillsShiftStart}}", "EndTime": "{{skillsShiftEnd}}", "TimeSlotType": "Normal", "Status": "Confirmed" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Shift",
+              "referenceId": "refShiftB",
+              "body": { "ServiceResourceId": "@{refResourceB.id}", "ServiceTerritoryId": "@{refTerritory.id}", "StartTime": "{{skillsShiftStart}}", "EndTime": "{{skillsShiftEnd}}", "TimeSlotType": "Normal", "Status": "Confirmed" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAccount",
+              "body": { "Name": "Skills Account {{$timestamp}}" }
+            }
+          ]
+        }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      // Mint FRESH timestamped users per run so the two ServiceResource rows never collide on the
+      // (RelatedRecordId, ResourceType) DB-unique key (the proven WFS create-case-worker pattern —
+      // fixed pre-existing users already own a ResourceType='T' SR → both inserts DUPLICATE_VALUE and the
+      // whole graph rolls back). The graph creates these users up front (refUserA/refUserB) and the
+      // ServiceResources point RelatedRecordId at @{refUserA.id}/@{refUserB.id}.
+      pm.environment.set("schedUserAName", pm.variables.replaceIn("sched-skills-a-{{$timestamp}}@revoman.org"));
+      pm.environment.set("schedUserBName", pm.variables.replaceIn("sched-skills-b-{{$timestamp}}@revoman.org"));
+      // STM + ServiceResourceSkill effective from a month ago (open-ended) so both validate over the window.
+      const monthAgo = new Date();
+      monthAgo.setUTCMonth(monthAgo.getUTCMonth() - 1);
+      pm.environment.set("skillsStmEffectiveStart", monthAgo.toISOString());
+      // BOTH resources carry the SAME wide member OH (08-16) and the SAME Confirmed Shift (08-16) covering
+      // tomorrow, so Availability (the UNION of member OH and Shift) is clean for BOTH at the 11:00-11:30
+      // window — UNLIKE the double-book fixture there is NO availability difference. The ONLY dimension on
+      // which resourceB differs is its MISSING ServiceResourceSkill. Since W-22901809 a Shift is
+      // unconditionally required for a resource to be admitted as a candidate, so resourceB ALSO gets a
+      // Shift → it is admitted, and the Skills rule (single-resource path) actually gets to evaluate and
+      // veto it; on the multi-resource path it is a non-primary helper and is NOT skill-checked at all.
+      const shiftStart = new Date();
+      shiftStart.setUTCDate(shiftStart.getUTCDate() + 1);
+      shiftStart.setUTCHours(8, 0, 0, 0);
+      const shiftEnd = new Date(shiftStart.getTime());
+      shiftEnd.setUTCHours(16, 0, 0, 0);
+      pm.environment.set("skillsShiftStart", shiftStart.toISOString());
+      pm.environment.set("skillsShiftEnd", shiftEnd.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      const jsonData = pm.response.json();
+      const responses = jsonData.graphs[0].graphResponse.compositeResponse;
+      // A rolled-back graph turns EVERY step's httpStatusCode to 400 (PROCESSING_HALTED for the bystanders,
+      // the real errorCode on the offending step), so this per-step check reliably fails the step on any
+      // rollback instead of the graph passing vacuously. (v67 composite/graph carries NO graph-level
+      // isSuccessful flag, so the per-step status IS the signal.)
+      responses.forEach((r) => {
+        if (r.httpStatusCode < 200 || r.httpStatusCode >= 300) {
+          throw new Error("Composite step " + r.referenceId + " failed: " + JSON.stringify(r.body));
+        }
+      });
+      const byRef = {};
+      responses.forEach(r => { byRef[r.referenceId] = r.body && r.body.id; });
+      pm.environment.set("schedTerritoryId", byRef["refTerritory"]);
+      pm.environment.set("schedWorkTypeId", byRef["refWorkType"]);
+      pm.environment.set("schedAccountId", byRef["refAccount"]);
+      pm.environment.set("schedResourceAId", byRef["refResourceA"]);
+      pm.environment.set("schedResourceBId", byRef["refResourceB"]);
+      // schedSkillId is set by the preceding 05-create-skill step (Skill is a SETUP object and cannot share
+      // this non-setup graph's transaction — MIXED_DML_OPERATION), so it is NOT in this graph response; do
+      // not overwrite it here.
+      pm.environment.set("schedSkillRequirementId", byRef["refSkillRequirement"]);
+      pm.environment.set("schedResourceASkillId", byRef["refResourceASkill"]);
+      pm.environment.set("schedMemberOhId", byRef["refMemberOh"]);
+      pm.environment.set("schedTerritoryOhId", byRef["refTerritoryOh"]);
+      pm.environment.set("schedShiftAId", byRef["refShiftA"]);
+      pm.environment.set("schedShiftBId", byRef["refShiftB"]);
+      pm.environment.set("schedStwtId", byRef["refStwt"]);
+    language: text/javascript
+order: 500

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/territory-helper/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/territory-helper/.resources/definition.yaml
@@ -1,0 +1,19 @@
+$kind: collection
+description: |-
+  OLD Scheduler-org TERRITORY-helper data graph (clone of the WFS Unified territory-non-required fixture,
+  retargeted to the scheduler org and admin session, and to the classic OH∪Shift availability model). ONE
+  Territory OH 08-16; ONE member OH 08-16 shared by both resources; resourceA + resourceB each get a
+  Confirmed Shift 08-16 tomorrow, so BOTH are fully AVAILABLE across the 11:30-12:30 straddle-noon window
+  (availability is NOT the discriminator — only territory coverage is). Both are PRIMARY
+  ServiceTerritoryMembers effective a month ago, created OPEN-ENDED so the full-day Shift inserts validate;
+  a SEPARATE follow-up PATCH then narrows resourceB's membership to END at noon → PARTIAL over the
+  straddle-noon window (covers the morning, not the afternoon), so only the territory/STM-coverage filter
+  can exclude resourceB. Standard objects, so the same graph books on the scheduler org. Mints two FRESH
+  timestamped users per run (SR is DB-unique on (RelatedRecordId, ResourceType)). Sets
+  sched{Territory,WorkType,Account,ResourceA,ResourceB}Id + schedResourceBStmId.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000110
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/territory-helper/10-set-resource-b-territory-membership-effective-end.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/territory-helper/10-set-resource-b-territory-membership-effective-end.request.yaml
@@ -1,0 +1,35 @@
+$kind: http-request
+description: >-
+  Narrows resourceB's ServiceTerritoryMember (created open-ended in the graph) to END at noon (12:00 UTC) of
+  the search day (tomorrow), making resourceB's membership PARTIAL over the 11:30-12:30 booking window.
+  resourceA's membership is left open-ended (clean). Done as a SEPARATE PATCH after the Shift exists because
+  the Shift insert validator requires the Shift to be fully contained in the membership interval — a partial
+  membership at graph time would reject the full-day (08-16) Shift. An STM update does not re-run that shift
+  validation, so the partial membership lands while resourceB's full-day Shift survives. After this,
+  resourceB is still fully AVAILABLE (Shift + member OH cover the window) but its membership [month-ago,
+  noon] OVERLAPS but does NOT CONTAIN the straddle-noon booking window (noon < 12:30) — so only the classic
+  engine's territory/STM membership filter can exclude it. Runs under {{adminToken}} (created it in the
+  graph). Sequenced after the graph (order 500) within this fixture Kick by order 1000.
+url: "{{baseUrl}}{{versionPath}}/sobjects/ServiceTerritoryMember/{{schedResourceBStmId}}"
+method: PATCH
+headers:
+  Content-Type: application/json
+  Accept: application/json
+body:
+  type: json
+  content: |-
+    {
+      "EffectiveEndDate": "{{schedResourceBStmEffectiveEnd}}"
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      // EffectiveEndDate = noon (12:00 UTC) of the search day (tomorrow). resourceB's membership now covers
+      // the morning of the 08-16 day but not the afternoon, so it OVERLAPS but does not CONTAIN the
+      // 11:30-12:30 straddle-noon booking window.
+      const effectiveEnd = new Date();
+      effectiveEnd.setUTCDate(effectiveEnd.getUTCDate() + 1);
+      effectiveEnd.setUTCHours(12, 0, 0, 0);
+      pm.environment.set("schedResourceBStmEffectiveEnd", effectiveEnd.toISOString());
+    language: text/javascript
+order: 1000

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/territory-helper/create-territory-helper-graph.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/territory-helper/create-territory-helper-graph.request.yaml
@@ -1,0 +1,292 @@
+$kind: http-request
+description: >-
+  OLD scheduler-org TERRITORY-helper data graph (clone of the WFS Unified territory-non-required fixture,
+  retargeted to the scheduler org and adminToken, and to the classic OH∪Shift availability model). Builds
+  the graph in one composite/graph call as {{adminToken}}. ONE Territory OH 08-16 (weekly TimeSlots), ONE
+  member OH 08-16 shared by BOTH resources, a WorkType (OnSite, 60m) + STWT, an Account. TWO User-backed
+  ServiceResources on DISTINCT users (ServiceResource is DB-unique on (RelatedRecordId, ResourceType)): the
+  graph MINTS two FRESH timestamped users per run up front (refUserA/refUserB, on the org's Standard User
+  profile 00exx000000n0KyAAI) and points resourceA/resourceB RelatedRecordId at @{refUserA.id}/@{refUserB.id}
+  — so the SR uniqueness key never collides (the proven WFS create-case-worker pattern). Both resources are
+  PRIMARY ServiceTerritoryMembers (TerritoryType=P) effective a month ago, created OPEN-ENDED (no
+  EffectiveEndDate). Both get a Confirmed Shift 08-16 tomorrow. Because the classic engine's availability is
+  the UNION of member OH and Shift (bookable iff the window fits OH ∪ Shift), BOTH resources are fully
+  AVAILABLE across the 11:30-12:30 straddle-noon booking window — availability is NOT the discriminator here.
+  The ONLY thing that differs is territory coverage: a SEPARATE follow-up PATCH
+  (set-resource-b-territory-membership-effective-end) narrows resourceB's ServiceTerritoryMember to END at
+  noon (12:00) of the search day AFTER its Shift exists (an STM update does not re-run the Shift-containment
+  validation, so the full-day 08-16 Shift survives). resourceB's membership [month-ago, noon] then OVERLAPS
+  but does NOT CONTAIN the 11:30-12:30 window (noon < 12:30), so ONLY the classic engine's territory/STM
+  membership filter can exclude resourceB. resourceA's membership stays open-ended (clean, CONTAINS the
+  whole window). Because the classic engine's territory/STM filter runs only for REQUIRED resources, B-as-
+  helper (non-required) is never territory-checked → the SA books Success even though B's membership does not
+  cover the afternoon; B-as-required puts B in the slot-gen intersection → the partial membership drops the
+  straddle-noon window → no A∩B slot → SlotNotAvailable (the territory-proof control). Sets schedTerritoryId
+  / schedWorkTypeId / schedAccountId / schedResourceAId / schedResourceBId / schedResourceBStmId. No
+  SchedulingMethod field (scheduler org schema lacks it → INVALID_FIELD).
+url: "{{baseUrl}}{{versionPath}}/composite/graph"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: json
+  content: |-
+    {
+      "graphs": [
+        {
+          "graphId": "territoryHelper",
+          "compositeRequest": [
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/User",
+              "referenceId": "refUserA",
+              "body": {
+                "Username": "{{schedUserAName}}",
+                "ProfileId": "00exx000000n0KyAAI",
+                "Alias": "stres-a",
+                "Email": "{{schedUserAName}}",
+                "EmailEncodingKey": "ISO-8859-1",
+                "LastName": "ResourceA",
+                "FirstName": "Territory",
+                "LanguageLocaleKey": "en_US",
+                "LocaleSidKey": "en_US",
+                "TimeZoneSidKey": "Asia/Kolkata"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/User",
+              "referenceId": "refUserB",
+              "body": {
+                "Username": "{{schedUserBName}}",
+                "ProfileId": "00exx000000n0KyAAI",
+                "Alias": "stres-b",
+                "Email": "{{schedUserBName}}",
+                "EmailEncodingKey": "ISO-8859-1",
+                "LastName": "ResourceB",
+                "FirstName": "Territory",
+                "LanguageLocaleKey": "en_US",
+                "LocaleSidKey": "en_US",
+                "TimeZoneSidKey": "Asia/Kolkata"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refTerritoryOh",
+              "body": { "Name": "Territory Territory OH {{$timestamp}}", "TimeZone": "GMT" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refMemberOh",
+              "body": { "Name": "Territory Member OH {{$timestamp}}", "TimeZone": "GMT" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsMon",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Monday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsTue",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Tuesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsWed",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Wednesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsThu",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Thursday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsFri",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Friday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsSat",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Saturday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsSun",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Sunday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsMon",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Monday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsTue",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Tuesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsWed",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Wednesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsThu",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Thursday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsFri",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Friday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsSat",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Saturday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsSun",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Sunday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritory",
+              "referenceId": "refTerritory",
+              "body": { "Name": "Territory Territory {{$timestamp}}", "OperatingHoursId": "@{refTerritoryOh.id}", "IsActive": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/WorkType",
+              "referenceId": "refWorkType",
+              "body": { "Name": "Territory WorkType {{$timestamp}}", "DurationType": "Minutes", "EstimatedDuration": 60 }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryWorkType",
+              "referenceId": "refStwt",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "WorkTypeId": "@{refWorkType.id}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceResource",
+              "referenceId": "refResourceA",
+              "body": { "Name": "Territory Resource A {{$timestamp}}", "RelatedRecordId": "@{refUserA.id}", "ResourceType": "T", "IsActive": true, "IsPrimary": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceResource",
+              "referenceId": "refResourceB",
+              "body": { "Name": "Territory Resource B {{$timestamp}}", "RelatedRecordId": "@{refUserB.id}", "ResourceType": "T", "IsActive": true, "IsPrimary": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryMember",
+              "referenceId": "refStmA",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "ServiceResourceId": "@{refResourceA.id}", "TerritoryType": "P", "OperatingHoursId": "@{refMemberOh.id}", "EffectiveStartDate": "{{territoryStmEffectiveStart}}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryMember",
+              "referenceId": "refStmB",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "ServiceResourceId": "@{refResourceB.id}", "TerritoryType": "P", "OperatingHoursId": "@{refMemberOh.id}", "EffectiveStartDate": "{{territoryStmEffectiveStart}}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Shift",
+              "referenceId": "refShiftA",
+              "body": { "ServiceResourceId": "@{refResourceA.id}", "ServiceTerritoryId": "@{refTerritory.id}", "StartTime": "{{territoryShiftStart}}", "EndTime": "{{territoryShiftEnd}}", "TimeSlotType": "Normal", "Status": "Confirmed" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Shift",
+              "referenceId": "refShiftB",
+              "body": { "ServiceResourceId": "@{refResourceB.id}", "ServiceTerritoryId": "@{refTerritory.id}", "StartTime": "{{territoryShiftStart}}", "EndTime": "{{territoryShiftEnd}}", "TimeSlotType": "Normal", "Status": "Confirmed" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAccount",
+              "body": { "Name": "Territory Account {{$timestamp}}" }
+            }
+          ]
+        }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      // Mint FRESH timestamped users per run so the two ServiceResource rows never collide on the
+      // (RelatedRecordId, ResourceType) DB-unique key (the proven WFS create-case-worker pattern). The
+      // graph creates these users up front (refUserA/refUserB) and the ServiceResources point
+      // RelatedRecordId at @{refUserA.id}/@{refUserB.id}.
+      pm.environment.set("schedUserAName", pm.variables.replaceIn("sched-terr-a-{{$timestamp}}@revoman.org"));
+      pm.environment.set("schedUserBName", pm.variables.replaceIn("sched-terr-b-{{$timestamp}}@revoman.org"));
+      // BOTH ServiceTerritoryMembers effective from a month ago and created OPEN-ENDED (no
+      // EffectiveEndDate) so the Shift insert validator (Shift must be fully contained in the membership
+      // interval) accepts the full-day 08-16 Shift on BOTH resources. resourceB's membership is narrowed to
+      // end at noon by a SEPARATE follow-up PATCH AFTER its Shift exists (an STM update does not re-run the
+      // shift validation), making it PARTIAL over the straddle-noon booking window so the territory/STM
+      // membership filter drops it; resourceA's membership stays open-ended (clean).
+      const monthAgo = new Date();
+      monthAgo.setUTCMonth(monthAgo.getUTCMonth() - 1);
+      pm.environment.set("territoryStmEffectiveStart", monthAgo.toISOString());
+      // Confirmed Shift covering tomorrow 08:00-16:00 UTC for BOTH resources (member OH is also 08-16), so
+      // the OH∪Shift availability union spans the 11:30-12:30 window for BOTH — availability is NOT the
+      // discriminator. The ONLY difference is that resourceB's membership is later narrowed to end at noon,
+      // so only the classic engine's territory/STM-coverage filter can exclude resourceB.
+      const shiftStart = new Date();
+      shiftStart.setUTCDate(shiftStart.getUTCDate() + 1);
+      shiftStart.setUTCHours(8, 0, 0, 0);
+      const shiftEnd = new Date(shiftStart.getTime());
+      shiftEnd.setUTCHours(16, 0, 0, 0);
+      pm.environment.set("territoryShiftStart", shiftStart.toISOString());
+      pm.environment.set("territoryShiftEnd", shiftEnd.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      const jsonData = pm.response.json();
+      const responses = jsonData.graphs[0].graphResponse.compositeResponse;
+      // A rolled-back graph turns EVERY step's httpStatusCode to 400 (PROCESSING_HALTED for the bystanders,
+      // the real errorCode on the offending step), so this per-step check reliably fails the step on any
+      // rollback instead of the graph passing vacuously. (This scheduler org's composite/graph response at
+      // v67 carries NO graph-level isSuccessful flag, so the per-step status IS the signal.)
+      responses.forEach((r) => {
+        if (r.httpStatusCode < 200 || r.httpStatusCode >= 300) {
+          throw new Error("Composite step " + r.referenceId + " failed: " + JSON.stringify(r.body));
+        }
+      });
+      const byRef = {};
+      responses.forEach(r => { byRef[r.referenceId] = r.body && r.body.id; });
+      pm.environment.set("schedTerritoryId", byRef["refTerritory"]);
+      pm.environment.set("schedWorkTypeId", byRef["refWorkType"]);
+      pm.environment.set("schedAccountId", byRef["refAccount"]);
+      pm.environment.set("schedResourceAId", byRef["refResourceA"]);
+      pm.environment.set("schedResourceBId", byRef["refResourceB"]);
+      // resourceB's STM id is consumed by the narrowing PATCH (set-resource-b-territory-membership-effective-end).
+      pm.environment.set("schedResourceBStmId", byRef["refStmB"]);
+      pm.environment.set("schedResourceAStmId", byRef["refStmA"]);
+      pm.environment.set("schedMemberOhId", byRef["refMemberOh"]);
+      pm.environment.set("schedTerritoryOhId", byRef["refTerritoryOh"]);
+      pm.environment.set("schedShiftAId", byRef["refShiftA"]);
+      pm.environment.set("schedShiftBId", byRef["refShiftB"]);
+      pm.environment.set("schedStwtId", byRef["refStwt"]);
+    language: text/javascript
+order: 500

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/two-primary-helper/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/two-primary-helper/.resources/definition.yaml
@@ -1,0 +1,16 @@
+$kind: collection
+description: |-
+  OLD Scheduler-org two-primary (Decision 4) data graph. A clone of the double-book fixture retargeted so
+  BOTH resources are FULLY AVAILABLE at the 11:00-11:30 booking window (member OH + Confirmed Shift 10-14
+  for A AND B) — unlike double-book (where B is busy at 11:00). Both are PRIMARY-eligible
+  ServiceTerritoryMembers (TerritoryType=P). The clean availability is deliberate: Decision 4 is about the
+  "at most one primary AssignedResource per ServiceAppointment" rule, NOT availability — so with two clean,
+  free resources the ONLY thing that can refuse the two-primary book is the primary-count/save constraint,
+  and the one-primary control (A primary + B non-primary, both free) BOOKS to prove the fixture is live.
+  Sets sched{Territory,WorkType,Account,ResourceA,ResourceB}Id (shared with the double-book book acts).
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000040
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/two-primary-helper/create-two-primary-graph.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/two-primary-helper/create-two-primary-graph.request.yaml
@@ -1,0 +1,319 @@
+$kind: http-request
+description: >-
+  OLD scheduler-org two-primary (Decision 4) data graph. Clone of the double-book graph, retargeted so BOTH
+  resources are FULLY AVAILABLE at the 11:00-11:30 window: member OH + Confirmed Shift 10:00-14:00 for A AND
+  B (double-book made B 12-14 / busy; here B is free too). Builds the graph in one composite/graph call as
+  {{adminToken}}. Territory OH 08-16, a WorkType (OnSite, 30m) + STWT, an Account. TWO User-backed
+  ServiceResources on DISTINCT fresh timestamped users (ServiceResource is DB-unique on (RelatedRecordId,
+  ResourceType) → the graph MINTS refUserA/refUserB per run on the org's Standard User profile
+  00exx000000n0KyAAI so the SR uniqueness key never collides). BOTH are PRIMARY ServiceTerritoryMembers
+  (TerritoryType=P) effective a month ago. Because Decision 4 refuses on the primary-COUNT / AssignedResource
+  save constraint (not availability), both resources are clean+free so the ONLY refuser of a two-primary book
+  is that constraint, and the one-primary control (A primary + B non-primary, both free) BOOKS. Sets
+  schedTerritoryId / schedWorkTypeId / schedAccountId / schedResourceAId / schedResourceBId.
+url: "{{baseUrl}}{{versionPath}}/composite/graph"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: json
+  content: |-
+    {
+      "graphs": [
+        {
+          "graphId": "twoPrimary",
+          "compositeRequest": [
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/User",
+              "referenceId": "refUserA",
+              "body": {
+                "Username": "{{schedUserAName}}",
+                "ProfileId": "00exx000000n0KyAAI",
+                "Alias": "sres-a",
+                "Email": "{{schedUserAName}}",
+                "EmailEncodingKey": "ISO-8859-1",
+                "LastName": "ResourceA",
+                "FirstName": "TwoPrim",
+                "LanguageLocaleKey": "en_US",
+                "LocaleSidKey": "en_US",
+                "TimeZoneSidKey": "Asia/Kolkata"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/User",
+              "referenceId": "refUserB",
+              "body": {
+                "Username": "{{schedUserBName}}",
+                "ProfileId": "00exx000000n0KyAAI",
+                "Alias": "sres-b",
+                "Email": "{{schedUserBName}}",
+                "EmailEncodingKey": "ISO-8859-1",
+                "LastName": "ResourceB",
+                "FirstName": "TwoPrim",
+                "LanguageLocaleKey": "en_US",
+                "LocaleSidKey": "en_US",
+                "TimeZoneSidKey": "Asia/Kolkata"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refTerritoryOh",
+              "body": { "Name": "TwoPrim Territory OH {{$timestamp}}", "TimeZone": "GMT" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refMemberOhA",
+              "body": { "Name": "TwoPrim Member OH A {{$timestamp}}", "TimeZone": "GMT" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refMemberOhB",
+              "body": { "Name": "TwoPrim Member OH B {{$timestamp}}", "TimeZone": "GMT" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsMon",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Monday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsTue",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Tuesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsWed",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Wednesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsThu",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Thursday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsFri",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Friday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsSat",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Saturday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsSun",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Sunday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsMon",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Monday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsTue",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Tuesday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsWed",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Wednesday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsThu",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Thursday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsFri",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Friday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsSat",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Saturday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberAtsSun",
+              "body": { "OperatingHoursId": "@{refMemberOhA.id}", "DayOfWeek": "Sunday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberBtsMon",
+              "body": { "OperatingHoursId": "@{refMemberOhB.id}", "DayOfWeek": "Monday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberBtsTue",
+              "body": { "OperatingHoursId": "@{refMemberOhB.id}", "DayOfWeek": "Tuesday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberBtsWed",
+              "body": { "OperatingHoursId": "@{refMemberOhB.id}", "DayOfWeek": "Wednesday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberBtsThu",
+              "body": { "OperatingHoursId": "@{refMemberOhB.id}", "DayOfWeek": "Thursday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberBtsFri",
+              "body": { "OperatingHoursId": "@{refMemberOhB.id}", "DayOfWeek": "Friday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberBtsSat",
+              "body": { "OperatingHoursId": "@{refMemberOhB.id}", "DayOfWeek": "Saturday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberBtsSun",
+              "body": { "OperatingHoursId": "@{refMemberOhB.id}", "DayOfWeek": "Sunday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritory",
+              "referenceId": "refTerritory",
+              "body": { "Name": "TwoPrim Territory {{$timestamp}}", "OperatingHoursId": "@{refTerritoryOh.id}", "IsActive": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/WorkType",
+              "referenceId": "refWorkType",
+              "body": { "Name": "TwoPrim WorkType {{$timestamp}}", "DurationType": "Minutes", "EstimatedDuration": 30 }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryWorkType",
+              "referenceId": "refStwt",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "WorkTypeId": "@{refWorkType.id}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceResource",
+              "referenceId": "refResourceA",
+              "body": { "Name": "TwoPrim Resource A {{$timestamp}}", "RelatedRecordId": "@{refUserA.id}", "ResourceType": "T", "IsActive": true, "IsPrimary": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceResource",
+              "referenceId": "refResourceB",
+              "body": { "Name": "TwoPrim Resource B {{$timestamp}}", "RelatedRecordId": "@{refUserB.id}", "ResourceType": "T", "IsActive": true, "IsPrimary": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryMember",
+              "referenceId": "refStmA",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "ServiceResourceId": "@{refResourceA.id}", "TerritoryType": "P", "OperatingHoursId": "@{refMemberOhA.id}", "EffectiveStartDate": "{{twoPrimaryStmEffectiveStart}}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryMember",
+              "referenceId": "refStmB",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "ServiceResourceId": "@{refResourceB.id}", "TerritoryType": "P", "OperatingHoursId": "@{refMemberOhB.id}", "EffectiveStartDate": "{{twoPrimaryStmEffectiveStart}}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Shift",
+              "referenceId": "refShiftA",
+              "body": { "ServiceResourceId": "@{refResourceA.id}", "ServiceTerritoryId": "@{refTerritory.id}", "StartTime": "{{twoPrimaryShiftAStart}}", "EndTime": "{{twoPrimaryShiftAEnd}}", "TimeSlotType": "Normal", "Status": "Confirmed" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Shift",
+              "referenceId": "refShiftB",
+              "body": { "ServiceResourceId": "@{refResourceB.id}", "ServiceTerritoryId": "@{refTerritory.id}", "StartTime": "{{twoPrimaryShiftBStart}}", "EndTime": "{{twoPrimaryShiftBEnd}}", "TimeSlotType": "Normal", "Status": "Confirmed" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAccount",
+              "body": { "Name": "TwoPrim Account {{$timestamp}}" }
+            }
+          ]
+        }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      // Mint FRESH timestamped users per run so the two ServiceResource rows never collide on the
+      // (RelatedRecordId, ResourceType) DB-unique key (the proven WFS create-case-worker pattern).
+      pm.environment.set("schedUserAName", pm.variables.replaceIn("sched-2prim-a-{{$timestamp}}@revoman.org"));
+      pm.environment.set("schedUserBName", pm.variables.replaceIn("sched-2prim-b-{{$timestamp}}@revoman.org"));
+      // STM effective from a month ago (open-ended) so the Shifts validate.
+      const monthAgo = new Date();
+      monthAgo.setUTCMonth(monthAgo.getUTCMonth() - 1);
+      pm.environment.set("twoPrimaryStmEffectiveStart", monthAgo.toISOString());
+      // BOTH resources fully available at 11:00-11:30: member OH + Confirmed Shift 10:00-14:00 for A AND B.
+      // Decision 4 refuses on the primary-count / AssignedResource save constraint, NOT availability, so
+      // both resources are clean+free — the one-primary control books, and the ONLY refuser of the
+      // two-primary book is the "one primary per SA" constraint.
+      const shiftAStart = new Date();
+      shiftAStart.setUTCDate(shiftAStart.getUTCDate() + 1);
+      shiftAStart.setUTCHours(10, 0, 0, 0);
+      const shiftAEnd = new Date(shiftAStart.getTime());
+      shiftAEnd.setUTCHours(14, 0, 0, 0);
+      pm.environment.set("twoPrimaryShiftAStart", shiftAStart.toISOString());
+      pm.environment.set("twoPrimaryShiftAEnd", shiftAEnd.toISOString());
+      const shiftBStart = new Date();
+      shiftBStart.setUTCDate(shiftBStart.getUTCDate() + 1);
+      shiftBStart.setUTCHours(10, 0, 0, 0);
+      const shiftBEnd = new Date(shiftBStart.getTime());
+      shiftBEnd.setUTCHours(14, 0, 0, 0);
+      pm.environment.set("twoPrimaryShiftBStart", shiftBStart.toISOString());
+      pm.environment.set("twoPrimaryShiftBEnd", shiftBEnd.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      const jsonData = pm.response.json();
+      const responses = jsonData.graphs[0].graphResponse.compositeResponse;
+      // A rolled-back graph turns EVERY step's httpStatusCode non-2xx (PROCESSING_HALTED for the
+      // bystanders, the real errorCode on the offending step), so this per-step check reliably fails the
+      // step on any rollback instead of passing vacuously (this org's v67 composite/graph carries no
+      // graph-level isSuccessful flag, so the per-step status IS the signal).
+      responses.forEach((r) => {
+        if (r.httpStatusCode < 200 || r.httpStatusCode >= 300) {
+          throw new Error("Composite step " + r.referenceId + " failed: " + JSON.stringify(r.body));
+        }
+      });
+      const byRef = {};
+      responses.forEach(r => { byRef[r.referenceId] = r.body && r.body.id; });
+      pm.environment.set("schedTerritoryId", byRef["refTerritory"]);
+      pm.environment.set("schedWorkTypeId", byRef["refWorkType"]);
+      pm.environment.set("schedAccountId", byRef["refAccount"]);
+      pm.environment.set("schedResourceAId", byRef["refResourceA"]);
+      pm.environment.set("schedResourceBId", byRef["refResourceB"]);
+    language: text/javascript
+order: 500

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/workloc-helper/.resources/definition.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/workloc-helper/.resources/definition.yaml
@@ -1,0 +1,16 @@
+$kind: collection
+description: |-
+  OLD Scheduler-org WorkingLocations (territory-member ROLE) data graph for the 1d parity slice. Seeds a
+  PRIMARY-ONLY AppointmentSchedulingPolicy (ShouldUsePrimaryMembers=true, ShouldUseSecondaryMembers=false)
+  plus one territory (OH 08-16), a 60m OnSite WorkType + STWT, an Account, and TWO fresh-user-backed
+  ServiceResources: resourceA a PRIMARY member (TerritoryType='P') and resourceB a SECONDARY member
+  (TerritoryType='S'), both with wide member OH 08-16 + a Confirmed Shift 08-16 → both fully available at
+  11:00. Under the primary-only policy the classic STM filter drops the Secondary resourceB by its ROLE
+  (not availability, not non-member). Sets schedWl{PrimaryOnlyPolicy,Territory,WorkType,Account,ResourceA,
+  ResourceB}Id for the 1d read-decision + write diffs.
+auth:
+  - id: 7e1f0c00-1005-4aaa-9bbb-000000000110
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{adminToken}}"

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/workloc-helper/05-create-primary-only-policy.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/workloc-helper/05-create-primary-only-policy.request.yaml
@@ -1,0 +1,40 @@
+$kind: http-request
+description: >-
+  Seeds the PRIMARY-ONLY AppointmentSchedulingPolicy for the 1d WorkingLocations slice as a STANDALONE
+  /sobjects POST (its own transaction). AppointmentSchedulingPolicy is a SETUP object, so inserting it in
+  the SAME composite/graph as the non-setup fixture rows (Account / ServiceTerritory / ServiceResource /
+  Shift) trips MIXED_DML_OPERATION ("DML operation on setup object is not permitted after you have updated
+  a non-setup object") and rolls the whole graph back — LIVE-OBSERVED on this org. Splitting it into its
+  own request dodges that. Fields: ShouldUsePrimaryMembers=true + ShouldUseSecondaryMembers=false is the
+  ONLY behavioral difference from the org-default policy that matters — it makes the classic STM SOQL
+  filter emit `TerritoryType IN ('P','R')`, dropping any SECONDARY-only member. ShouldEnforceRequiredResource
+  =true matches the org default (and gives the required-control its refusal). AppointmentStartTimeInterval
+  ="15" is a required restrictedPicklist field. Both shift flags are OMITTED (default false → OH-mode), so
+  the wide member OH 08-16 keeps resourceA available and availability is never the blocker. IsOrgDefault is
+  not createable, so this policy applies only via an explicit schedulingPolicyId on the read/book acts; the
+  org default is untouched. Runs order 400 (before the data graph at 500). Captures schedWlPrimaryOnlyPolicyId.
+url: "{{baseUrl}}{{versionPath}}/sobjects/AppointmentSchedulingPolicy"
+method: POST
+headers:
+  Content-Type: application/json
+  Accept: application/json
+body:
+  type: json
+  content: |-
+    {
+      "DeveloperName": "WlPrimaryOnly{{$timestamp}}",
+      "MasterLabel": "WL Primary-Only {{$timestamp}}",
+      "ShouldUsePrimaryMembers": true,
+      "ShouldUseSecondaryMembers": false,
+      "ShouldEnforceRequiredResource": true,
+      "AppointmentStartTimeInterval": "15"
+    }
+scripts:
+  - type: afterResponse
+    code: |-
+      const data = pm.response.json() || {};
+      pm.environment.set("schedWlPrimaryOnlyPolicyId", data.id);
+      console.log("OLD workloc primary-only policy http=" + pm.response.code + " id=" + data.id +
+                  " body=" + JSON.stringify(data).slice(0,300));
+    language: text/javascript
+order: 400

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/workloc-helper/create-workloc-helper-graph.request.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/fixtures/workloc-helper/create-workloc-helper-graph.request.yaml
@@ -1,0 +1,304 @@
+$kind: http-request
+description: >-
+  OLD scheduler-org WorkingLocations (territory-member ROLE) data graph for the 1d helper-fitness parity
+  slice. Clone of the double-book fixture retargeted so the ONLY thing that disqualifies resourceB is its
+  SECONDARY territory-member ROLE under a PRIMARY-ONLY SchedulingPolicy — NOT availability (both resources
+  are fully available at the booked hour). The primary-only AppointmentSchedulingPolicy is seeded by the
+  SIBLING step 05-create-primary-only-policy (a standalone /sobjects POST — AppointmentSchedulingPolicy is
+  a SETUP object, so inserting it in the SAME composite/graph transaction as the non-setup Account /
+  Territory / ServiceResource rows triggers MIXED_DML_OPERATION; it must be its own transaction). That
+  policy sets ShouldUsePrimaryMembers=true, ShouldUseSecondaryMembers=false, ShouldEnforceRequiredResource=
+  true, AppointmentStartTimeInterval=15, both shift flags OMITTED (OH-mode). The classic engine reads these
+  booleans straight off the policy entity (SchedulingDbUtil.buildSchedulingPolicyConstraint) — no
+  SchedulingRule linkage needed, unlike the Unified WFS side. Under this policy the STM SOQL filter
+  (createPrimarySecondarySTMWhereCondition) emits `TerritoryType IN ('P','R')`, so a SECONDARY ('S') member
+  is dropped from the candidate pool on BOTH the getAppointmentSlots read and the service-appointments
+  availability check — the cleanest WorkingLocations isolation: resourceB IS a member (not a non-member
+  exclusion), its Secondary ROLE alone disqualifies it. IsOrgDefault is not createable, so this policy is
+  used only via an explicit schedulingPolicyId on the read/book acts; the org default (both members ON) is
+  untouched. This graph (order 500, after the policy seed at order 400) then builds, in one composite/graph
+  call as {{adminToken}}:
+    - Territory OH 08-16 (Mon-Sun), member OH 08-16 (Mon-Sun) — WIDE, covering the 11:00-12:00 window for
+      BOTH resources. WorkType (OnSite, 60m, matching the Unified WLSNR WorkType) + STWT, an Account.
+    - TWO User-backed ServiceResources on DISTINCT FRESH timestamped users minted up front
+      (refUserA/refUserB, org Standard User profile 00exx000000n0KyAAI) so the SR (RelatedRecordId,
+      ResourceType) DB-unique key never collides across runs.
+    - resourceA: PRIMARY ServiceTerritoryMember (TerritoryType='P') + Confirmed Shift 08-16 → passes the
+      primary-only member filter AND is available → offers slots / books.
+    - resourceB: SECONDARY ServiceTerritoryMember (TerritoryType='S') + Confirmed Shift 08-16 → fully
+      available at 11:00, but the PRIMARY-ONLY policy drops it from the STM candidate pool by its ROLE.
+  Because availability is checked ONLY for required resources, B-as-helper (non-required) is never even
+  reached by the required-eligibility path AND its Secondary role means it is not a candidate anyway → the
+  SA books Success (the WorkingLocations helper-escape claim). B-as-required puts B in the required
+  intersection, where the primary-only STM filter has already removed it → no A∩B slot at 11:00 →
+  refused (the ROLE-proof control). Sets schedWlTerritoryId / schedWlWorkTypeId / schedWlAccountId /
+  schedWlResourceAId / schedWlResourceBId (schedWlPrimaryOnlyPolicyId is set by the sibling policy-seed
+  step). In OH-mode the wide member OH 08-16 keeps resourceA available regardless of Shift, so availability
+  is never the blocker — the Secondary role is the ONLY reason B is excluded (Secondary-under-primary-only,
+  NOT non-member).
+url: "{{baseUrl}}{{versionPath}}/composite/graph"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: json
+  content: |-
+    {
+      "graphs": [
+        {
+          "graphId": "worklocHelper",
+          "compositeRequest": [
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/User",
+              "referenceId": "refUserA",
+              "body": {
+                "Username": "{{schedWlUserAName}}",
+                "ProfileId": "00exx000000n0KyAAI",
+                "Alias": "wlra",
+                "Email": "{{schedWlUserAName}}",
+                "EmailEncodingKey": "ISO-8859-1",
+                "LastName": "WlResourceA",
+                "FirstName": "WorkLoc",
+                "LanguageLocaleKey": "en_US",
+                "LocaleSidKey": "en_US",
+                "TimeZoneSidKey": "Asia/Kolkata"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/User",
+              "referenceId": "refUserB",
+              "body": {
+                "Username": "{{schedWlUserBName}}",
+                "ProfileId": "00exx000000n0KyAAI",
+                "Alias": "wlrb",
+                "Email": "{{schedWlUserBName}}",
+                "EmailEncodingKey": "ISO-8859-1",
+                "LastName": "WlResourceB",
+                "FirstName": "WorkLoc",
+                "LanguageLocaleKey": "en_US",
+                "LocaleSidKey": "en_US",
+                "TimeZoneSidKey": "Asia/Kolkata"
+              }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refTerritoryOh",
+              "body": { "Name": "WL Territory OH {{$timestamp}}", "TimeZone": "GMT" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/OperatingHours",
+              "referenceId": "refMemberOh",
+              "body": { "Name": "WL Member OH {{$timestamp}}", "TimeZone": "GMT" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsMon",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Monday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsTue",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Tuesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsWed",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Wednesday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsThu",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Thursday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsFri",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Friday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsSat",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Saturday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refTerritoryTsSun",
+              "body": { "OperatingHoursId": "@{refTerritoryOh.id}", "DayOfWeek": "Sunday", "Type": "Normal", "StartTime": "08:00:00.000Z", "EndTime": "16:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsMon",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Monday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsTue",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Tuesday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsWed",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Wednesday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsThu",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Thursday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsFri",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Friday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsSat",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Saturday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/TimeSlot",
+              "referenceId": "refMemberTsSun",
+              "body": { "OperatingHoursId": "@{refMemberOh.id}", "DayOfWeek": "Sunday", "Type": "Normal", "StartTime": "10:00:00.000Z", "EndTime": "14:00:00.000Z" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritory",
+              "referenceId": "refTerritory",
+              "body": { "Name": "WL Territory {{$timestamp}}", "OperatingHoursId": "@{refTerritoryOh.id}", "IsActive": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/WorkType",
+              "referenceId": "refWorkType",
+              "body": { "Name": "WL WorkType {{$timestamp}}", "DurationType": "Minutes", "EstimatedDuration": 30 }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryWorkType",
+              "referenceId": "refStwt",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "WorkTypeId": "@{refWorkType.id}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceResource",
+              "referenceId": "refResourceA",
+              "body": { "Name": "WL Resource A {{$timestamp}}", "RelatedRecordId": "@{refUserA.id}", "ResourceType": "T", "IsActive": true, "IsPrimary": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceResource",
+              "referenceId": "refResourceB",
+              "body": { "Name": "WL Resource B {{$timestamp}}", "RelatedRecordId": "@{refUserB.id}", "ResourceType": "T", "IsActive": true, "IsPrimary": true }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryMember",
+              "referenceId": "refStmA",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "ServiceResourceId": "@{refResourceA.id}", "TerritoryType": "P", "OperatingHoursId": "@{refMemberOh.id}", "EffectiveStartDate": "{{schedWlStmEffectiveStart}}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/ServiceTerritoryMember",
+              "referenceId": "refStmB",
+              "body": { "ServiceTerritoryId": "@{refTerritory.id}", "ServiceResourceId": "@{refResourceB.id}", "TerritoryType": "S", "OperatingHoursId": "@{refMemberOh.id}", "EffectiveStartDate": "{{schedWlStmEffectiveStart}}" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Shift",
+              "referenceId": "refShiftA",
+              "body": { "ServiceResourceId": "@{refResourceA.id}", "ServiceTerritoryId": "@{refTerritory.id}", "StartTime": "{{schedWlShiftStart}}", "EndTime": "{{schedWlShiftEnd}}", "TimeSlotType": "Normal", "Status": "Confirmed" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Shift",
+              "referenceId": "refShiftB",
+              "body": { "ServiceResourceId": "@{refResourceB.id}", "ServiceTerritoryId": "@{refTerritory.id}", "StartTime": "{{schedWlShiftStart}}", "EndTime": "{{schedWlShiftEnd}}", "TimeSlotType": "Normal", "Status": "Confirmed" }
+            },
+            {
+              "method": "POST",
+              "url": "{{versionPath}}/sobjects/Account",
+              "referenceId": "refAccount",
+              "body": { "Name": "WL Account {{$timestamp}}" }
+            }
+          ]
+        }
+      ]
+    }
+scripts:
+  - type: beforeRequest
+    code: |-
+      // Mint FRESH timestamped users per run so the two ServiceResource rows never collide on the
+      // (RelatedRecordId, ResourceType) DB-unique key (the proven WFS create-case-worker pattern). The
+      // graph creates these users up front (refUserA/refUserB) and the ServiceResources point
+      // RelatedRecordId at @{refUserA.id}/@{refUserB.id}.
+      pm.environment.set("schedWlUserAName", pm.variables.replaceIn("sched-wl-a-{{$timestamp}}@revoman.org"));
+      pm.environment.set("schedWlUserBName", pm.variables.replaceIn("sched-wl-b-{{$timestamp}}@revoman.org"));
+      // Both STMs effective from a month ago (open-ended) so the full-day 08-16 Shifts validate against
+      // the membership interval.
+      const monthAgo = new Date();
+      monthAgo.setUTCMonth(monthAgo.getUTCMonth() - 1);
+      pm.environment.set("schedWlStmEffectiveStart", monthAgo.toISOString());
+      // Confirmed Shift covering tomorrow 10:00-14:00 UTC for BOTH resources, matching the proven 1.5
+      // double-book resourceA window (member OH 10-14 + Shift 10-14) which LIVE-returns slots at 11:00 on
+      // this org. Both resources are unambiguously available at 11:00-11:30; the ONLY thing that excludes
+      // resourceB is its SECONDARY territory-member ROLE under the primary-only policy (availability is
+      // never the blocker).
+      const shiftStart = new Date();
+      shiftStart.setUTCDate(shiftStart.getUTCDate() + 1);
+      shiftStart.setUTCHours(10, 0, 0, 0);
+      const shiftEnd = new Date(shiftStart.getTime());
+      shiftEnd.setUTCHours(14, 0, 0, 0);
+      pm.environment.set("schedWlShiftStart", shiftStart.toISOString());
+      pm.environment.set("schedWlShiftEnd", shiftEnd.toISOString());
+    language: text/javascript
+  - type: afterResponse
+    code: |-
+      const jsonData = pm.response.json();
+      const responses = jsonData.graphs[0].graphResponse.compositeResponse;
+      // A rolled-back graph turns EVERY step's httpStatusCode to 400 (PROCESSING_HALTED for the
+      // bystanders, the real errorCode on the offending step), so this per-step check reliably fails the
+      // step on any rollback instead of the graph passing vacuously (this scheduler org's composite/graph
+      // response at v67 carries NO graph-level isSuccessful flag, so the per-step status IS the signal).
+      responses.forEach((r) => {
+        if (r.httpStatusCode < 200 || r.httpStatusCode >= 300) {
+          throw new Error("Composite step " + r.referenceId + " failed: " + JSON.stringify(r.body));
+        }
+      });
+      const byRef = {};
+      responses.forEach(r => { byRef[r.referenceId] = r.body && r.body.id; });
+      pm.environment.set("schedWlTerritoryId", byRef["refTerritory"]);
+      pm.environment.set("schedWlWorkTypeId", byRef["refWorkType"]);
+      pm.environment.set("schedWlAccountId", byRef["refAccount"]);
+      pm.environment.set("schedWlResourceAId", byRef["refResourceA"]);
+      pm.environment.set("schedWlResourceBId", byRef["refResourceB"]);
+      // The SHARED grant-ls-user-access Kick (reused AS-IS per the brief) looks up each resource's backing
+      // User by the env names schedResourceAId / schedResourceBId (the double-book fixture's names). Export
+      // those aliases so the grant works unchanged — without them the grant queries empty ids, grants no
+      // Lightning-Scheduler access, and the classic engine prunes BOTH resources → an all-0 dead read.
+      pm.environment.set("schedResourceAId", byRef["refResourceA"]);
+      pm.environment.set("schedResourceBId", byRef["refResourceB"]);
+      pm.environment.set("schedWlMemberOhId", byRef["refMemberOh"]);
+      pm.environment.set("schedWlTerritoryOhId", byRef["refTerritoryOh"]);
+      pm.environment.set("schedWlShiftAId", byRef["refShiftA"]);
+      pm.environment.set("schedWlShiftBId", byRef["refShiftB"]);
+      pm.environment.set("schedWlStwtId", byRef["refStwt"]);
+    language: text/javascript
+order: 500

--- a/src/integrationTest/resources/pm-templates/v3/core/scheduler/scheduler.environment.yaml
+++ b/src/integrationTest/resources/pm-templates/v3/core/scheduler/scheduler.environment.yaml
@@ -1,0 +1,12 @@
+name: scheduler
+values:
+  - key: baseUrl
+    value: ''
+  - key: username
+    value: ''
+  - key: password
+    value: ''
+  - key: adminToken
+    value: ''
+  - key: accessToken
+    value: ''


### PR DESCRIPTION
## What

Scheduler ↔ Unified Scheduling behavioral **parity** ReVoman suite — compares the OLD Salesforce Scheduler (classic `scheduling-impl` engine) against the newer Unified Scheduling OnSite path across all 13 scenarios from the 262↔264 WFS parity report. Two live orgs, differential: scheduler org (old, public Scheduler REST) vs the **262** Unified org as a proxy, diffed on both read (include/exclude) and write (book/refuse) axes with normalized verdicts.

`SchedulerVsUnifiedParityE2ETest` — **14 methods, all live-verified GREEN**: 1.5, 1a, 1b, 1c, 1d, 1.4, 2, 3, 4, 4z, 5, 8, 9 + an auth smoke test.

## Headline findings

- **Parity holds on nearly every customer-visible contract.** Strongest where the two products literally share code (Decision 5's `AssignedResource` save-validator).
- **Two null-safety divergences (262 Unified observed):** Decisions **1.4** (required-resource) and **3** (missing `isRequiredResource` flag) — the Unified engine NPE-crashes (HTTP 500) where old Scheduler degrades gracefully (clean 400). Same family as the existing `2026-07-01-wfs-262-slotgen-npe-family` handoff; code-cited fix direction in `~/work/handoff/2026-07-03-scheduler-vs-unified-1_4-crash-divergence.md`.
- **Config/mechanism differences (same observable):** D8 (load-balancing cap not constructible on the test org), D9 (shift-sharing enforced on a different read — inverted axis, same visible result).

## Version note

The Unified side was measured on **262** (`orgfarm-4dbef90d6c`); 264 was the eventual target with 262 as proxy but was **not** run against — 264 status is unverified.

## Caveats

- New test class + Postman V3 collections only; one visibility-only widening of existing WFS `Kick` constants in `ReVomanConfigForWfs` (cross-package reuse).
- Skips cleanly when external-org creds are absent (not part of unattended CI).
- Full decision log: `~/work/impl-decisions/2026-07-03-scheduler-vs-unified-1x-parity-decisions.md`.

## Base note
Stacked on `wfs/decision-1-9-revoman-tests` (the fork point) for a clean 5-commit diff — retarget to `master` if/when that branch merges.
