### PR TITLE
fix: 12 verified bugs from whole-repo code review

### DIFF
--- a/src/main/kotlin/com/salesforce/revoman/input/config/PollingConfig.kt
+++ b/src/main/kotlin/com/salesforce/revoman/input/config/PollingConfig.kt
@@ -48,11 +48,25 @@ class PollingConfigBuilder internal constructor(private val pick: PostTxnStepPic
     this.requestBuilder = requestBuilder
   }
 
-  fun every(interval: Duration): PollingConfigBuilder = apply { this.interval = interval }
+  fun every(interval: Duration): PollingConfigBuilder = apply {
+    require(!interval.isNegative && !interval.isZero) {
+      "Polling interval must be strictly positive, got: $interval"
+    }
+    this.interval = interval
+  }
 
-  fun timeout(timeout: Duration): PollingConfigBuilder = apply { this.timeout = timeout }
+  fun timeout(timeout: Duration): PollingConfigBuilder = apply {
+    require(!timeout.isNegative && !timeout.isZero) {
+      "Polling timeout must be strictly positive, got: $timeout"
+    }
+    this.timeout = timeout
+  }
 
   /** Terminal operation — builds the [PollingConfig] */
-  fun until(completionPredicate: PollingCompletionPredicate): PollingConfig =
-    PollingConfig(pick, requestBuilder, completionPredicate, interval, timeout)
+  fun until(completionPredicate: PollingCompletionPredicate): PollingConfig {
+    check(::requestBuilder.isInitialized) {
+      "PollingConfig requires request(...) to be called before until(...)"
+    }
+    return PollingConfig(pick, requestBuilder, completionPredicate, interval, timeout)
+  }
 }

--- a/src/main/kotlin/com/salesforce/revoman/input/json/adapters/salesforce/CompositeGraphResponse.kt
+++ b/src/main/kotlin/com/salesforce/revoman/input/json/adapters/salesforce/CompositeGraphResponse.kt
@@ -57,7 +57,7 @@ data class CompositeGraphResponse(val graphs: List<Graph>) {
         graphResponse.compositeResponse.filter {
           it.httpStatusCode !in SUCCESSFUL_HTTP_STATUSES &&
             it.body.firstOrNull()?.let { error ->
-              error.errorCode == PROCESSING_HALTED ||
+              error.errorCode == PROCESSING_HALTED &&
                 error.message == OPERATION_IN_TRANSACTION_FAILED_ERROR
             } != true
         }

--- a/src/main/kotlin/com/salesforce/revoman/input/json/adapters/salesforce/CompositeResponse.kt
+++ b/src/main/kotlin/com/salesforce/revoman/input/json/adapters/salesforce/CompositeResponse.kt
@@ -83,7 +83,10 @@ data class CompositeResponse(val compositeResponse: List<Response>) {
               }
             }
             reader.endObject()
-            return Record(attributes!!, recordBody)
+            return Record(
+              attributes ?: throw JsonDataException("Record missing required 'attributes' field"),
+              recordBody,
+            )
           }
 
           override fun toJson(writer: JsonWriter, record: Record?) =

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/DynamicVariableGenerator.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/DynamicVariableGenerator.kt
@@ -62,7 +62,7 @@ private val dynamicVariableGenerators: Map<String, () -> String> =
       },
   )
 
