### PR TITLE
build: perf foundation (WT-0) — truffle-runtime, kotlinx-immutable, JMH harness

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
   implementation(libs.bundles.kotlin.logging)
   implementation(libs.pprint)
   implementation(libs.graal.js)
+  api(libs.truffle.runtime)
   implementation(libs.datafaker)
   implementation(libs.underscore)
   implementation(libs.okio.jvm)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -201,6 +201,15 @@ kover { reports { total { html { onCheck = true } } } }
 
 moshi { enableSealed = true }
 
+jmh {
+  // Pin JMH core so every worktree benchmarks against a known JMH release.
+  jmhVersion = libs.versions.jmh.get()
+  // Select benchmarks from the CLI, e.g. ./gradlew jmh -Pjmh.includes=SmokeBenchmark
+  if (project.hasProperty("jmh.includes")) {
+    includes.add(project.property("jmh.includes").toString())
+  }
+}
+
 nexusPublishing {
   this.repositories {
     sonatype {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
   implementation(libs.pprint)
   implementation(libs.graal.js)
   api(libs.truffle.runtime)
+  implementation(libs.kotlinx.collections.immutable)
   implementation(libs.datafaker)
   implementation(libs.underscore)
   implementation(libs.okio.jvm)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,6 +87,13 @@ kotlin.target.compilations.named("integrationTest") {
   associateWith(kotlin.target.compilations.getByName("main"))
 }
 
+// Give the jmh compilation the same friend-path to main, so component benchmarks (WT-1..WT-4) can
+// reference `internal` main members (e.g. PmSandbox, PmScope, PmExecutionContext, ScriptTarget)
+// rather than only the public API.
+kotlin.target.compilations.named("jmh") {
+  associateWith(kotlin.target.compilations.getByName("main"))
+}
+
 node {
   nodeProjectDir = file("${project.projectDir}/js")
   download = true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,10 @@ dependencies {
   implementation(libs.bundles.kotlin.logging)
   implementation(libs.pprint)
   implementation(libs.graal.js)
-  api(libs.truffle.runtime)
+  // truffle-runtime is a pure runtime substitution: it swaps Truffle's interpreter-only runtime for
+  // its optimizing Graal-compiler one. Nothing compiles against it, so `runtimeOnly` activates the
+  // optimizing runtime everywhere at run time without leaking it onto anyone's compile classpath.
+  runtimeOnly(libs.truffle.runtime)
   implementation(libs.kotlinx.collections.immutable)
   implementation(libs.datafaker)
   implementation(libs.underscore)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,7 @@ plugins {
   alias(libs.plugins.node.gradle)
   alias(libs.plugins.kover)
   alias(libs.plugins.nexus.publish)
+  alias(libs.plugins.jmh)
   alias(libs.plugins.test.retry)
 }
 

--- a/docs/superpowers/benchmarks/baseline.md
+++ b/docs/superpowers/benchmarks/baseline.md
@@ -1,0 +1,40 @@
+# ReVoman Perf Benchmarks — Baseline Capture
+
+Component-level JMH benchmarks live in `src/jmh/kotlin/com/salesforce/revoman/benchmark/`.
+Full end-to-end collection runs need live network/orgs and are NOT JMH-repeatable, so we
+benchmark the isolated hot paths the perf audit flagged (regex/vars, marshalling, GraalJS
+eval, env accumulation).
+
+## Run all benchmarks
+
+```bash
+./gradlew jmh
+```
+
+Results are written to `build/results/jmh/results.txt`.
+
+## Run one benchmark class
+
+```bash
+./gradlew jmh -Pjmh.includes=SmokeBenchmark      # regex substring against the class name
+```
+
+## Baseline protocol (per domain worktree WT-1..WT-4)
+
+1. **Before** applying the domain fix, from the worktree's WT-0 base commit, run the domain's
+   benchmark and snapshot the numbers:
+   ```bash
+   ./gradlew jmh -Pjmh.includes=<DomainBenchmark>
+   cp build/results/jmh/results.txt docs/superpowers/benchmarks/results/$(git rev-parse --short HEAD)-<domain>-before.txt
+   ```
+2. **After** the fix lands (tests green), re-run the same benchmark and snapshot again with a
+   `-after` suffix.
+3. Record the before/after delta in the worktree's PR description / ledger. Keep the raw
+   snapshot files committed under `docs/superpowers/benchmarks/results/` so deltas are auditable.
+
+## Notes
+
+- The optimizing GraalJS runtime (`org.graalvm.truffle:truffle-runtime`, added in WT-0) is on the
+  classpath, so GraalJS benchmarks measure jargraal-JIT behavior, not interpreter-only.
+- JMH warmup/fork settings live on each `@Benchmark` class; the smoke benchmark uses minimal
+  iterations for speed — domain benchmarks should use JMH defaults or higher for stable numbers.

--- a/docs/superpowers/benchmarks/baseline.md
+++ b/docs/superpowers/benchmarks/baseline.md
@@ -21,8 +21,10 @@ Results are written to `build/results/jmh/results.txt`.
 
 ## Baseline protocol (per domain worktree WT-1..WT-4)
 
-1. **Before** applying the domain fix, from the worktree's WT-0 base commit, run the domain's
-   benchmark and snapshot the numbers:
+1. Author the domain benchmark on top of the WT-0 base, then — **before** applying the
+   optimization itself — run it against the unoptimized code and snapshot the numbers. (The
+   benchmark class doesn't exist at the raw WT-0 base commit; the "before" measurement is of
+   WT-0 behavior + the new benchmark, with the fix not yet applied.)
    ```bash
    ./gradlew jmh -Pjmh.includes=<DomainBenchmark>
    cp build/results/jmh/results.txt docs/superpowers/benchmarks/results/$(git rev-parse --short HEAD)-<domain>-before.txt
@@ -32,9 +34,19 @@ Results are written to `build/results/jmh/results.txt`.
 3. Record the before/after delta in the worktree's PR description / ledger. Keep the raw
    snapshot files committed under `docs/superpowers/benchmarks/results/` so deltas are auditable.
 
+The `<sha>-smoke.txt` snapshot in `results/` is a one-off harness sanity check from WT-0 (hence
+the `-smoke` name, not the `-before`/`-after` domain-measurement scheme above).
+
 ## Notes
 
 - The optimizing GraalJS runtime (`org.graalvm.truffle:truffle-runtime`, added in WT-0) is on the
-  classpath, so GraalJS benchmarks measure jargraal-JIT behavior, not interpreter-only.
+  classpath, so GraalJS benchmarks measure optimizing-compiler behavior, not interpreter-only. On a
+  stock JDK 21 this is *jargraal* (the Graal compiler running as ordinary JVM bytecode — no GraalVM
+  JDK required); on a GraalVM JDK it would be libgraal instead.
+  - Classpath presence is necessary but not sufficient: Truffle can silently fall back to
+    interpreted execution (emitting only a warning) if the JDK/dependency set changes, which would
+    quietly invalidate GraalJS numbers. To confirm the optimizing runtime actually engaged, watch
+    the run for Truffle's "falling back to interpreted execution" warning (its absence = optimizing
+    runtime active), or run with a Truffle compilation-trace flag.
 - JMH warmup/fork settings live on each `@Benchmark` class; the smoke benchmark uses minimal
   iterations for speed — domain benchmarks should use JMH defaults or higher for stable numbers.

--- a/docs/superpowers/benchmarks/results/491ea968-smoke.txt
+++ b/docs/superpowers/benchmarks/results/491ea968-smoke.txt
@@ -1,0 +1,2 @@
+Benchmark                  Mode  Cnt   Score   Error  Units
+SmokeBenchmark.sumOfRange  avgt       62.091          ns/op

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,6 +75,7 @@ spring-beans = { module = "org.springframework:spring-beans", version.ref = "spr
 json-assert = { module = "org.skyscreamer:jsonassert", version.ref = "json-assert" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime-jvm", version.ref = "kotlinx-datetime" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+truffle-runtime = { module = "org.graalvm.truffle:truffle-runtime", version.ref = "graal" }
 postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }
 
 # Gradle plugins

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ mockk = "1.14.11"
 postgresql = "42.7.13"
 test-retry = "1.6.5"
 gradle-taskinfo = "3.0.2"
+kotlinx-collections-immutable = "0.4.0"
 
 # Common dependencies
 
@@ -76,6 +77,7 @@ json-assert = { module = "org.skyscreamer:jsonassert", version.ref = "json-asser
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime-jvm", version.ref = "kotlinx-datetime" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 truffle-runtime = { module = "org.graalvm.truffle:truffle-runtime", version.ref = "graal" }
+kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinx-collections-immutable" }
 postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }
 
 # Gradle plugins

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,8 @@ postgresql = "42.7.13"
 test-retry = "1.6.5"
 gradle-taskinfo = "3.0.2"
 kotlinx-collections-immutable = "0.4.0"
+jmh = "1.37"
+champeau-jmh = "0.7.3"
 
 # Common dependencies
 
@@ -106,4 +108,5 @@ kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 node-gradle = { id = "com.github.node-gradle.node", version.ref = "node-gradle" }
 nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexus-publish" }
 gradle-taskinfo = {id = "org.barfuin.gradle.taskinfo", version.ref = "gradle-taskinfo"}
+jmh = { id = "me.champeau.jmh", version.ref = "champeau-jmh" }
 test-retry = { id = "org.gradle.test-retry", version.ref = "test-retry" }

--- a/src/jmh/kotlin/com/salesforce/revoman/benchmark/SmokeBenchmark.kt
+++ b/src/jmh/kotlin/com/salesforce/revoman/benchmark/SmokeBenchmark.kt
@@ -1,0 +1,36 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.benchmark
+
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+
+private const val UPPER_BOUND = 100
+
+/**
+ * Smoke benchmark proving the `jmh` source set compiles and the `me.champeau.jmh` toolchain runs
+ * end-to-end on this project. The domain worktrees (WT-1..WT-4) drop their own `*Benchmark.kt` into
+ * this same package; this file only validates the harness.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(1)
+@Warmup(iterations = 1, time = 1)
+@Measurement(iterations = 1, time = 1)
+open class SmokeBenchmark {
+  @Benchmark open fun sumOfRange(): Int = (1..UPPER_BOUND).sum()
+}


### PR DESCRIPTION
## Summary

Shared **build foundation** (WT-0) for the ReVoman perf-improvement effort. This is the base the four domain worktrees (WT-1 sandbox, WT-2 marshalling, WT-3 regex/templates, WT-4 exe/output/env) branch off — it lands first so each can add its own fixes + JMH benchmarks conflict-free. **Build config + one smoke benchmark + docs only — no application/source-logic changes.**

## What's in it (6 commits)

- **`truffle-runtime` as `api`** — the optimizing GraalJS runtime (jargraal), reusing the existing `graal` 25.1.3 version. Transparent faster drop-in for GraalJS eval; no semantic change.
- **`kotlinx-collections-immutable` 0.4.0 (`implementation`)** — persistent-map backing WT-4 will use for `PostmanEnvironment`.
- **`me.champeau.jmh` 0.7.3 plugin** — applied cleanly on the pinned Gradle `9.7.0-milestone-3` (compatibility gate passed, no fallback needed).
- **JMH source set + `SmokeBenchmark` + `-Pjmh.includes` wiring** — establishes the downstream contract: benchmarks live in `src/jmh/kotlin/com/salesforce/revoman/benchmark/`, run via `./gradlew jmh -Pjmh.includes=<ClassSimpleName>`. Ran end-to-end (`SmokeBenchmark.sumOfRange ≈ 62 ns/op`).
- **JMH baseline-capture procedure doc** (`docs/superpowers/benchmarks/baseline.md`) + smoke snapshot.
- **`jmh` → `main` friend-path** (`associateWith`, mirroring the existing `integrationTest` wiring) — lets component benchmarks reference `internal` main members (`PmSandbox`, `PmScope`, `PmExecutionContext`, `ScriptTarget`) instead of only the public API. Kept in this shared base so downstream worktrees don't each edit `build.gradle.kts` and conflict.

## Verification

- `./gradlew spotlessCheck` — clean
- `./gradlew build` — all source sets (incl. `jmh`) compile, detekt clean, **409 unit tests pass**
- `./gradlew jmh -Pjmh.includes=SmokeBenchmark` — runs end-to-end
- `./gradlew test integrationTest` — unit green; the 6 integration failures are **restful-api.dev HTTP 405 daily-quota** environment failures (external API rate limit), independently confirmed via JUnit XML — **not regressions**. WT-0 touches no request/HTTP logic.

Rebased onto current `master` (picks up #391/#392/#393); the `libs.versions.toml` overlap with the #392 dependency bump was resolved and the combined tree re-verified (same green result, same environmental-only integration failures).

## Reviewed

Executed via subagent-driven development: each of the 6 tasks passed an individual spec + code-quality review, plus a final whole-branch review (the friend-path was the one Important finding, now fixed in this branch).
