### PR TITLE
build: migrate detekt to 2.0.0-alpha.5 (fix Gradle-10 ReportingExtension deprecation)

### DIFF
--- a/buildSrc/src/main/kotlin/revoman.root-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/revoman.root-conventions.gradle.kts
@@ -8,11 +8,11 @@
 import com.adarshr.gradle.testlogger.theme.ThemeType.MOCHA
 import com.diffplug.spotless.LineEnding.PLATFORM_NATIVE
 import com.diffplug.spotless.extra.wtp.EclipseWtpFormatterStep.XML
-import io.gitlab.arturbosch.detekt.Detekt
+import dev.detekt.gradle.Detekt
 
 plugins {
   id("com.diffplug.spotless")
-  id("io.gitlab.arturbosch.detekt")
+  id("dev.detekt")
   id("com.adarshr.test-logger")
 }
 
@@ -71,4 +71,5 @@ detekt {
 
 testlogger.theme = MOCHA
 
-tasks.withType<Detekt>().configureEach { reports { xml.required.set(true) } }
+// detekt 2.0 renamed the XML report to `checkstyle` (the XML output is Checkstyle-format).
+tasks.withType<Detekt>().configureEach { reports { checkstyle.required.set(true) } }

--- a/detekt/baseline.xml
+++ b/detekt/baseline.xml
@@ -1,10 +1,10 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" ?>
 <SmellBaseline>
   <ManuallySuppressedIssues>
     <ID>TooManyFunctions:ResponseConfig.kt$ResponseConfig$Companion</ID>
-    <ID>TooManyFunctions:PostmanEnvironment.kt$PostmanEnvironment&lt;ValueT : Any?> : MutableMap</ID>
+    <ID>TooManyFunctions:PostmanEnvironment.kt$PostmanEnvironment&lt;ValueT : Any?&gt; : MutableMap</ID>
     <ID>TooManyFunctions:ExeUtils.kt$com.salesforce.revoman.internal.exe.ExeUtils.kt</ID>
-    <ID>LongMethod:ReVoman.kt$ReVoman$private fun executeStepsSerially( pmStepsFlattened: List&lt;Pair&lt;Step, Item>>, kick: Kick, moshiReVoman: MoshiReVoman, ): List&lt;StepReport></ID>
+    <ID>LongMethod:ReVoman.kt$ReVoman$private fun executeStepsSerially( pmStepsFlattened: List&lt;Pair&lt;Step, Item&gt;&gt;, kick: Kick, moshiReVoman: MoshiReVoman, ): List&lt;StepReport&gt;</ID>
     <ID>SpreadOperator:Step.kt$Step$(*FOLDER_DELIMITER.toCharArray())</ID>
     <ID>SpreadOperator:CaseInsensitiveEnumAdapter.kt$CaseInsensitiveEnumAdapter$(*nameStrings.toTypedArray())</ID>
     <ID>TooManyFunctions:JsonWriterUtils.kt$com.salesforce.revoman.input.json.JsonWriterUtils.kt</ID>
@@ -16,5 +16,59 @@
     <ID>MagicNumber:Constants.kt$299</ID>
     <ID>FunctionNaming:RestfulAPIDevKtTest.kt$RestfulAPIDevKtTest$@Test fun `execute restful-api dev pm collection`()</ID>
   </ManuallySuppressedIssues>
-  <CurrentIssues/>
+  <CurrentIssues>
+    <ID>ComplexCondition:JsonPretty.kt:JsonPretty$next &lt; n &amp;&amp; ((c == '{' &amp;&amp; json[next] == '}') || (c == '[' &amp;&amp; json[next] == ']'))</ID>
+    <ID>ComplexCondition:ReVoman.kt:ReVoman$!bypassLedger &amp;&amp; entry != null &amp;&amp; entry.produces.isNotEmpty() &amp;&amp; entry.hash.isNotEmpty() &amp;&amp; step.sourceHash.isNotEmpty() &amp;&amp; entry.hash != step.sourceHash &amp;&amp; envKeys.containsAll(entry.produces)</ID>
+    <ID>CyclomaticComplexMethod:JsonPretty.kt:JsonPretty$private fun reindent: String</ID>
+    <ID>CyclomaticComplexMethod:ReVoman.kt:ReVoman$@OptIn(ExperimentalStdlibApi::class) private fun runStep: StepReport</ID>
+    <ID>CyclomaticComplexMethod:SandboxBridge.kt:SandboxBridge$private fun decodeResult: PmExecutionResult</ID>
+    <ID>CyclomaticComplexMethod:StepReport.kt:StepReport.Companion$private fun failure: Either&lt;ExeFailure, HttpStatusUnsuccessful&gt;?</ID>
+    <ID>CyclomaticComplexMethod:Template.kt:Request$internal fun toHttpRequest: org.http4k.core.Request</ID>
+    <ID>EmptyFunctionBlock:ConsoleRunLogSink.kt:ConsoleRunLogSink${}</ID>
+    <ID>EmptyFunctionBlock:KickTest.kt:KickTest.&lt;no name provided&gt;${}</ID>
+    <ID>EmptyFunctionBlock:RegexReplacerScopesTest.kt:RegexReplacerScopesTest.RecordingSink${}</ID>
+    <ID>EmptyFunctionBlock:RunLogContextActiveSinkTest.kt:RunLogContextActiveSinkTest.&lt;no name provided&gt;${}</ID>
+    <ID>FunctionOnlyReturningConstant:TypeAdapter.kt:TypeAdapter$@FromJson fun fromJson: Type?</ID>
+    <ID>LongMethod:Polling.kt:@JvmSynthetic internal fun executePolling: Either&lt;PollingFailure, PollingReport?&gt;</ID>
+    <ID>LongMethod:ReVoman.kt:ReVoman$@OptIn(ExperimentalStdlibApi::class) private fun revUpInternal: Rundown</ID>
+    <ID>LongMethod:ReVoman.kt:ReVoman$@OptIn(ExperimentalStdlibApi::class) private fun runStep: StepReport</ID>
+    <ID>LongMethod:ReVoman.kt:ReVoman$private fun executeStepsSerially: SequenceResult</ID>
+    <ID>LongMethod:SandboxBridge.kt:SandboxBridge$fun boot</ID>
+    <ID>LoopWithTooManyJumpStatements:JsonPretty.kt:JsonPretty$while</ID>
+    <ID>LoopWithTooManyJumpStatements:ReVoman.kt:ReVoman$while</ID>
+    <ID>LoopWithTooManyJumpStatements:SandboxBridge.kt:SandboxBridge$for</ID>
+    <ID>LoopWithTooManyJumpStatements:SandboxEventLoop.kt:SandboxEventLoop$while</ID>
+    <ID>MagicNumber:ClasspathResolver.kt:3</ID>
+    <ID>MagicNumber:ClasspathResolver.kt:4</ID>
+    <ID>MagicNumber:DynamicVariableGenerator.kt:256</ID>
+    <ID>MagicNumber:V3ToV2Converter.kt:V3ToV2Converter$16</ID>
+    <ID>NestedBlockDepth:StepReport.kt:StepReport.Companion$private fun failure: Either&lt;ExeFailure, HttpStatusUnsuccessful&gt;?</ID>
+    <ID>ReturnCount:ClasspathResolver.kt:fun resolveClasspath: Pair&lt;Path, FileSystem&gt;?</ID>
+    <ID>ReturnCount:ClasspathResolver.kt:fun resolveClasspathDir: Pair&lt;Path, FileSystem&gt;?</ID>
+    <ID>ReturnCount:ExeUtils.kt:internal fun ledgerSkipDecision: Boolean</ID>
+    <ID>ReturnCount:ExeUtils.kt:internal fun shouldStepBePicked: Boolean</ID>
+    <ID>ReturnCount:Flatted.kt:Flatted$fun parse: Any?</ID>
+    <ID>ReturnCount:Polling.kt:@JvmSynthetic internal fun executePolling: Either&lt;PollingFailure, PollingReport?&gt;</ID>
+    <ID>ReturnCount:ReVoman.kt:ReVoman$@OptIn(ExperimentalStdlibApi::class) private fun runStep: StepReport</ID>
+    <ID>ReturnCount:V3ToV2Converter.kt:V3ToV2Converter$fun toAuth: Auth?</ID>
+    <ID>ReturnCount:V3YamlReader.kt:V3YamlReader$private fun mapToBody: V3Body?</ID>
+    <ID>SwallowedException:JsonPretty.kt:JsonPretty$e: RuntimeException</ID>
+    <ID>SwallowedException:SandboxEventLoopTest.kt:SandboxEventLoopTest$e: IllegalStateException</ID>
+    <ID>ThrowsCount:CompositeResponse.kt:CompositeResponse.Response.SuccessResponse.RecordFactory.RecordAdapter$override fun fromJson: Record?</ID>
+    <ID>TooGenericExceptionCaught:JsonPretty.kt:JsonPretty$e: RuntimeException</ID>
+    <ID>TooGenericExceptionThrown:PollingTest.kt:PollingTest$throw RuntimeException("http call failed")</ID>
+    <ID>TooGenericExceptionThrown:PollingTest.kt:PollingTest$throw RuntimeException("predicate failed")</ID>
+    <ID>TooGenericExceptionThrown:PollingTest.kt:PollingTest$throw RuntimeException("request build failed")</ID>
+    <ID>TooManyFunctions:FileUtils.kt:com.salesforce.revoman.input.FileUtils.kt</ID>
+    <ID>TooManyFunctions:JsonReaderUtils.kt:com.salesforce.revoman.input.json.JsonReaderUtils.kt</ID>
+    <ID>TooManyFunctions:JsonWriterUtils.kt:com.salesforce.revoman.input.json.JsonWriterUtils.kt</ID>
+    <ID>TooManyFunctions:KickDef.kt:KickDef</ID>
+    <ID>TooManyFunctions:MoshiReVoman.kt:MoshiReVoman</ID>
+    <ID>TooManyFunctions:PostmanEnvironment.kt:PostmanEnvironment&lt;ValueT : Any?&gt; : MutableMap</ID>
+    <ID>TooManyFunctions:PostmanSDK.kt:PostmanSDK</ID>
+    <ID>TooManyFunctions:RundownJsonWriter.kt:com.salesforce.revoman.output.RundownJsonWriter.kt</ID>
+    <ID>TooManyFunctions:V3YamlReader.kt:V3YamlReader</ID>
+    <ID>UnusedParameter:StepDirective.kt:fromCursor: Int</ID>
+    <ID>UnusedParameter:TypeAdapter.kt:TypeAdapter$ignore: String</ID>
+  </CurrentIssues>
 </SmellBaseline>

--- a/detekt/config.yml
+++ b/detekt/config.yml
@@ -1,5 +1,3 @@
-build:
-  maxIssues: 999
 comments:
   active: false
 style:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,7 @@ champeau-jmh = "0.7.3"
 
 junit = "5.11.4"
 kover = "0.9.8"
-detekt = "1.23.8"
+detekt = "2.0.0-alpha.5"
 spotless = "8.8.0"
 apache-log4j = "3.0.0-beta2"
 
@@ -84,7 +84,7 @@ postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" 
 
 # Gradle plugins
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-detekt-gradle = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
+detekt-gradle = { module = "dev.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 spotless-gradle = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 
 [bundles]
@@ -100,7 +100,7 @@ kotlin-logging = ["kotlin-logging-jvm", "log4j-api", "log4j-core", "log4j-slf4j2
 [plugins]
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+detekt = { id = "dev.detekt", version.ref = "detekt" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 testLogger = { id = "com.adarshr.test-logger", version.ref = "testLogger" }
 moshix = { id = "dev.zacsweers.moshix", version.ref = "moshix" }


### PR DESCRIPTION
## Summary

Migrates detekt `1.23.8` → `2.0.0-alpha.5` to clear the Gradle-10 `ReportingExtension.file(String)` deprecation that detekt 1.23.x triggers on plugin apply (`ReportingExtension.file` is removed in Gradle 10; detekt 2.0 uses the new `getBaseDirectory()` API).

detekt 2.0 is a **groupId migration**, not a plain version bump:

- coordinates `io.gitlab.arturbosch.detekt` → `dev.detekt` (module + plugin id)
- task class `io.gitlab.arturbosch.detekt.Detekt` → `dev.detekt.gradle.Detekt`
- report DSL `xml` → `checkstyle` (2.0 renamed it — the XML output is Checkstyle-format)
- `config.yml`: dropped obsolete `build.maxIssues` (removed in 2.0; the baseline suppresses known issues instead)
- `baseline.xml`: regenerated in the 2.0 format (67 IDs)

## Verification

- `./gradlew build -x integrationTest` — GREEN (compile + unit tests + detekt)
- `./gradlew spotlessCheck` — clean
- `ReportingExtension` deprecation confirmed gone (deprecation count 2 → 1)

`build`/`check` run only the plain `:detekt` task — same lint coverage as v1. detekt 2.0 also adds opt-in type-resolution tasks (`detektMain`/`detektTest`) that surface extra rules; these are **not** wired into `build`, so nothing new gates the build.

## Caveat

The "Deprecated Gradle features were used" banner will **still print** — a second, separate deprecation (`Project object as a dependency notation`) comes from **kover 0.9.8** (the latest stable release), inside `PrepareKover.kt`. Unfixable until kover ships an upstream fix. This PR removes one of the two deprecations; the kover one remains tracked for the eventual Gradle-10 upgrade.

detekt 2.0.0-alpha.5 is a pre-release; adopted here specifically because the Gradle-10 fix is not backported to the 1.23.x stable line.