-fun getRandomHex() = nextInt(255).toString(16).uppercase()
+fun getRandomHex(): String = "%02X".format(nextInt(256))
 
 private val charPool = ('a'..'z') + ('A'..'Z') + ('0'..'9')
 

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/RegexReplacer.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/RegexReplacer.kt
@@ -32,25 +32,41 @@ class RegexReplacer(
    *   from `collectionVariables` or `globals` is resolved but left untouched in its own store.
    */
   internal fun replaceVariablesRecursively(stringWithRegex: String?, pm: PostmanSDK): String? =
-    stringWithRegex?.let {
-      postManVariableRegex.replace(it) { variable ->
-        val variableKey = variable.groups[VARIABLE_KEY]?.value!!
-        customDynamicVariableGenerators[variableKey]
-          ?.let { cdvg ->
-            replaceVariablesRecursively(
-              cdvg.generate(variableKey, pm.currentStepReport, pm.rundown),
-              pm,
-            )
-          }
-          ?.also { value -> setItBackInEnvironment(variableKey, value, pm) }
-          ?: replaceVariablesRecursively(dynamicVariableGenerator(variableKey, pm), pm)?.also {
-            value ->
-            setItBackInEnvironment(variableKey, value, pm)
-          }
-          ?: resolveFromScopes(variableKey, pm)
-          ?: variable.value
+    replaceVariablesRecursively(stringWithRegex, pm, emptySet())
+
+  private fun replaceVariablesRecursively(
+    stringWithRegex: String?,
+    pm: PostmanSDK,
+    visitedKeys: Set<String>,
+  ): String? = stringWithRegex?.let {
+    postManVariableRegex.replace(it) { variable ->
+      val variableKey = variable.groups[VARIABLE_KEY]?.value!!
+      if (variableKey in visitedKeys) {
+        RevomanLog.warn {
+          "Cyclic variable reference detected: $variableKey is part of a resolution chain. Leaving placeholder {{$variableKey}} unresolved."
+        }
+        return@replace variable.value
       }
+      val newVisitedKeys = visitedKeys + variableKey
+      customDynamicVariableGenerators[variableKey]
+        ?.let { cdvg ->
+          replaceVariablesRecursively(
+            cdvg.generate(variableKey, pm.currentStepReport, pm.rundown),
+            pm,
+            newVisitedKeys,
+          )
+        }
+        ?.also { value -> setItBackInEnvironment(variableKey, value, pm) }
+        ?: replaceVariablesRecursively(
+            dynamicVariableGenerator(variableKey, pm),
+            pm,
+            newVisitedKeys,
+          )
+          ?.also { value -> setItBackInEnvironment(variableKey, value, pm) }
+        ?: resolveFromScopes(variableKey, pm, newVisitedKeys)
+        ?: variable.value
     }
+  }
 
   /**
    * Resolves [variableKey] across the three persistent Postman scopes by precedence (`environment`
@@ -60,20 +76,30 @@ class RegexReplacer(
    * `globals` hits are read-only — no ledger involvement, no write-back into their stores. Returns
    * `null` when no scope contains the key (caller falls back to the literal `{{key}}`).
    */
-  private fun resolveFromScopes(variableKey: String, pm: PostmanSDK): String? =
+  private fun resolveFromScopes(
+    variableKey: String,
+    pm: PostmanSDK,
+    visitedKeys: Set<String>,
+  ): String? =
     when {
       pm.environment.containsKey(variableKey) ->
-        replaceVariablesRecursively(pm.environment.getAsString(variableKey), pm)?.also { value ->
-          pm.environment.recordConsumed(variableKey)
-          setItBackInEnvironment(variableKey, value, pm)
-          RevomanLog.debug { "{{$variableKey}} resolved from scope 'environment'" }
-        }
+        replaceVariablesRecursively(pm.environment.getAsString(variableKey), pm, visitedKeys)
+          ?.also { value ->
+            pm.environment.recordConsumed(variableKey)
+            setItBackInEnvironment(variableKey, value, pm)
+            RevomanLog.debug { "{{$variableKey}} resolved from scope 'environment'" }
+          }
       pm.collectionVariables.containsKey(variableKey) ->
-        replaceVariablesRecursively(pm.collectionVariables.getAsString(variableKey), pm)?.also {
-          RevomanLog.debug { "{{$variableKey}} resolved from scope 'collectionVariables'" }
-        }
+        replaceVariablesRecursively(
+            pm.collectionVariables.getAsString(variableKey),
+            pm,
+            visitedKeys,
+          )
+          ?.also {
+            RevomanLog.debug { "{{$variableKey}} resolved from scope 'collectionVariables'" }
+          }
       pm.globals.containsKey(variableKey) ->
-        replaceVariablesRecursively(pm.globals.getAsString(variableKey), pm)?.also {
+        replaceVariablesRecursively(pm.globals.getAsString(variableKey), pm, visitedKeys)?.also {
           RevomanLog.debug { "{{$variableKey}} resolved from scope 'globals'" }
         }
       else -> null

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/sandbox/Flatted.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/sandbox/Flatted.kt
@@ -71,7 +71,19 @@ internal object Flatted {
 
   private fun deref(value: Any?, slots: List<Any?>, built: Array<Any?>, done: BooleanArray): Any? =
     when (value) {
-      is String -> resolve(value.toInt(), slots, built, done)
+      is String -> {
+        val index: Int =
+          value.toIntOrNull()
+            ?: throw IllegalStateException(
+              "Flatted: invalid slot reference '$value' (not a number)"
+            )
+        if (index !in slots.indices) {
+          throw IllegalStateException(
+            "Flatted: invalid slot reference '$value' (index out of range, valid: 0-${slots.size - 1})"
+          )
+        }
+        resolve(index, slots, built, done)
+      }
       else -> value
     }
 }

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3ToV2Converter.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3ToV2Converter.kt
@@ -55,8 +55,30 @@ internal object V3ToV2Converter {
   internal fun mergeQueryParams(url: String, queryParams: Map<String, String>): String {
     if (queryParams.isEmpty()) return url
     val separator = if (url.contains("?")) "&" else "?"
-    val extra = queryParams.entries.joinToString("&") { (k, v) -> "$k=$v" }
+    val extra =
+      queryParams.entries.joinToString("&") { (k, v) ->
+        "${encodeQueryComponent(k)}=${encodeQueryComponent(v)}"
+      }
     return "$url$separator$extra"
+  }
+
+  /**
+   * Encodes a query parameter key or value per RFC-3986, preserving Postman `{{variable}}`
+   * placeholders. Encodes unsafe/reserved chars (space→%20, &→%26, =→%3D, +→%2B, '→%27, etc.) but
+   * leaves unreserved chars (A-Za-z0-9-._~) and braces ({, }) unchanged so that `{{var}}`
+   * placeholders survive to later RegexReplacer substitution.
+   */
+  private fun encodeQueryComponent(component: String): String {
+    val result = StringBuilder()
+    for (char in component) {
+      when {
+        char in 'A'..'Z' || char in 'a'..'z' || char in '0'..'9' -> result.append(char)
+        char == '-' || char == '.' || char == '_' || char == '~' -> result.append(char)
+        char == '{' || char == '}' -> result.append(char)
+        else -> result.append("%${char.code.toString(16).uppercase().padStart(2, '0')}")
+      }
+    }
+    return result.toString()
   }
 
   private fun toBody(v3body: V3Body?): Body? {

--- a/src/main/kotlin/com/salesforce/revoman/output/Rundown.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/Rundown.kt
@@ -62,7 +62,7 @@ data class Rundown(
 
   @get:JvmName("areAllStepsExceptIgnoredSuccessful")
   val areAllStepsExceptIgnoredSuccessful: Boolean by lazy {
-    stepReports.all { it.isSuccessful || !isStepIgnoredForFailure(it, this) }
+    stepReports.all { it.isSuccessful || isStepIgnoredForFailure(it, this) }
   }
 
   fun reportsForStepsInFolder(folderName: String): List<StepReport?> = stepReports.filter {
@@ -108,4 +108,4 @@ data class Rundown(
 }
 
 fun <T> List<T>.endsWith(list: List<T>): Boolean =
-  list.isNotEmpty() && list.size < size && subList(lastIndex - list.lastIndex, size) == list
+  list.isNotEmpty() && list.size <= size && subList(lastIndex - list.lastIndex, size) == list

--- a/src/main/kotlin/com/salesforce/revoman/output/postman/PostmanEnvironment.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/postman/PostmanEnvironment.kt
@@ -137,7 +137,7 @@ constructor(
 
   fun getAsString(key: String?) = moshiReVoman.anyToString(mutableEnv[key])
 
-  fun getInt(key: String?) = mutableEnv[key] as Int?
+  fun getInt(key: String?) = mutableEnv[key] as? Int
 
   @JvmOverloads
   fun <PojoT : Any> getTypedObj(

--- a/src/main/kotlin/com/salesforce/revoman/output/report/StepReport.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/report/StepReport.kt
@@ -105,7 +105,10 @@ internal constructor(
 
   @JvmField
   val isHttpStatusSuccessful: Boolean =
-    failure?.fold({ it !is PostStepHookFailure }, { true }) != true
+    failure?.fold(
+      { it is PostStepHookFailure || it is PollingFailure || it is PmTestFailure },
+      { false },
+    ) ?: true
 
   /**
    * True when this step's HTTP dispatch was SKIPPED on a warm run by the ledger (its produced keys

--- a/src/test/java/com/salesforce/revoman/output/postman/PostmanEnvironmentTest.java
+++ b/src/test/java/com/salesforce/revoman/output/postman/PostmanEnvironmentTest.java
@@ -11,6 +11,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.squareup.moshi.Types;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -95,5 +96,37 @@ class PostmanEnvironmentTest {
         .isInstanceOf(Map.class);
     assertThat(pm.<String>getTypedObj("key7", String.class)).isEqualTo(env.get("key7").get());
     assertThat(pm.<Object>getTypedObj("key8", Object.class)).isNull();
+  }
+
+  @Test
+  @DisplayName("getInt returns null for Long value without throwing")
+  void getIntReturnsNullForLongValue() {
+    final var pm = new PostmanEnvironment<>(Map.of("longKey", 123L, "intKey", 456));
+    assertThat(pm.getInt("longKey")).isNull();
+    assertThat(pm.getInt("intKey")).isEqualTo(456);
+  }
+
+  @Test
+  @DisplayName("getInt returns null for String value without throwing")
+  void getIntReturnsNullForStringValue() {
+    final var pm = new PostmanEnvironment<>(Map.of("stringKey", "123", "intKey", 456));
+    assertThat(pm.getInt("stringKey")).isNull();
+    assertThat(pm.getInt("intKey")).isEqualTo(456);
+  }
+
+  @Test
+  @DisplayName("getInt returns null for non-existent key")
+  void getIntReturnsNullForNonExistentKey() {
+    final var pm = new PostmanEnvironment<>(Map.of("intKey", 456));
+    assertThat(pm.getInt("nonExistentKey")).isNull();
+  }
+
+  @Test
+  @DisplayName("getInt returns null when value is null")
+  void getIntReturnsNullWhenValueIsNull() {
+    final var map = new HashMap<String, Object>();
+    map.put("nullKey", null);
+    final var pm = new PostmanEnvironment<>(map);
+    assertThat(pm.getInt("nullKey")).isNull();
   }
 }

--- a/src/test/kotlin/com/salesforce/revoman/input/config/PollingConfigTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/input/config/PollingConfigTest.kt
@@ -8,7 +8,9 @@
 package com.salesforce.revoman.input.config
 
 import com.salesforce.revoman.input.config.StepPick.PostTxnStepPick
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import java.time.Duration
 import org.http4k.core.Method
@@ -68,5 +70,85 @@ class PollingConfigTest {
     val builder = PollingRequestBuilder { _, _ -> customRequest }
     val config = PollingConfig.poll(alwaysPick).request(builder).until(alwaysComplete)
     config.requestBuilder shouldBe builder
+  }
+
+  @Test
+  fun `until without request throws IllegalStateException with helpful message`() {
+    val exception =
+      shouldThrow<IllegalStateException> { PollingConfig.poll(alwaysPick).until(alwaysComplete) }
+    exception.message shouldContain "request(...)"
+    exception.message shouldContain "until(...)"
+  }
+
+  @Test
+  fun `every with zero duration throws IllegalArgumentException`() {
+    val exception =
+      shouldThrow<IllegalArgumentException> {
+        PollingConfig.poll(alwaysPick)
+          .request(noOpRequest)
+          .every(Duration.ZERO)
+          .until(alwaysComplete)
+      }
+    exception.message shouldContain "interval"
+    exception.message shouldContain "positive"
+  }
+
+  @Test
+  fun `every with negative duration throws IllegalArgumentException`() {
+    val exception =
+      shouldThrow<IllegalArgumentException> {
+        PollingConfig.poll(alwaysPick)
+          .request(noOpRequest)
+          .every(Duration.ofSeconds(-1))
+          .until(alwaysComplete)
+      }
+    exception.message shouldContain "interval"
+    exception.message shouldContain "positive"
+  }
+
+  @Test
+  fun `timeout with zero duration throws IllegalArgumentException`() {
+    val exception =
+      shouldThrow<IllegalArgumentException> {
+        PollingConfig.poll(alwaysPick)
+          .request(noOpRequest)
+          .timeout(Duration.ZERO)
+          .until(alwaysComplete)
+      }
+    exception.message shouldContain "timeout"
+    exception.message shouldContain "positive"
+  }
+
+  @Test
+  fun `timeout with negative duration throws IllegalArgumentException`() {
+    val exception =
+      shouldThrow<IllegalArgumentException> {
+        PollingConfig.poll(alwaysPick)
+          .request(noOpRequest)
+          .timeout(Duration.ofSeconds(-1))
+          .until(alwaysComplete)
+      }
+    exception.message shouldContain "timeout"
+    exception.message shouldContain "positive"
+  }
+
+  @Test
+  fun `every with positive duration succeeds`() {
+    val config =
+      PollingConfig.poll(alwaysPick)
+        .request(noOpRequest)
+        .every(Duration.ofMillis(100))
+        .until(alwaysComplete)
+    config.interval shouldBe Duration.ofMillis(100)
+  }
+
+  @Test
+  fun `timeout with positive duration succeeds`() {
+    val config =
+      PollingConfig.poll(alwaysPick)
+        .request(noOpRequest)
+        .timeout(Duration.ofSeconds(5))
+        .until(alwaysComplete)
+    config.timeout shouldBe Duration.ofSeconds(5)
   }
 }

--- a/src/test/kotlin/com/salesforce/revoman/input/json/adapters/salesforce/CompositeGraphResponseTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/input/json/adapters/salesforce/CompositeGraphResponseTest.kt
@@ -1,0 +1,128 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.input.json.adapters.salesforce
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
+import io.vavr.control.Either
+import org.junit.jupiter.api.Test
+
+class CompositeGraphResponseTest {
+  private val moshi =
+    initMoshi(
+      customAdaptersWithType =
+        mapOf(
+          CompositeGraphResponse.Graph::class.java to Either.right(CompositeGraphResponse.ADAPTER)
+        )
+    )
+
+  @Test
+  fun `errorResponses retains PROCESSING_HALTED error with normal message`() {
+    val json =
+      """
+      {
+          "graphs": [{
+              "graphId": "graph1",
+              "isSuccessful": false,
+              "graphResponse": {
+                  "compositeResponse": [{
+                      "referenceId": "ref1",
+                      "httpStatusCode": 400,
+                      "httpHeaders": {},
+                      "body": [{
+                          "errorCode": "PROCESSING_HALTED",
+                          "message": "Operation failed due to validation error",
+                          "fields": []
+                      }]
+                  }]
+              }
+          }]
+      }
+      """
+        .trimIndent()
+
+    val response =
+      moshi.fromJson<CompositeGraphResponse>(json, CompositeGraphResponse::class.java)!!
+    val errorGraph = response.graphs.first() as CompositeGraphResponse.Graph.ErrorGraph
+
+    // The error should be retained because it has PROCESSING_HALTED but NOT the rollback message
+    assertThat(errorGraph.errorResponses).hasSize(1)
+    assertThat(errorGraph.firstErrorResponseBody?.errorCode).isEqualTo("PROCESSING_HALTED")
+    assertThat(errorGraph.firstErrorResponseBody?.message)
+      .isEqualTo("Operation failed due to validation error")
+  }
+
+  @Test
+  fun `errorResponses filters out PROCESSING_HALTED error with rollback message`() {
+    val json =
+      """
+      {
+          "graphs": [{
+              "graphId": "graph1",
+              "isSuccessful": false,
+              "graphResponse": {
+                  "compositeResponse": [{
+                      "referenceId": "ref1",
+                      "httpStatusCode": 400,
+                      "httpHeaders": {},
+                      "body": [{
+                          "errorCode": "PROCESSING_HALTED",
+                          "message": "The transaction was rolled back since another operation in the same transaction failed.",
+                          "fields": []
+                      }]
+                  }]
+              }
+          }]
+      }
+      """
+        .trimIndent()
+
+    val response =
+      moshi.fromJson<CompositeGraphResponse>(json, CompositeGraphResponse::class.java)!!
+    val errorGraph = response.graphs.first() as CompositeGraphResponse.Graph.ErrorGraph
+
+    // This error should be filtered out because it has both PROCESSING_HALTED and the rollback
+    // message
+    assertThat(errorGraph.errorResponses).isEmpty()
+    assertThat(errorGraph.firstErrorResponseBody).isNull()
+  }
+
+  @Test
+  fun `errorResponses retains error with only rollback message but different error code`() {
+    val json =
+      """
+      {
+          "graphs": [{
+              "graphId": "graph1",
+              "isSuccessful": false,
+              "graphResponse": {
+                  "compositeResponse": [{
+                      "referenceId": "ref1",
+                      "httpStatusCode": 400,
+                      "httpHeaders": {},
+                      "body": [{
+                          "errorCode": "SOME_OTHER_ERROR",
+                          "message": "The transaction was rolled back since another operation in the same transaction failed.",
+                          "fields": []
+                      }]
+                  }]
+              }
+          }]
+      }
+      """
+        .trimIndent()
+
+    val response =
+      moshi.fromJson<CompositeGraphResponse>(json, CompositeGraphResponse::class.java)!!
+    val errorGraph = response.graphs.first() as CompositeGraphResponse.Graph.ErrorGraph
+
+    // This error should be retained because it doesn't have PROCESSING_HALTED error code
+    assertThat(errorGraph.errorResponses).hasSize(1)
+    assertThat(errorGraph.firstErrorResponseBody?.errorCode).isEqualTo("SOME_OTHER_ERROR")
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/input/json/adapters/salesforce/CompositeResponseTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/input/json/adapters/salesforce/CompositeResponseTest.kt
@@ -1,0 +1,94 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.input.json.adapters.salesforce
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
+import com.squareup.moshi.JsonDataException
+import io.vavr.control.Either
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class CompositeResponseTest {
+  private val moshi =
+    initMoshi(
+      customAdaptersWithType =
+        mapOf(CompositeResponse.Response::class.java to Either.right(CompositeResponse.ADAPTER))
+    )
+
+  @Test
+  fun `Record parsing throws JsonDataException when attributes field is missing`() {
+    val json =
+      """
+      {
+          "compositeResponse": [{
+              "referenceId": "ref1",
+              "httpStatusCode": 200,
+              "httpHeaders": {},
+              "body": {
+                  "done": true,
+                  "totalSize": 1,
+                  "records": [{
+                      "someField": "someValue",
+                      "anotherId": "12345"
+                  }]
+              }
+          }]
+      }
+      """
+        .trimIndent()
+
+    val exception =
+      assertThrows<JsonDataException> {
+        moshi.fromJson<CompositeResponse>(json, CompositeResponse::class.java)
+      }
+
+    assertThat(exception.message).contains("Record missing required 'attributes' field")
+  }
+
+  @Test
+  fun `Record parsing succeeds when attributes field is present`() {
+    val json =
+      """
+      {
+          "compositeResponse": [{
+              "referenceId": "ref1",
+              "httpStatusCode": 200,
+              "httpHeaders": {},
+              "body": {
+                  "done": true,
+                  "totalSize": 1,
+                  "records": [{
+                      "attributes": {
+                          "type": "Account",
+                          "url": "/services/data/v58.0/sobjects/Account/001xx000003DGbXXXX"
+                      },
+                      "Id": "001xx000003DGbXXXX",
+                      "Name": "Test Account"
+                  }]
+              }
+          }]
+      }
+      """
+        .trimIndent()
+
+    val response = moshi.fromJson<CompositeResponse>(json, CompositeResponse::class.java)!!
+
+    assertThat(response.compositeResponse).hasSize(1)
+    val successResponse =
+      response.compositeResponse.first() as CompositeResponse.Response.SuccessResponse
+    assertThat(successResponse.body?.records).hasSize(1)
+
+    val record = successResponse.body?.records?.first()!!
+    assertThat(record.attributes.type).isEqualTo("Account")
+    assertThat(record.attributes.url)
+      .isEqualTo("/services/data/v58.0/sobjects/Account/001xx000003DGbXXXX")
+    assertThat(record.recordBody["Id"]).isEqualTo("001xx000003DGbXXXX")
+    assertThat(record.recordBody["Name"]).isEqualTo("Test Account")
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/DynamicVariableGeneratorTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/DynamicVariableGeneratorTest.kt
@@ -1,0 +1,44 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.postman
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class DynamicVariableGeneratorTest {
+  @Test
+  fun `getRandomHex always returns exactly 2 uppercase hex digits`() {
+    repeat(100) {
+      val hex = getRandomHex()
+      assertThat(hex).hasLength(2)
+      assertThat(hex).matches("[0-9A-F]{2}")
+    }
+  }
+
+  @Test
+  fun `getRandomHex can produce FF`() {
+    val hexValues = (1..1000).map { getRandomHex() }.toSet()
+    assertThat(hexValues).contains("FF")
+  }
+
+  @Test
+  fun `getRandomHex can produce 00`() {
+    val hexValues = (1..1000).map { getRandomHex() }.toSet()
+    assertThat(hexValues).contains("00")
+  }
+
+  @Test
+  fun `getRandomHex produces values in 00 to FF range`() {
+    repeat(100) {
+      val hex = getRandomHex()
+      val value = hex.toInt(16)
+      assertThat(value).isAtLeast(0)
+      assertThat(value).isAtMost(255)
+    }
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/RegexReplacerTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/RegexReplacerTest.kt
@@ -15,6 +15,7 @@ import com.squareup.moshi.adapter
 import io.kotest.matchers.equals.shouldNotBeEqual
 import io.kotest.matchers.maps.shouldContain
 import io.kotest.matchers.maps.shouldContainAll
+import io.kotest.matchers.shouldBe
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
 
@@ -104,5 +105,45 @@ class RegexReplacerTest {
     val resultStr = pm.regexReplacer.replaceVariablesRecursively(jsonStr, pm)!!
     val result = Moshi.Builder().build().adapter<Map<String, String>>().fromJson(resultStr)!!
     result["key1"]!! shouldNotBeEqual result["key2"]!!
+  }
+
+  @Test
+  fun `self-referencing variable does not cause StackOverflowError`() {
+    val regexReplacer = RegexReplacer()
+    val pm = PostmanSDK(moshiReVoman, null, regexReplacer)
+    pm.environment["self"] = "{{self}}"
+    val result = regexReplacer.replaceVariablesRecursively("{{self}}", pm)
+    result shouldBe "{{self}}"
+  }
+
+  @Test
+  fun `mutually cyclic variables do not cause StackOverflowError`() {
+    val regexReplacer = RegexReplacer()
+
+    // Test resolving {{a}} where a -> b -> a
+    val pm1 = PostmanSDK(moshiReVoman, null, regexReplacer)
+    pm1.environment["a"] = "{{b}}"
+    pm1.environment["b"] = "{{a}}"
+    val resultA = regexReplacer.replaceVariablesRecursively("{{a}}", pm1)
+    // When resolving {{a}}, we visit a, expand to {{b}}, visit b, expand to {{a}}, but a is already
+    // visited so we break the cycle and return {{a}}
+    resultA shouldBe "{{a}}"
+
+    // Test resolving {{b}} where b -> a -> b (fresh environment)
+    val pm2 = PostmanSDK(moshiReVoman, null, regexReplacer)
+    pm2.environment["a"] = "{{b}}"
+    pm2.environment["b"] = "{{a}}"
+    val resultB = regexReplacer.replaceVariablesRecursively("{{b}}", pm2)
+    resultB shouldBe "{{b}}"
+  }
+
+  @Test
+  fun `two-level indirection still resolves correctly`() {
+    val regexReplacer = RegexReplacer()
+    val pm = PostmanSDK(moshiReVoman, null, regexReplacer)
+    pm.environment["a"] = "{{b}}"
+    pm.environment["b"] = "value"
+    val result = regexReplacer.replaceVariablesRecursively("{{a}}", pm)
+    result shouldBe "value"
   }
 }

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/sandbox/FlattedTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/sandbox/FlattedTest.kt
@@ -7,7 +7,9 @@
  */
 package com.salesforce.revoman.internal.postman.sandbox
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import org.junit.jupiter.api.Test
 
 class FlattedTest {
@@ -41,5 +43,36 @@ class FlattedTest {
     val decoded = Flatted.parse("""[["1"],{"self":"1"}]""") as List<*>
     val obj = decoded[0] as Map<*, *>
     (obj["self"] === obj) shouldBe true
+  }
+
+  @Test
+  fun `valid nested Flatted still decodes correctly`() {
+    // Slot 0: array with refs to slots 1,2; Slot 1: obj with nested->slot3; Slot 2: obj with
+    // value->slot4; Slot 3,4: strings
+    val json = """[["1","2"],{"nested":"3"},{"value":"4"},"a","b"]"""
+    val decoded = Flatted.parse(json) as List<*>
+    decoded.size shouldBe 2
+    val obj1 = decoded[0] as Map<*, *>
+    val obj2 = decoded[1] as Map<*, *>
+    obj1["nested"] shouldBe "a"
+    obj2["value"] shouldBe "b"
+  }
+
+  @Test
+  fun `non-numeric string reference throws clear error`() {
+    // Array at slot 0 contains "not-a-number" which is not a valid index
+    val json = """[["not-a-number"],"value"]"""
+    val exception = shouldThrow<IllegalStateException> { Flatted.parse(json) }
+    exception.message shouldContain "Flatted"
+    exception.message shouldContain "not-a-number"
+  }
+
+  @Test
+  fun `out-of-range index throws clear error`() {
+    // Array at slot 0 contains "99" which is out of range (only 2 slots)
+    val json = """[["99"],"value"]"""
+    val exception = shouldThrow<IllegalStateException> { Flatted.parse(json) }
+    exception.message shouldContain "Flatted"
+    exception.message shouldContain "99"
   }
 }

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3ToV2ConverterTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3ToV2ConverterTest.kt
@@ -202,4 +202,61 @@ class V3ToV2ConverterTest {
     val item = V3ToV2Converter.toItem(v3, fallbackName = "x", inheritedAuth = inherited)
     assertThat(item.request.auth!!.bearer.single().value).isEqualTo("INHERITED")
   }
+
+  @Test
+  fun `query param value with space is percent-encoded`() {
+    val merged = V3ToV2Converter.mergeQueryParams("{{baseUrl}}/x", mapOf("q" to "hello world"))
+    assertThat(merged).isEqualTo("{{baseUrl}}/x?q=hello%20world")
+  }
+
+  @Test
+  fun `query param value with ampersand and equals is percent-encoded`() {
+    val merged = V3ToV2Converter.mergeQueryParams("{{baseUrl}}/x", mapOf("q" to "A&B=C"))
+    assertThat(merged).isEqualTo("{{baseUrl}}/x?q=A%26B%3DC")
+  }
+
+  @Test
+  fun `query param value with plus sign is percent-encoded`() {
+    val merged = V3ToV2Converter.mergeQueryParams("{{baseUrl}}/x", mapOf("q" to "A+B"))
+    assertThat(merged).isEqualTo("{{baseUrl}}/x?q=A%2BB")
+  }
+
+  @Test
+  fun `query param value with single quote is percent-encoded`() {
+    val merged = V3ToV2Converter.mergeQueryParams("{{baseUrl}}/x", mapOf("q" to "A'B"))
+    assertThat(merged).isEqualTo("{{baseUrl}}/x?q=A%27B")
+  }
+
+  @Test
+  fun `query param value containing Postman variable placeholder survives unencoded`() {
+    val merged = V3ToV2Converter.mergeQueryParams("{{baseUrl}}/x", mapOf("q" to "{{var}}"))
+    assertThat(merged).isEqualTo("{{baseUrl}}/x?q={{var}}")
+  }
+
+  @Test
+  fun `query param value with placeholder and special chars encodes only the special chars`() {
+    val merged =
+      V3ToV2Converter.mergeQueryParams(
+        "{{baseUrl}}/x",
+        mapOf("q" to "SELECT Id FROM Account WHERE Name='{{name}}'"),
+      )
+    assertThat(merged)
+      .isEqualTo("{{baseUrl}}/x?q=SELECT%20Id%20FROM%20Account%20WHERE%20Name%3D%27{{name}}%27")
+  }
+
+  @Test
+  fun `query param key is also percent-encoded`() {
+    val merged = V3ToV2Converter.mergeQueryParams("{{baseUrl}}/x", mapOf("key with space" to "val"))
+    assertThat(merged).isEqualTo("{{baseUrl}}/x?key%20with%20space=val")
+  }
+
+  @Test
+  fun `unreserved chars in query params are not encoded`() {
+    val merged =
+      V3ToV2Converter.mergeQueryParams(
+        "{{baseUrl}}/x",
+        mapOf("k" to "azAZ09-._~"),
+      )
+    assertThat(merged).isEqualTo("{{baseUrl}}/x?k=azAZ09-._~")
+  }
 }

--- a/src/test/kotlin/com/salesforce/revoman/output/RundownExtensionsTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/output/RundownExtensionsTest.kt
@@ -1,0 +1,55 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.output
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class RundownExtensionsTest {
+  @Test
+  fun `endsWith matches when lists are equal`() {
+    val list = listOf("A", "B", "C")
+    val suffix = listOf("A", "B", "C")
+    list.endsWith(suffix) shouldBe true
+  }
+
+  @Test
+  fun `endsWith matches shorter suffix`() {
+    val list = listOf("A", "B", "C", "D")
+    val suffix = listOf("C", "D")
+    list.endsWith(suffix) shouldBe true
+  }
+
+  @Test
+  fun `endsWith fails when suffix is longer`() {
+    val list = listOf("A", "B")
+    val suffix = listOf("A", "B", "C")
+    list.endsWith(suffix) shouldBe false
+  }
+
+  @Test
+  fun `endsWith fails when suffix does not match`() {
+    val list = listOf("A", "B", "C", "D")
+    val suffix = listOf("B", "C")
+    list.endsWith(suffix) shouldBe false
+  }
+
+  @Test
+  fun `endsWith fails with empty suffix`() {
+    val list = listOf("A", "B", "C")
+    val suffix = emptyList<String>()
+    list.endsWith(suffix) shouldBe false
+  }
+
+  @Test
+  fun `endsWith matches single element`() {
+    val list = listOf("A")
+    val suffix = listOf("A")
+    list.endsWith(suffix) shouldBe true
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/output/RundownStopReasonTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/output/RundownStopReasonTest.kt
@@ -7,11 +7,26 @@
  */
 package com.salesforce.revoman.output
 
+import arrow.core.Either.Right
 import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.input.config.StepPick.PostTxnStepPick
+import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
+import com.salesforce.revoman.internal.postman.template.Item
+import com.salesforce.revoman.internal.postman.template.Request
+import com.salesforce.revoman.internal.postman.template.Url
 import com.salesforce.revoman.output.postman.PostmanEnvironment
+import com.salesforce.revoman.output.report.Step
+import com.salesforce.revoman.output.report.StepReport
+import com.salesforce.revoman.output.report.TxnInfo
+import com.salesforce.revoman.output.report.failure.HookFailure.PostStepHookFailure
+import org.http4k.core.Method.POST
+import org.http4k.core.Response
+import org.http4k.core.Status.Companion.OK
 import org.junit.jupiter.api.Test
 
 class RundownStopReasonTest {
+  private val moshiReVoman = initMoshi()
+
   @Test
   fun `stopReason defaults to COMPLETED`() {
     val rundown =
@@ -22,5 +37,45 @@ class RundownStopReasonTest {
         providedStepsToExecuteCount = 0,
       )
     assertThat(rundown.stopReason).isEqualTo(StopReason.COMPLETED)
+  }
+
+  @Test
+  fun `areAllStepsExceptIgnoredSuccessful when only ignored failures exist`() {
+    val rawRequest =
+      Request(method = POST.toString(), url = Url("https://overfullstack.github.io/"))
+    val requestInfo =
+      TxnInfo(
+        txnObjType = String::class.java,
+        txnObj = "fakeRequest",
+        httpMsg = rawRequest.toHttpRequest(moshiReVoman),
+        moshiReVoman = moshiReVoman,
+      )
+    val responseInfo: TxnInfo<Response> =
+      TxnInfo(
+        txnObjType = String::class.java,
+        txnObj = "fakeResponse",
+        httpMsg = Response(OK),
+        moshiReVoman = moshiReVoman,
+      )
+    val failedStepReport =
+      StepReport(
+        Step("", Item(request = rawRequest)),
+        Right(requestInfo),
+        null,
+        Right(responseInfo),
+        PostStepHookFailure(RuntimeException("fakeRTE"), requestInfo, responseInfo),
+        null,
+        null,
+        pmEnvSnapshot = PostmanEnvironment(),
+      )
+    val rundown =
+      Rundown(
+        stepReports = listOf(failedStepReport),
+        mutableEnv = PostmanEnvironment(),
+        haltOnFailureOfTypeExcept =
+          mapOf(ExeType.POST_STEP_HOOK to PostTxnStepPick { _, _ -> true }),
+        providedStepsToExecuteCount = 0,
+      )
+    assertThat(rundown.areAllStepsExceptIgnoredSuccessful).isTrue()
   }
 }

--- a/src/test/kotlin/com/salesforce/revoman/output/report/StepReportTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/output/report/StepReportTest.kt
@@ -13,10 +13,15 @@ import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
 import com.salesforce.revoman.internal.postman.template.Item
 import com.salesforce.revoman.internal.postman.template.Request
 import com.salesforce.revoman.internal.postman.template.Url
+import com.salesforce.revoman.output.ExeType
 import com.salesforce.revoman.output.postman.PostmanEnvironment
 import com.salesforce.revoman.output.report.failure.HookFailure.PostStepHookFailure
+import com.salesforce.revoman.output.report.failure.HookFailure.PreStepHookFailure
+import com.salesforce.revoman.output.report.failure.PollingFailure
 import com.salesforce.revoman.output.report.failure.RequestFailure.HttpRequestFailure
+import com.salesforce.revoman.output.report.failure.ResponseFailure.PostResJSFailure
 import io.kotest.matchers.shouldBe
+import java.time.Duration
 import org.http4k.core.Method.POST
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.BAD_REQUEST
@@ -170,5 +175,226 @@ class StepReportTest {
       )
     executed.isLedgerSkipped shouldBe false
     StepReport.assertNotLedgerSkipped(executed) // no-op, must not throw
+  }
+
+  @Test
+  fun `http status successful when pm-test fails after 200 response`() {
+    val rawRequest =
+      Request(method = POST.toString(), url = Url("https://overfullstack.github.io/"))
+    val requestInfo =
+      TxnInfo(
+        txnObjType = String::class.java,
+        txnObj = "fakeRequest",
+        httpMsg = rawRequest.toHttpRequest(moshiReVoman),
+        moshiReVoman = moshiReVoman,
+      )
+    val responseInfo: TxnInfo<Response> =
+      TxnInfo(
+        txnObjType = String::class.java,
+        txnObj = "fakeResponse",
+        httpMsg = Response(OK),
+        moshiReVoman = moshiReVoman,
+      )
+    val stepReportPmTestFailure =
+      StepReport(
+          Step("", Item(request = rawRequest)),
+          Right(requestInfo),
+          null,
+          Right(responseInfo),
+          pmEnvSnapshot = PostmanEnvironment(),
+        )
+        .copy(
+          pmTestAssertions =
+            listOf(PmTestAssertion("test1", false, false, "test failed", ExeType.POST_RES_JS))
+        )
+    println(stepReportPmTestFailure)
+    stepReportPmTestFailure.isHttpStatusSuccessful shouldBe true
+  }
+
+  @Test
+  fun `http status successful when polling fails after 200 response`() {
+    val rawRequest =
+      Request(method = POST.toString(), url = Url("https://overfullstack.github.io/"))
+    val requestInfo =
+      TxnInfo(
+        txnObjType = String::class.java,
+        txnObj = "fakeRequest",
+        httpMsg = rawRequest.toHttpRequest(moshiReVoman),
+        moshiReVoman = moshiReVoman,
+      )
+    val responseInfo: TxnInfo<Response> =
+      TxnInfo(
+        txnObjType = String::class.java,
+        txnObj = "fakeResponse",
+        httpMsg = Response(OK),
+        moshiReVoman = moshiReVoman,
+      )
+    val pollingFailure =
+      PollingFailure.PollingTimeoutFailure(
+        failure = RuntimeException("polling timeout"),
+        pollAttempts = 5,
+        timeout = Duration.ofSeconds(10),
+        lastPollResponse = Response(OK),
+      )
+    val stepReportPollingFailure =
+      StepReport(
+        Step("", Item(request = rawRequest)),
+        Right(requestInfo),
+        null,
+        Right(responseInfo),
+        null,
+        pollingFailure,
+        null,
+        pmEnvSnapshot = PostmanEnvironment(),
+      )
+    println(stepReportPollingFailure)
+    stepReportPollingFailure.isHttpStatusSuccessful shouldBe true
+  }
+
+  @Test
+  fun `http status unsuccessful when genuine non-2xx response`() {
+    val rawRequest =
+      Request(method = POST.toString(), url = Url("https://overfullstack.github.io/"))
+    val requestInfo =
+      TxnInfo(
+        txnObjType = String::class.java,
+        txnObj = "fakeRequest",
+        httpMsg = rawRequest.toHttpRequest(moshiReVoman),
+        moshiReVoman = moshiReVoman,
+      )
+    val badResponseInfo: TxnInfo<Response> =
+      TxnInfo(
+        txnObjType = String::class.java,
+        txnObj = "fakeBadResponse",
+        httpMsg = Response(BAD_REQUEST),
+        moshiReVoman = moshiReVoman,
+      )
+    val stepReportBadResponse =
+      StepReport(
+        Step("", Item(request = rawRequest)),
+        Right(requestInfo),
+        null,
+        Right(badResponseInfo),
+        pmEnvSnapshot = PostmanEnvironment(),
+      )
+    println(stepReportBadResponse)
+    stepReportBadResponse.isHttpStatusSuccessful shouldBe false
+  }
+
+  @Test
+  fun `http status unsuccessful when request fails`() {
+    val rawRequest =
+      Request(method = POST.toString(), url = Url("https://overfullstack.github.io/"))
+    val requestInfo =
+      TxnInfo(
+        txnObjType = String::class.java,
+        txnObj = "fakeRequest",
+        httpMsg = rawRequest.toHttpRequest(moshiReVoman),
+        moshiReVoman = moshiReVoman,
+      )
+    val stepReportRequestFailure =
+      StepReport(
+        Step("", Item(request = rawRequest)),
+        Left(HttpRequestFailure(RuntimeException("connection error"), requestInfo)),
+        pmEnvSnapshot = PostmanEnvironment(),
+      )
+    println(stepReportRequestFailure)
+    stepReportRequestFailure.isHttpStatusSuccessful shouldBe false
+  }
+
+  @Test
+  fun `http status unsuccessful when response fails`() {
+    val rawRequest =
+      Request(method = POST.toString(), url = Url("https://overfullstack.github.io/"))
+    val requestInfo =
+      TxnInfo(
+        txnObjType = String::class.java,
+        txnObj = "fakeRequest",
+        httpMsg = rawRequest.toHttpRequest(moshiReVoman),
+        moshiReVoman = moshiReVoman,
+      )
+    val responseInfo: TxnInfo<Response> =
+      TxnInfo(
+        txnObjType = String::class.java,
+        txnObj = "fakeResponse",
+        httpMsg = Response(OK),
+        moshiReVoman = moshiReVoman,
+      )
+    val stepReportResponseFailure =
+      StepReport(
+        Step("", Item(request = rawRequest)),
+        Right(requestInfo),
+        null,
+        Left(
+          PostResJSFailure(RuntimeException("response script error"), requestInfo, responseInfo)
+        ),
+        pmEnvSnapshot = PostmanEnvironment(),
+      )
+    println(stepReportResponseFailure)
+    stepReportResponseFailure.isHttpStatusSuccessful shouldBe false
+  }
+
+  @Test
+  fun `http status unsuccessful when pre-step hook fails`() {
+    val rawRequest =
+      Request(method = POST.toString(), url = Url("https://overfullstack.github.io/"))
+    val requestInfo =
+      TxnInfo(
+        txnObjType = String::class.java,
+        txnObj = "fakeRequest",
+        httpMsg = rawRequest.toHttpRequest(moshiReVoman),
+        moshiReVoman = moshiReVoman,
+      )
+    val preStepHookFailure = PreStepHookFailure(RuntimeException("pre-hook error"), requestInfo)
+    val stepReportPreHookFailure =
+      StepReport(
+        Step("", Item(request = rawRequest)),
+        Right(requestInfo),
+        preStepHookFailure,
+        pmEnvSnapshot = PostmanEnvironment(),
+      )
+    println(stepReportPreHookFailure)
+    stepReportPreHookFailure.isHttpStatusSuccessful shouldBe false
+  }
+
+  @Test
+  fun `http status successful for fully successful step`() {
+    val rawRequest =
+      Request(method = POST.toString(), url = Url("https://overfullstack.github.io/"))
+    val requestInfo =
+      TxnInfo(
+        txnObjType = String::class.java,
+        txnObj = "fakeRequest",
+        httpMsg = rawRequest.toHttpRequest(moshiReVoman),
+        moshiReVoman = moshiReVoman,
+      )
+    val responseInfo: TxnInfo<Response> =
+      TxnInfo(
+        txnObjType = String::class.java,
+        txnObj = "fakeResponse",
+        httpMsg = Response(OK),
+        moshiReVoman = moshiReVoman,
+      )
+    val stepReportSuccess =
+      StepReport(
+        Step("", Item(request = rawRequest)),
+        Right(requestInfo),
+        null,
+        Right(responseInfo),
+        pmEnvSnapshot = PostmanEnvironment(),
+      )
+    println(stepReportSuccess)
+    stepReportSuccess.isHttpStatusSuccessful shouldBe true
+  }
+
+  @Test
+  fun `http status successful for skipped step`() {
+    val skipped =
+      StepReport.ledgerSkipped(
+        Step("1", Item(name = "skipped-step", request = Request())),
+        setOf("someKey"),
+        PostmanEnvironment(),
+      )
+    skipped.isHttpStatusSuccessful shouldBe true
   }
 }


### PR DESCRIPTION
Whole-repo `/code-review` (xhigh) surfaced 12 verified correctness bugs. Each fix is TDD'd with a regression test (~50 new tests). Full unit suite green (409 tests), `spotlessCheck` clean.

## Fixes

| # | Bug | File |
|---|-----|------|
| 1 | `isHttpStatusSuccessful` mislabeled 2xx steps as HTTP failures — only excused `PostStepHookFailure`; now also excuses `PollingFailure`/`PmTestFailure` (all occur after a successful 2xx) | `output/report/StepReport.kt` |
| 2 | `areAllStepsExceptIgnoredSuccessful` inverted ignore check — an unsuccessful-but-ignored step wrongly failed the run; dropped the stray `!` | `output/Rundown.kt` |
| 3 | `List.endsWith` returned false on equal-length lists (`<` → `<=`), breaking `stepNameMatches` for full-path lookups (`setNextRequest`, `reportForStepName`) | `output/Rundown.kt` |
| 4 | `PostmanEnvironment.getInt` threw `ClassCastException` on non-Int values (`as Int?` → `as? Int`) | `output/postman/PostmanEnvironment.kt` |
| 5 | Cyclic variable (`self = {{self}}`) caused `StackOverflowError` — added visited-key cycle detection, falls back to literal placeholder | `internal/postman/RegexReplacer.kt` |
| 6 | v3→v2 query params not URL-encoded — added encoder that preserves `{{var}}` placeholders for later resolution | `internal/postman/template/v3/V3ToV2Converter.kt` |
| 7 | `$randomHexColor` produced malformed colors (`nextInt(255)` never `FF`, no zero-pad) → `%02X`.format(`nextInt(256)`) | `internal/postman/DynamicVariableGenerator.kt` |
| 8 | Graph error filter used `\|\|` where sibling `CompositeResponse` uses `&&`, over-filtering genuine `PROCESSING_HALTED` errors | `input/json/adapters/salesforce/CompositeGraphResponse.kt` |
| 9 | `Record(attributes!!, ...)` threw raw NPE on missing `attributes` → clear `JsonDataException` | `input/json/adapters/salesforce/CompositeResponse.kt` |
| 10 | `PollingConfig.until()` without `request()` threw cryptic `UninitializedPropertyAccessException` → clear `IllegalStateException` | `input/config/PollingConfig.kt` |
| 11 | `PollingConfig` accepted non-positive interval/timeout → validated at build time | `input/config/PollingConfig.kt` |
| 12 | `Flatted.deref` `value.toInt()` unguarded (NFE / AIOOBE on corrupt bridge data) → `toIntOrNull` + range check with clear error | `internal/postman/sandbox/Flatted.kt` |

## Test plan
- `./gradlew spotlessCheck test` → BUILD SUCCESSFUL, 409 passing
- Each fix has a dedicated regression test (red→green TDD)