### PR TITLE
ci: float all GitHub Actions on @main (no version pinning)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,10 @@
   "ignoreUnstable": false,
   "automerge": true,
   "commitBodyTable": true,
+  "github-actions": {
+    "comment": "Actions are pinned to @main (float on upstream default branch, no version pinning) — so disable Renovate's github-actions manager; it would otherwise pin @main to a commit SHA.",
+    "enabled": false
+  },
   "packageRules": [
     {
       "matchUpdateTypes": [

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,16 +20,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@main
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@main
         with:
           distribution: jetbrains
           java-version: 21
 
       # Replaces the deprecated gradle/gradle-build-action; adds dependency caching + a build report.
       - name: 'Setup Gradle'
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@main
 
       # Full coverage: unit (`test`) + integration (`integrationTest`) + spotlessCheck + kover, all
       # via `build`. The `integration.core.*` org tests skip-loud (no creds on CI); the live
@@ -41,7 +41,7 @@ jobs:
       # Surface JUnit HTML reports even when the build fails, so a red run is diagnosable.
       - name: 'Upload test reports'
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@main
         with:
           name: test-reports
           path: build/reports/tests/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,14 +18,14 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@main
       with:
         # Antora needs full history for url: . content sources
         fetch-depth: 0
     - name: Configure Pages
-      uses: actions/configure-pages@v6
+      uses: actions/configure-pages@main
     - name: Install Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@main
       with:
         node-version: '26'
     - name: Install Antora + Lunr extension
@@ -33,9 +33,9 @@ jobs:
     - name: Generate Site
       run: npx antora antora-playbook.yml
     - name: Upload Artifacts
-      uses: actions/upload-pages-artifact@v5
+      uses: actions/upload-pages-artifact@main
       with:
         path: build/site
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v5
+      uses: actions/deploy-pages@main


### PR DESCRIPTION
## What
Pin every action in `build.yml` + `docs.yml` to `@main` — always run newest upstream code, no version pinning. Also disable Renovate's `github-actions` manager (with `@main` there's nothing to bump, and it'd otherwise pin `@main`→SHA).

## Note on `@latest`
GitHub Actions has **no `@latest` ref** — `uses: action@latest` fails to resolve (npm-ism; not valid for actions). `@main` (each action's default branch) is the only true "float / no pinning" form. Verified none of these repos publish a `latest` tag/branch.

## Actions switched (all → `@main`)
`checkout`, `setup-java`, `setup-gradle`, `upload-artifact`, `configure-pages`, `setup-node`, `upload-pages-artifact`, `deploy-pages`.

## Trade-off (explicitly accepted)
`@main` runs **unreleased, unreviewed** third-party code, is **non-reproducible**, and a bad upstream commit can **break CI at any time**. This is the deliberate cost of "newest always, no pinning".