### PR TITLE
docs: perf-improvements design + implementation plans (WT-0..WT-4)

### DIFF
--- a/docs/superpowers/plans/2026-07-13-perf-wt0-foundation.md
+++ b/docs/superpowers/plans/2026-07-13-perf-wt0-foundation.md
@@ -1,0 +1,252 @@
+# Perf WT-0: Foundation (deps + JMH) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the shared build foundation — the `truffle-runtime` optimizing GraalJS dependency, the `kotlinx-collections-immutable` dependency, and a working JMH benchmark module with a baseline-capture procedure — so the four domain worktrees (WT-1..WT-4) can branch off it and each add their own benchmarks and fixes conflict-free.
+
+**Architecture:** This worktree touches ONLY build configuration — `gradle/libs.versions.toml` and `build.gradle.kts` — plus one trivial Kotlin benchmark and one markdown procedure doc. No application/source-logic changes. The "tests" for this build/config plan are Gradle invocations that must succeed: `./gradlew dependencies` (deps resolve), `./gradlew tasks` (the JMH plugin applies on the pinned Gradle), `./gradlew jmh -Pjmh.includes=SmokeBenchmark` (the harness runs end-to-end), and `./gradlew build test integrationTest` (nothing regresses). Every task ends with a real verification command, its expected output, and a conventional commit.
+
+**Tech Stack:** Kotlin 2.4.20-Beta1, Gradle (wrapper 9.7.0-milestone-3), JMH via me.champeau.jmh, GraalVM 25.1.3, kotlinx.collections.immutable
+
+## Global Constraints
+- JDK 21+ required
+- All existing tests must stay green: `./gradlew test integrationTest`
+- Preserve the functional-programming style (STYLE.md): Either/map/flatMap/fold, immutable flow — no imperative rewrites
+- `./gradlew spotlessApply` before every commit
+- Prefer `./gradlew` (wrapper); fall back to installed `gradle` only if the distribution can't be fetched
+
+## Versions to verify before/while implementing (no guessing at merge time)
+- **`champeau-jmh = "0.7.3"`** (the `me.champeau.jmh` plugin) — **must be confirmed compatible with the pinned Gradle `9.7.0-milestone-3`.** Task 3's verification IS this gate. If the plugin fails to apply on the milestone Gradle, use the manual-JMH fallback documented under Task 3 (no plugin: raw `jmh` source set + `org.openjdk.jmh` deps + a `JavaExec` task).
+- **`kotlinx-collections-immutable = "0.4.0"`** — confirm it resolves via `./gradlew dependencies`; bump to the newest stable if `0.4.0` is unresolved on the configured repos. On the JVM this multiplatform artifact resolves to the `-jvm` variant.
+- **`jmh = "1.37"`** (JMH core, pinned via the `jmh { jmhVersion = … }` extension) — confirm it is the JMH core version the chosen plugin release expects; adjust if the plugin bundles a newer default.
+
+---
+
+### Task 1: Add the `truffle-runtime` optimizing GraalJS dependency
+**Files:**
+- Modify: `gradle/libs.versions.toml` (add a `[libraries]` entry after line 75)
+- Modify: `build.gradle.kts:33` (add an `api` dependency next to `implementation(libs.graal.js)`)
+**Interfaces:**
+- Produces: `libs.truffle.runtime` catalog accessor, exposed as an `api` dependency so every ReVoman consumer (and WT-1's shared-`Engine` work) inherits the optimizing runtime (jargraal) on stock JDK 21.
+
+- [ ] **Step 1: Add the catalog library entry.** In `gradle/libs.versions.toml`, in the `[libraries]` block, add this line immediately after the `mockk = …` line (currently line 75). Reuse the existing `graal` version (25.1.3):
+  ```toml
+  truffle-runtime = { module = "org.graalvm.truffle:truffle-runtime", version.ref = "graal" }
+  ```
+- [ ] **Step 2: Add the `api` dependency.** In `build.gradle.kts`, inside the `dependencies { … }` block, add this line immediately after `implementation(libs.graal.js)` (currently line 33) so both GraalJS artifacts sit together:
+  ```kotlin
+  api(libs.truffle.runtime)
+  ```
+- [ ] **Step 3: Run `./gradlew dependencies --configuration runtimeClasspath | grep -i truffle`** — Expected: a line resolving `org.graalvm.truffle:truffle-runtime:25.1.3` on the runtime classpath, and `BUILD SUCCESSFUL` for the underlying task. (If `grep` filters out the `BUILD SUCCESSFUL` line, re-run without the pipe to confirm success.)
+- [ ] **Step 4: Format + commit.**
+  ```bash
+  ./gradlew spotlessApply
+  git add gradle/libs.versions.toml build.gradle.kts
+  git commit -m "build: add org.graalvm.truffle:truffle-runtime as api dep (optimizing GraalJS runtime)"
+  ```
+
+---
+
+### Task 2: Add the `kotlinx-collections-immutable` dependency
+**Files:**
+- Modify: `gradle/libs.versions.toml` (add a `[versions]` entry after line 30 and a `[libraries]` entry after the Task 1 entry)
+- Modify: `build.gradle.kts` (add an `implementation` dependency in the `dependencies` block)
+**Interfaces:**
+- Produces: `libs.kotlinx.collections.immutable` catalog accessor (`implementation` scope) — WT-4 uses it to back `PostmanEnvironment` with a persistent map (fix E2).
+
+- [ ] **Step 1: Add the version.** In `gradle/libs.versions.toml`, in the `[versions]` block, add this line immediately after `gradle-taskinfo = "3.0.2"` (currently line 30):
+  ```toml
+  kotlinx-collections-immutable = "0.4.0"
+  ```
+- [ ] **Step 2: Add the catalog library entry.** In `gradle/libs.versions.toml`, in the `[libraries]` block, add this line immediately after the `truffle-runtime = …` line added in Task 1:
+  ```toml
+  kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinx-collections-immutable" }
+  ```
+- [ ] **Step 3: Add the `implementation` dependency.** In `build.gradle.kts`, inside the `dependencies { … }` block, add this line immediately after `implementation(libs.graal.js)` / the Task 1 `api(libs.truffle.runtime)` line (grouping is cosmetic; any spot in the `implementation` group is fine):
+  ```kotlin
+  implementation(libs.kotlinx.collections.immutable)
+  ```
+- [ ] **Step 4: Run `./gradlew dependencies --configuration runtimeClasspath | grep -i collections-immutable`** — Expected: a line resolving `org.jetbrains.kotlinx:kotlinx-collections-immutable(-jvm):0.4.0`. If the line is ABSENT or shows `FAILED`, the version is wrong: run `./gradlew dependencies --configuration compileClasspath` to see the resolution error, bump `kotlinx-collections-immutable` in `[versions]` to the newest stable release, and re-run until it resolves. Record the version you settled on in the commit message.
+- [ ] **Step 5: Format + commit.**
+  ```bash
+  ./gradlew spotlessApply
+  git add gradle/libs.versions.toml build.gradle.kts
+  git commit -m "build: add kotlinx-collections-immutable (persistent-map backing for env, WT-4)"
+  ```
+
+---
+
+### Task 3: Register the `me.champeau.jmh` plugin (Gradle-9 compatibility gate)
+**Files:**
+- Modify: `gradle/libs.versions.toml` (`[versions]` after Task 2 entry; `[plugins]` after line 102)
+- Modify: `build.gradle.kts:11-19` (add an `alias(...)` to the `plugins { }` block)
+**Interfaces:**
+- Produces: the applied `me.champeau.jmh` plugin and its task graph (`jmh`, `jmhJar`, `jmhClasses`, `compileJmhKotlin`) — the shared benchmark harness all domain worktrees build on. Also produces the `libs.plugins.jmh` catalog accessor.
+
+- [ ] **Step 1: Add the plugin + JMH-core versions.** In `gradle/libs.versions.toml`, in the `[versions]` block, add these two lines immediately after the `kotlinx-collections-immutable = "0.4.0"` line from Task 2. (Distinct roots `jmh` and `champeau-jmh` avoid the version-catalog "cannot have both a value and sub-values" clash.)
+  ```toml
+  jmh = "1.37"
+  champeau-jmh = "0.7.3"
+  ```
+- [ ] **Step 2: Add the plugin catalog entry.** In `gradle/libs.versions.toml`, in the `[plugins]` block, add this line immediately after `gradle-taskinfo = {id = "org.barfuin.gradle.taskinfo", version.ref = "gradle-taskinfo"}` (currently line 102):
+  ```toml
+  jmh = { id = "me.champeau.jmh", version.ref = "champeau-jmh" }
+  ```
+- [ ] **Step 3: Apply the plugin.** In `build.gradle.kts`, in the `plugins { }` block, add this line immediately after `alias(libs.plugins.nexus.publish)` (currently line 18), i.e. as the last alias before the closing `}`:
+  ```kotlin
+  alias(libs.plugins.jmh)
+  ```
+- [ ] **Step 4: Run `./gradlew tasks --all | grep -i jmh`** — Expected: the plugin applied cleanly on Gradle 9.7.0-milestone-3 and registered its tasks, e.g. lines containing `jmh`, `jmhJar`, `jmhClasses`, and `compileJmhKotlin`. Also confirm the overall invocation prints `BUILD SUCCESSFUL`.
+  - **If this FAILS** (plugin incompatible with the milestone Gradle — a genuine risk with a pre-release Gradle): do NOT block. Fall back to a manual JMH setup and note it in the commit. Revert Steps 2-3 (keep the `[versions]` entries) and instead: (a) declare a `jmh` source set via `sourceSets { create("jmh") { … } }` extending the main output; (b) add `jmhImplementation("org.openjdk.jmh:jmh-core:1.37")` and `kapt("org.openjdk.jmh:jmh-generator-annprocess:1.37")` (JMH's `@Benchmark` annotation processor — kapt is already applied via `revoman.kt-conventions`); (c) register a `JavaExec` task named `jmh` whose `mainClass` is `org.openjdk.jmh.Main`, classpath is the `jmh` source set runtime classpath, and which forwards `-Pjmh.includes` as its first program argument. The Task 4/5 source-set path and `-Pjmh.includes` invocation stay identical, so WT-1..4 are unaffected.
+- [ ] **Step 5: Format + commit.**
+  ```bash
+  ./gradlew spotlessApply
+  git add gradle/libs.versions.toml build.gradle.kts
+  git commit -m "build: apply me.champeau.jmh plugin for the benchmark module"
+  ```
+
+---
+
+### Task 4: Wire `-Pjmh.includes`, add the JMH source set + smoke benchmark, run it
+**Files:**
+- Modify: `build.gradle.kts` (add a top-level `jmh { }` extension block after the `moshi { … }` block, ~line 155)
+- Create: `src/jmh/kotlin/com/salesforce/revoman/benchmark/SmokeBenchmark.kt`
+**Interfaces:**
+- Produces: (1) the source-set path **`src/jmh/kotlin/com/salesforce/revoman/benchmark/`** — WT-1..WT-4 each drop their own `*Benchmark.kt` here; (2) the invocation contract **`./gradlew jmh -Pjmh.includes=<ClassSimpleName>`** — wired by the `jmh { }` block reading the `jmh.includes` project property; (3) a pinned JMH core version via `jmhVersion`.
+
+- [ ] **Step 1: Add the `jmh { }` extension block.** In `build.gradle.kts`, after the `moshi { enableSealed = true }` line (currently line 155), add:
+  ```kotlin
+  jmh {
+    // Pin JMH core so every worktree benchmarks against a known JMH release.
+    jmhVersion = libs.versions.jmh.get()
+    // Select benchmarks from the CLI, e.g. ./gradlew jmh -Pjmh.includes=SmokeBenchmark
+    if (project.hasProperty("jmh.includes")) {
+      includes.add(project.property("jmh.includes").toString())
+    }
+  }
+  ```
+  (This targets the champeau-jmh 0.7.x lazy-property API: `jmhVersion` is a `Property<String>` set via `=`, `includes` is a `ListProperty<String>` appended via `.add(...)`. If you took the manual-JMH fallback in Task 3, skip this block — the `JavaExec` task already reads `-Pjmh.includes`.)
+- [ ] **Step 2: Create the smoke benchmark.** Create `src/jmh/kotlin/com/salesforce/revoman/benchmark/SmokeBenchmark.kt` with exactly this content (open class + open method so JMH can subclass/invoke it; named constant avoids the detekt `MagicNumber` rule; fast fork/iteration settings keep the smoke run to a few seconds):
+  ```kotlin
+  /**
+   * ************************************************************************************************
+   * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+   * Version 2.0 For full license text, see the LICENSE file in the repo root or
+   * http://www.apache.org/licenses/LICENSE-2.0
+   * ************************************************************************************************
+   */
+  package com.salesforce.revoman.benchmark
+
+  import java.util.concurrent.TimeUnit
+  import org.openjdk.jmh.annotations.Benchmark
+  import org.openjdk.jmh.annotations.BenchmarkMode
+  import org.openjdk.jmh.annotations.Fork
+  import org.openjdk.jmh.annotations.Measurement
+  import org.openjdk.jmh.annotations.Mode
+  import org.openjdk.jmh.annotations.OutputTimeUnit
+  import org.openjdk.jmh.annotations.Scope
+  import org.openjdk.jmh.annotations.State
+  import org.openjdk.jmh.annotations.Warmup
+
+  private const val UPPER_BOUND = 100
+
+  /**
+   * Smoke benchmark proving the `jmh` source set compiles and the `me.champeau.jmh` toolchain runs
+   * end-to-end on this project. The domain worktrees (WT-1..WT-4) drop their own `*Benchmark.kt`
+   * into this same package; this file only validates the harness.
+   */
+  @State(Scope.Benchmark)
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  @Fork(1)
+  @Warmup(iterations = 1, time = 1)
+  @Measurement(iterations = 1, time = 1)
+  open class SmokeBenchmark {
+    @Benchmark open fun sumOfRange(): Int = (1..UPPER_BOUND).sum()
+  }
+  ```
+- [ ] **Step 3: Run `./gradlew jmh -Pjmh.includes=SmokeBenchmark`** — Expected: the run compiles `compileJmhKotlin`, executes JMH, prints a results table whose last data row contains `SmokeBenchmark.sumOfRange … avgt …`, writes results to `build/results/jmh/results.txt`, and ends with `BUILD SUCCESSFUL`. (First run downloads JMH artifacts — that's expected.)
+- [ ] **Step 4: Sanity-check compile-only path.** Run `./gradlew compileJmhKotlin` — Expected: `BUILD SUCCESSFUL` (or `UP-TO-DATE`), proving the Kotlin `jmh` compilation is wired so WT-1..4 files will compile.
+- [ ] **Step 5: Format + commit.**
+  ```bash
+  ./gradlew spotlessApply
+  git add build.gradle.kts src/jmh/kotlin/com/salesforce/revoman/benchmark/SmokeBenchmark.kt
+  git commit -m "feat: add JMH source set + SmokeBenchmark, wire -Pjmh.includes selection"
+  ```
+
+---
+
+### Task 5: Document the baseline-capture procedure and record the smoke baseline
+**Files:**
+- Create: `docs/superpowers/benchmarks/baseline.md`
+- Create: `docs/superpowers/benchmarks/results/` (holds captured result snapshots; add a `.gitkeep`)
+**Interfaces:**
+- Produces: the baseline protocol every domain worktree follows — run its benchmark on the WT-0 base commit BEFORE its fix lands, snapshot `build/results/jmh/results.txt` into `docs/superpowers/benchmarks/results/<sha>-<domain>.txt`, then re-run after the fix and record the delta.
+
+- [ ] **Step 1: Create the results snapshot dir.** Create an empty file `docs/superpowers/benchmarks/results/.gitkeep` so the directory is tracked.
+- [ ] **Step 2: Create the baseline doc.** Create `docs/superpowers/benchmarks/baseline.md` with exactly this content:
+  ````markdown
+  # ReVoman Perf Benchmarks — Baseline Capture
+
+  Component-level JMH benchmarks live in `src/jmh/kotlin/com/salesforce/revoman/benchmark/`.
+  Full end-to-end collection runs need live network/orgs and are NOT JMH-repeatable, so we
+  benchmark the isolated hot paths the perf audit flagged (regex/vars, marshalling, GraalJS
+  eval, env accumulation).
+
+  ## Run all benchmarks
+
+  ```bash
+  ./gradlew jmh
+  ```
+
+  Results are written to `build/results/jmh/results.txt`.
+
+  ## Run one benchmark class
+
+  ```bash
+  ./gradlew jmh -Pjmh.includes=SmokeBenchmark      # regex substring against the class name
+  ```
+
+  ## Baseline protocol (per domain worktree WT-1..WT-4)
+
+  1. **Before** applying the domain fix, from the worktree's WT-0 base commit, run the domain's
+     benchmark and snapshot the numbers:
+     ```bash
+     ./gradlew jmh -Pjmh.includes=<DomainBenchmark>
+     cp build/results/jmh/results.txt docs/superpowers/benchmarks/results/$(git rev-parse --short HEAD)-<domain>-before.txt
+     ```
+  2. **After** the fix lands (tests green), re-run the same benchmark and snapshot again with a
+     `-after` suffix.
+  3. Record the before/after delta in the worktree's PR description / ledger. Keep the raw
+     snapshot files committed under `docs/superpowers/benchmarks/results/` so deltas are auditable.
+
+  ## Notes
+
+  - The optimizing GraalJS runtime (`org.graalvm.truffle:truffle-runtime`, added in WT-0) is on the
+    classpath, so GraalJS benchmarks measure jargraal-JIT behavior, not interpreter-only.
+  - JMH warmup/fork settings live on each `@Benchmark` class; the smoke benchmark uses minimal
+    iterations for speed — domain benchmarks should use JMH defaults or higher for stable numbers.
+  ````
+- [ ] **Step 3: Capture the smoke baseline.** Run `./gradlew jmh -Pjmh.includes=SmokeBenchmark` then copy the result: `cp build/results/jmh/results.txt "docs/superpowers/benchmarks/results/$(git rev-parse --short HEAD)-smoke.txt"` — Expected: `BUILD SUCCESSFUL` and a non-empty snapshot file containing a `SmokeBenchmark.sumOfRange` row. This proves the capture mechanism end-to-end.
+- [ ] **Step 4: Commit.**
+  ```bash
+  git add docs/superpowers/benchmarks/
+  git commit -m "docs: add JMH baseline-capture procedure + smoke snapshot"
+  ```
+
+---
+
+### Task 6: Full green gate (nothing regressed)
+**Files:** none (verification only)
+**Interfaces:**
+- Produces: the guarantee that WT-1..WT-4 branch off a green WT-0 — deps resolve, formatting is clean, and unit + integration tests still pass with the new `truffle-runtime` runtime on the classpath.
+
+- [ ] **Step 1: Verify formatting is clean.** Run `./gradlew spotlessCheck` — Expected: `BUILD SUCCESSFUL` (no formatting violations from the new benchmark / build-script edits).
+- [ ] **Step 2: Run the unit build + tests.** Run `./gradlew build` — Expected: `BUILD SUCCESSFUL` (compiles all source sets, runs detekt + unit `test`; the new `truffle-runtime` classpath addition must not break the build or unit tests).
+- [ ] **Step 3: Run the full test gate.** Run `./gradlew test integrationTest` — Expected: `BUILD SUCCESSFUL`. (Integration tests may require network access to Pokemon/restfulapi.dev/apigee; run where that access is available. WT-0 changes only build config, so behavior is unchanged — this confirms the optimizing GraalJS runtime is a transparent, faster drop-in.)
+- [ ] **Step 4: Commit (only if Step 1 auto-fixed anything).** If `spotlessCheck` failed and you ran `./gradlew spotlessApply` to fix it:
+  ```bash
+  git add -A
+  git commit -m "chore: spotless formatting for WT-0 foundation"
+  ```
+  Otherwise no commit is needed — WT-0 is complete and green.

--- a/docs/superpowers/plans/2026-07-13-perf-wt1-sandbox.md
+++ b/docs/superpowers/plans/2026-07-13-perf-wt1-sandbox.md
@@ -1,0 +1,697 @@
+# Perf WT-1: Sandbox / GraalJS Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut GraalJS per-eval latency in the Postman sandbox by sharing one immutable GraalVM `Engine` across the two per-run `Context`s (reusing the parsed 2.2 MB bootcode Source + JIT), memoizing the `JSON.parse` closure, and stop the per-step 3× duplication of the current step's report in `pm.rundown` — all behavior-preserving except the intentional mid-run `Rundown` de-duplication (E1).
+
+**Architecture:** ONE process-wide immutable `Engine` (a top-level `by lazy` val in `SandboxBridge.kt`) is passed to BOTH `Context.newBuilder("js").engine(sharedGraalEngine)` sites — the sandbox `Context` in `SandboxBridge.boot()` and the `JSEvaluator` `Context` in `PostmanSDK`. Each `Context` stays STRICTLY per-run (never shared) so guest globals/env cannot bleed between runs. Stateless guest closures (`JSON.parse`) are memoized as `by lazy` `Value`s bound to their per-run Context; the constant `imports` prefix becomes an immutable `val`.
+
+**Tech Stack:** Kotlin, GraalVM 25.1.3 polyglot (`js-language` + `truffle-runtime`), Moshi, JMH.
+
+## Global Constraints
+- JDK 21+; branched off WT-0 (has `libs.truffle.runtime` + JMH source set)
+- Owns ONLY `SandboxBridge.kt`, `PmJsEval.kt`, `PostmanSDK.kt` — touch no other source file
+- Correctness gate: `./gradlew test integrationTest` green (non-core; core IT needs `-PincludeCoreIT` + a real org — skip it)
+- Preserve FP style (STYLE.md): Either/map/flatMap/fold, immutable flow — no imperative rewrites
+- CRITICAL: share GraalVM Engine ONLY, never a Context (guest-state bleed)
+- `./gradlew spotlessApply` before every commit
+---
+
+## Interfaces (WT-0 contract this worktree consumes)
+
+- **Consumes from WT-0:** `libs.truffle.runtime` catalog accessor added as `api` in `build.gradle.kts` (A1); a `src/jmh/kotlin` source set wired with the `me.champeau.jmh`-style plugin and a **friend-path to `main`** (`associateWith` the `main` compilation, mirroring the `integrationTest` wiring at `build.gradle.kts:83-85`) so the benchmark can see `internal` members (`PmSandbox`, `PmScope`, `PmExecutionContext`, `ScriptTarget`). Benchmark run contract: `./gradlew jmh -Pjmh.includes=SandboxBenchmark`.
+- **Produces (for the whole effort):** a shared `internal val sharedGraalEngine: Engine` (top-level in `SandboxBridge.kt`) — no `ReVoman.kt` edit required; a de-duplicated mid-run `pm.rundown` from `syncProgress` (E1).
+- **DO NOT TOUCH `ReVoman.kt`** (owned by WT-4). The `Rundown` seed at `ReVoman.kt:402` (`stepReportsSoFar + preStepReport`) is deliberately left in place this pass — see the E1 coupling note at the end.
+
+---
+
+## Task 0 — Preflight: confirm WT-0 landed
+
+**Files:** `build.gradle.kts`, `gradle/libs.versions.toml` (READ-ONLY here — do not edit; they belong to WT-0)
+**Interfaces:** Consumes WT-0 deps + jmh source set.
+
+- [ ] Confirm the Truffle runtime dep is present:
+  ```bash
+  grep -n "truffle" gradle/libs.versions.toml build.gradle.kts
+  ```
+  Expected: a `truffle-runtime = { module = "org.graalvm.truffle:truffle-runtime", version.ref = "graal" }` catalog entry and an `api(libs.truffle.runtime)` line in `build.gradle.kts`.
+- [ ] Confirm the JMH source set + friend-path exist:
+  ```bash
+  ls src/jmh/kotlin 2>/dev/null; grep -n "jmh\|associateWith" build.gradle.kts
+  ```
+  Expected: `src/jmh/kotlin` exists; a jmh compilation `associateWith` the `main` compilation. If the friend-path is MISSING, the sandbox benchmark (Task 12) must fall back to the PUBLIC-API variant (`PostmanSDK.jsonStrToObj` / `evaluateJS`) — note it and proceed.
+- [ ] Baseline the existing suite so later regressions are attributable:
+  ```bash
+  ./gradlew test integrationTest
+  ```
+  Expected: `BUILD SUCCESSFUL`. (Core IT excluded by `build.gradle.kts:188-193`.)
+
+---
+
+## Task 1 — A2 characterization + state-bleed tests (RED-safe: green on baseline, must stay green)
+
+**Files:**
+- NEW `src/test/kotlin/com/salesforce/revoman/internal/postman/sandbox/SandboxEngineSharingTest.kt`
+- NEW `src/test/kotlin/com/salesforce/revoman/internal/postman/PostmanSDKEvalIsolationTest.kt`
+
+**Interfaces:** Consumes `PmSandbox`, `PmExecutionContext`, `PmScope`, `ScriptTarget` (internal, sandbox pkg) and `PostmanSDK` + `initMoshi`. Produces the state-bleed gate (#1 risk).
+
+- [ ] Write the sandbox reuse + state-bleed test. Real APIs: `PmSandbox()`, `sandbox.execute(script, ScriptTarget.TEST, PmExecutionContext(environment = PmScope("e", emptyMap()), response = ...))` returns `PmExecutionResult` with `.environment`, `.assertions`, `.error` (all confirmed from `PmSandboxScriptApiTest.kt`).
+  ```kotlin
+  /**
+   * ************************************************************************************************
+   * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+   * Version 2.0 For full license text, see the LICENSE file in the repo root or
+   * http://www.apache.org/licenses/LICENSE-2.0
+   * ************************************************************************************************
+   */
+  package com.salesforce.revoman.internal.postman.sandbox
+
+  import io.kotest.matchers.shouldBe
+  import org.junit.jupiter.api.Test
+
+  /**
+   * A2 guard: the shared immutable GraalVM Engine reuses parsed bootcode across runs, but each run
+   * gets its OWN Context. These tests pin that (a) repeated evals in one sandbox are deterministic
+   * and (b) two sandboxes NEVER see each other's guest globals or env — the #1 state-bleed risk.
+   */
+  class SandboxEngineSharingTest {
+      private fun testCtx(env: Map<String, Any?> = emptyMap()) =
+          PmExecutionContext(environment = PmScope("e", env))
+
+      @Test
+      fun `same script evaluated twice in one sandbox yields identical results`() {
+          val sandbox = PmSandbox()
+          val script =
+              """
+              pm.test('sum', () => pm.expect(1 + 1).to.eql(2));
+              pm.environment.set('n', 41 + 1);
+              """
+                  .trimIndent()
+          val r1 = sandbox.execute(script, ScriptTarget.TEST, testCtx())
+          val r2 = sandbox.execute(script, ScriptTarget.TEST, testCtx())
+          sandbox.close()
+          r1.error shouldBe null
+          r2.error shouldBe null
+          r1.assertions[0].passed shouldBe true
+          r2.assertions[0].passed shouldBe true
+          r1.environment["n"] shouldBe 42
+          r2.environment["n"] shouldBe 42
+      }
+
+      @Test
+      fun `two sandboxes sharing the Engine do not leak guest globals or env`() {
+          val s1 = PmSandbox()
+          s1.execute(
+              "globalThis.__leak = 'from-s1'; pm.environment.set('leakedEnv', 'v1');",
+              ScriptTarget.TEST,
+              testCtx(),
+          )
+          val s2 = PmSandbox()
+          val r =
+              s2.execute(
+                  """
+                  pm.environment.set('sawGlobal', typeof globalThis.__leak);
+                  pm.environment.set('sawEnv', pm.environment.has('leakedEnv'));
+                  """
+                      .trimIndent(),
+                  ScriptTarget.TEST,
+                  testCtx(),
+              )
+          s1.close()
+          s2.close()
+          r.error shouldBe null
+          r.environment["sawGlobal"] shouldBe "undefined" // fresh Context: s1's global unseen
+          r.environment["sawEnv"] shouldBe false // fresh Context: s1's env unseen
+      }
+  }
+  ```
+- [ ] Write the JSEvaluator (PostmanSDK) isolation test. Real APIs: `PostmanSDK(initMoshi(), "js")`, `pm.evaluateJS(js): Value`, `Value.asString()` (confirmed from `EvalJsTest.kt`). Use `globalThis`, NOT `pm.variables.set` (the latter logs `currentStepReport.step`, which is `lateinit` and would NPE).
+  ```kotlin
+  /**
+   * ************************************************************************************************
+   * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+   * Version 2.0 For full license text, see the LICENSE file in the repo root or
+   * http://www.apache.org/licenses/LICENSE-2.0
+   * ************************************************************************************************
+   */
+  package com.salesforce.revoman.internal.postman
+
+  import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
+  import io.kotest.matchers.shouldBe
+  import org.junit.jupiter.api.Test
+
+  /**
+   * A2 guard for the JSEvaluator Context (peer of the sandbox Context). The Engine is shared; the
+   * Context is per-PostmanSDK. Two instances must NOT see each other's guest globals.
+   */
+  class PostmanSDKEvalIsolationTest {
+      @Test
+      fun `two PostmanSDK instances sharing the Engine do not leak JS globals`() {
+          val pm1 = PostmanSDK(initMoshi())
+          pm1.evaluateJS("globalThis.__leak = 'from-pm1'; 1")
+          val pm2 = PostmanSDK(initMoshi())
+          pm2.evaluateJS("typeof globalThis.__leak").asString() shouldBe "undefined"
+      }
+  }
+  ```
+- [ ] Run them on the pre-change tree:
+  ```bash
+  ./gradlew test --tests "com.salesforce.revoman.internal.postman.sandbox.SandboxEngineSharingTest" --tests "com.salesforce.revoman.internal.postman.PostmanSDKEvalIsolationTest"
+  ```
+  Expected: `BUILD SUCCESSFUL` — both PASS already (per-run Context isolation holds today; these lock it so the Engine-sharing refactor can't regress it).
+- [ ] `./gradlew spotlessApply` + commit: `test(sandbox): pin Engine-reuse determinism + cross-run state-bleed isolation (A2)`
+
+---
+
+## Task 2 — A2 implement: one shared immutable Engine
+
+**Files:** `SandboxBridge.kt` (~line 45 Context build; ~line 56 the `engine.WarnInterpreterOnly` option), `PostmanSDK.kt` (~line 122 options map; ~line 130 `engine.WarnInterpreterOnly`; ~line 132 Context build)
+**Interfaces:** Produces `sharedGraalEngine`. Consumes WT-0's `truffle-runtime`.
+
+- [ ] Add the shared Engine as a top-level `by lazy` val in `SandboxBridge.kt`. Add `import org.graalvm.polyglot.Engine` (the file already imports `Context`, `Source`, `Value` from `org.graalvm.polyglot`). Place it just below the imports, above `internal class SandboxBridge`:
+  ```kotlin
+  /**
+   * ONE process-wide immutable GraalVM [Engine], shared by every per-run [Context] (the sandbox
+   * Context here AND the PostmanSDK JSEvaluator Context). The Engine caches the parsed 2.2 MB
+   * bootcode [Source] and JIT-compiled code across runs and across both Context kinds, so the
+   * interpreter->JIT warm-up and the bootcode parse are paid once per JVM, not per ReVoman run.
+   *
+   * Engines are thread-safe and long-lived by design; Contexts are single-threaded and per-run.
+   * Sharing the Engine does NOT weaken the single-threaded Context contract, and — critically —
+   * guest state (globals/env) lives in the Context, so sharing the Engine cannot bleed state
+   * between runs. Never construct a Context WITHOUT this Engine. Left unclosed for the JVM lifetime
+   * (standard for a shared library Engine).
+   */
+  internal val sharedGraalEngine: Engine by lazy {
+      Engine.newBuilder("js")
+          .allowExperimentalOptions(true)
+          // Engine-level option: silence the "interpreter only / fallback runtime" warning. With
+          // WT-0's truffle-runtime on the classpath this warning should no longer fire — Task 14
+          // verifies and removes this line if so. Kept here (single home) until then.
+          .option("engine.WarnInterpreterOnly", "false")
+          .build()
+  }
+  ```
+- [ ] In `SandboxBridge.boot()`, wire the Engine into the Context and DROP the now-duplicated engine option. BEFORE (lines 45-59):
+  ```kotlin
+      ctx =
+        Context.newBuilder("js")
+          .allowExperimentalOptions(true)
+          .option("js.esm-eval-returns-exports", "true")
+          .option("js.ecmascript-version", "2024")
+          // Silence GraalVM's "fallback runtime / interpreter only" warning. ...
+          .option("engine.WarnInterpreterOnly", "false")
+          .allowHostAccess(HostAccess.ALL)
+          .allowHostClassLookup { true }
+          .build()
+  ```
+  AFTER (engine option removed — it now lives on `sharedGraalEngine`; the long comment block goes away):
+  ```kotlin
+      ctx =
+        Context.newBuilder("js")
+          .engine(sharedGraalEngine)
+          .allowExperimentalOptions(true)
+          .option("js.esm-eval-returns-exports", "true")
+          .option("js.ecmascript-version", "2024")
+          .allowHostAccess(HostAccess.ALL)
+          .allowHostClassLookup { true }
+          .build()
+  ```
+- [ ] In `PostmanSDK.kt`, add `import com.salesforce.revoman.internal.postman.sandbox.sharedGraalEngine` (both are `internal` in the same module — cross-package `internal` access is allowed). Then in `JSEvaluator.init`, drop the engine-level option from the options map and wire the Engine into the Context. BEFORE (lines 122-140):
+  ```kotlin
+      init {
+        val options = buildMap {
+          if (!nodeModulesPath.isNullOrBlank()) {
+            logger.info { "nodeModulesPath: $nodeModulesPath" }
+            put("js.commonjs-require", "true")
+            put("js.commonjs-require-cwd", nodeModulesPath)
+            imports = "var _ = require('lodash')\n"
+          }
+          put("js.esm-eval-returns-exports", "true")
+          put("engine.WarnInterpreterOnly", "false")
+        }
+        jsContext =
+          Context.newBuilder("js")
+            .allowExperimentalOptions(true)
+            .allowIO(IOAccess.ALL)
+            .allowExperimentalOptions(true)
+            .options(options)
+            .allowHostAccess(HostAccess.ALL)
+            .allowHostClassLookup { true }
+            .build()
+  ```
+  AFTER (engine option removed; the duplicate `allowExperimentalOptions(true)` collapsed to one; `.engine(sharedGraalEngine)` added; `imports` becomes a `val` — see Task 7/A4, which this init already enables):
+  ```kotlin
+      init {
+        val options = buildMap {
+          if (!nodeModulesPath.isNullOrBlank()) {
+            logger.info { "nodeModulesPath: $nodeModulesPath" }
+            put("js.commonjs-require", "true")
+            put("js.commonjs-require-cwd", nodeModulesPath)
+          }
+          put("js.esm-eval-returns-exports", "true")
+        }
+        jsContext =
+          Context.newBuilder("js")
+            .engine(sharedGraalEngine)
+            .allowExperimentalOptions(true)
+            .allowIO(IOAccess.ALL)
+            .options(options)
+            .allowHostAccess(HostAccess.ALL)
+            .allowHostClassLookup { true }
+            .build()
+  ```
+  (The `imports` assignment moves out of `init` in Task 7. If Task 7 is deferred, keep `imports = "var _ = require('lodash')\n"` inside the `if` block for now.)
+- [ ] Run the A2 tests + the existing sandbox/eval suites:
+  ```bash
+  ./gradlew test --tests "com.salesforce.revoman.internal.postman.sandbox.*" --tests "com.salesforce.revoman.input.EvalJsTest" --tests "com.salesforce.revoman.internal.postman.PostmanSDKEvalIsolationTest"
+  ```
+  Expected: `BUILD SUCCESSFUL` — all green (reuse + isolation preserved; `PmSandboxBootTest`, `PmSandboxScriptApiTest`, `EvalJsTest` unaffected).
+- [ ] Full correctness gate:
+  ```bash
+  ./gradlew test integrationTest
+  ```
+  Expected: `BUILD SUCCESSFUL`.
+- [ ] `./gradlew spotlessApply` + commit: `perf(sandbox): share one immutable GraalVM Engine across both JS contexts (A2)`
+
+---
+
+## Task 3 — A3 characterization test: repeated JSON parsing
+
+**Files:** NEW `src/test/kotlin/com/salesforce/revoman/internal/postman/PostmanSDKJsonStrToObjTest.kt`
+**Interfaces:** Consumes `PostmanSDK.jsonStrToObj(String): Value` (public, line 226). Produces the memoization-safety gate.
+
+- [ ] Write the test. Real API: `pm.jsonStrToObj(jsonStr).getMember("k")` / `.asInt()` / `.asString()` on the returned `Value` (GraalJS `Value` reflection). Two calls with DIFFERENT JSON must return DIFFERENT correct results — proving a memoized parse CLOSURE (A3) is reused but the parse itself is NOT wrongly cached by input.
+  ```kotlin
+  /**
+   * ************************************************************************************************
+   * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+   * Version 2.0 For full license text, see the LICENSE file in the repo root or
+   * http://www.apache.org/licenses/LICENSE-2.0
+   * ************************************************************************************************
+   */
+  package com.salesforce.revoman.internal.postman
+
+  import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
+  import io.kotest.matchers.shouldBe
+  import org.junit.jupiter.api.Test
+
+  /**
+   * A3 guard: `jsonStrToObj` memoizes the JSON.parse arrow CLOSURE, not the parse RESULT. Repeated
+   * calls with different inputs must still parse each input correctly (closure reuse != result
+   * cache), and comment-tolerant parsing (`allowComments: true`) must be preserved.
+   */
+  class PostmanSDKJsonStrToObjTest {
+      private val pm = PostmanSDK(initMoshi())
+
+      @Test
+      fun `repeated parses with different inputs each parse correctly`() {
+          pm.jsonStrToObj("""{"a": 1}""").getMember("a").asInt() shouldBe 1
+          pm.jsonStrToObj("""{"a": 2}""").getMember("a").asInt() shouldBe 2
+          pm.jsonStrToObj("""{"b": "x"}""").getMember("b").asString() shouldBe "x"
+      }
+
+      @Test
+      fun `parse still tolerates JSON5 comments`() {
+          pm.jsonStrToObj(
+                  """
+                  {
+                    // a line comment
+                    "a": 1
+                  }
+                  """
+                      .trimIndent()
+              )
+              .getMember("a")
+              .asInt() shouldBe 1
+      }
+  }
+  ```
+- [ ] Run on the pre-change tree:
+  ```bash
+  ./gradlew test --tests "com.salesforce.revoman.internal.postman.PostmanSDKJsonStrToObjTest"
+  ```
+  Expected: `BUILD SUCCESSFUL` — PASS today (behavior is what we preserve).
+- [ ] `./gradlew spotlessApply` + commit: `test(sandbox): pin jsonStrToObj closure-reuse + comment tolerance (A3)`
+
+---
+
+## Task 4 — A3 implement: memoize the JSON.parse closure
+
+**Files:** `PostmanSDK.kt` (~line 226 `jsonStrToObj`)
+**Interfaces:** none new.
+
+- [ ] Memoize the arrow function as a `by lazy` `Value` and reuse it. BEFORE (lines 225-227):
+  ```kotlin
+    @Language("JavaScript")
+    fun jsonStrToObj(jsonStr: String): Value =
+      evaluateJS("jsonStr => JSON.parse(jsonStr, {allowComments: true})").execute(jsonStr)
+  ```
+  AFTER:
+  ```kotlin
+    // Memoized JSON.parse closure: a stateless guest function bound to this instance's jsContext.
+    // Parsing the function literal once (not per call) skips a Source parse + compile on every
+    // json()/jsonStrToObj call. Reuse is safe — the closure holds no per-call state; only its
+    // argument varies. `by lazy` defers forcing until the first parse (jsEvaluator is init'd last).
+    @Language("JavaScript")
+    private val jsonParseFn: Value by lazy {
+      evaluateJS("jsonStr => JSON.parse(jsonStr, {allowComments: true})")
+    }
+
+    fun jsonStrToObj(jsonStr: String): Value = jsonParseFn.execute(jsonStr)
+  ```
+- [ ] Run A3 + the JSON-heavy eval test (`EvalJsTest.pm response to json()` exercises `pm.response.json()` → `jsonStrToObj`):
+  ```bash
+  ./gradlew test --tests "com.salesforce.revoman.internal.postman.PostmanSDKJsonStrToObjTest" --tests "com.salesforce.revoman.input.EvalJsTest"
+  ```
+  Expected: `BUILD SUCCESSFUL` — all green.
+- [ ] Full gate:
+  ```bash
+  ./gradlew test integrationTest
+  ```
+  Expected: `BUILD SUCCESSFUL`.
+- [ ] `./gradlew spotlessApply` + commit: `perf(sandbox): memoize JSON.parse closure in jsonStrToObj (A3)`
+
+---
+
+## Task 5 — A4 implement: hoist `imports` to an immutable val; document the (unsafe) result-memo decision
+
+**Files:** `PostmanSDK.kt` (~line 119 `private var imports`; ~line 146 `evaluateJS`)
+**Interfaces:** none.
+
+> **Decision (record in code):** the spec's *optional* `Map<String,Value>` memo for repeated identical scripts is INTENTIONALLY SKIPPED — it is NOT clean. `evaluateJS` injects per-call `bindings` into the Context (line 148) and pm scripts routinely have side effects (`pm.environment.set(...)`) and identical text with different bindings (e.g. `xml2Json` with different `responseBody`). A script->Value result cache would skip binding injection and re-execution, corrupting behavior. The real repeated-script win is captured by A3's closure memo. A4 here is limited to making `imports` immutable.
+
+- [ ] Turn `imports` from a mutated `var` into a computed `val`. This depends on the Task 2/A2 `init` edit that already removed `imports = ...` from the options `buildMap`. BEFORE (line 119):
+  ```kotlin
+      private var imports = ""
+  ```
+  AFTER:
+  ```kotlin
+      // Constant per-instance prefix, computed once. Non-empty only when a nodeModulesPath enabled
+      // commonjs-require (so lodash `_` is importable). Hoisted to a val — never mutated after init.
+      private val imports: String =
+          if (!nodeModulesPath.isNullOrBlank()) "var _ = require('lodash')\n" else ""
+  ```
+  Confirm `evaluateJS` (line 149) still reads it: `Source.newBuilder("js", imports + js, "script.js").build()` — unchanged.
+- [ ] Sanity-run the lodash/require path (`EvalJsTest.eval JS with lodash` / `eval JS with moment` boot the `nodeModulesPath="js"` instance):
+  ```bash
+  ./gradlew test --tests "com.salesforce.revoman.input.EvalJsTest"
+  ```
+  Expected: `BUILD SUCCESSFUL` — `imports` still prepends `var _ = require('lodash')` for the js-node instance.
+- [ ] Full gate:
+  ```bash
+  ./gradlew test integrationTest
+  ```
+  Expected: `BUILD SUCCESSFUL`.
+- [ ] `./gradlew spotlessApply` + commit: `perf(sandbox): hoist imports prefix to an immutable val; document no result-memo (A4)`
+
+---
+
+## Task 6 — E1 test: `syncProgress` replaces the current step's report (RED first)
+
+**Files:** NEW `src/test/kotlin/com/salesforce/revoman/internal/postman/PostmanSDKSyncProgressTest.kt`
+**Interfaces:** Consumes `PostmanSDK.syncProgress(StepReport)` (internal, line 155), `Rundown` ctor, `StepReport` ctor, `Step`, `Item`, `PostmanEnvironment` (all confirmed from `PollingTest.kt` + `PostmanSDKCollectionVariablesTest.kt`). Produces the E1 correctness gate.
+
+> This is the ONE genuinely red->green fix (behavior of mid-run `pm.rundown` intentionally changes). The test mimics `ReVoman.runStep`'s real sequence: `ReVoman.kt:402` seeds `pm.rundown` with `stepReportsSoFar + preStepReport` (current step LAST), then `syncProgress` is called 3× per step (`ReVoman.kt:451,468,483`). Today each call APPENDS → the current step ends up 4× in `pm.rundown.stepReports`. E1 makes each call REPLACE → exactly once, prior steps preserved.
+
+- [ ] Write the test:
+  ```kotlin
+  /**
+   * ************************************************************************************************
+   * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+   * Version 2.0 For full license text, see the LICENSE file in the repo root or
+   * http://www.apache.org/licenses/LICENSE-2.0
+   * ************************************************************************************************
+   */
+  package com.salesforce.revoman.internal.postman
+
+  import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
+  import com.salesforce.revoman.internal.postman.template.Item
+  import com.salesforce.revoman.output.Rundown
+  import com.salesforce.revoman.output.postman.PostmanEnvironment
+  import com.salesforce.revoman.output.report.Step
+  import com.salesforce.revoman.output.report.StepReport
+  import io.kotest.matchers.collections.shouldHaveSize
+  import io.kotest.matchers.shouldBe
+  import org.junit.jupiter.api.Test
+
+  /**
+   * E1 guard: mirrors ReVoman.runStep — the Rundown is seeded with prior steps + THIS step's
+   * pre-step report (current LAST), then syncProgress runs 3x per step. syncProgress must REPLACE
+   * the current step's entry (not append), so the mid-run pm.rundown holds each step exactly once
+   * and prior steps + loop-iteration history are preserved.
+   */
+  class PostmanSDKSyncProgressTest {
+      private fun step(name: String) = Step(index = "1", rawPMStep = Item(name = name))
+
+      private fun report(step: Step) = StepReport(step = step, pmEnvSnapshot = PostmanEnvironment())
+
+      private fun pmWithSeededRundown(stepReportsSoFar: List<StepReport>): PostmanSDK =
+          PostmanSDK(initMoshi()).apply {
+              rundown =
+                  Rundown(
+                      stepReports = stepReportsSoFar,
+                      mutableEnv = PostmanEnvironment(),
+                      haltOnFailureOfTypeExcept = emptyMap(),
+                      providedStepsToExecuteCount = stepReportsSoFar.size,
+                  )
+          }
+
+      @Test
+      fun `three syncProgress calls keep the current step exactly once and preserve prior steps`() {
+          val stepA = step("a")
+          val stepB = step("b")
+          val reportA = report(stepA)
+          val preReportB = report(stepB)
+          // ReVoman.kt:402 seed: prior steps + current step's pre-step report (current LAST).
+          val pm = pmWithSeededRundown(listOf(reportA, preReportB))
+
+          // ReVoman.kt:451,468,483: 3 syncProgress calls for the SAME step, each with an evolved sr.
+          val srB1 = preReportB.copy(nextRequest = "afterHttp")
+          val srB2 = srB1.copy(nextRequest = "afterPostRes")
+          val srB3 = srB2.copy(nextRequest = "afterHooks")
+          pm.syncProgress(srB1)
+          pm.syncProgress(srB2)
+          pm.syncProgress(srB3)
+
+          pm.rundown.stepReports shouldHaveSize 2 // a + b, NOT a + b + b + b + b
+          pm.rundown.stepReports.map { it.step.name } shouldBe listOf("a", "b")
+          pm.rundown.stepReports.last() shouldBe srB3 // most-evolved report wins
+          pm.currentStepReport shouldBe srB3
+      }
+
+      @Test
+      fun `first syncProgress on an empty-prefix seed keeps a single entry`() {
+          val stepA = step("a")
+          val pre = report(stepA)
+          val pm = pmWithSeededRundown(listOf(pre)) // first step of the run
+          val evolved = pre.copy(nextRequest = "x")
+          pm.syncProgress(evolved)
+          pm.rundown.stepReports shouldHaveSize 1
+          pm.rundown.stepReports.last() shouldBe evolved
+      }
+
+      @Test
+      fun `looped step preserves the prior iteration report`() {
+          val stepA = step("a")
+          val iter0Final = report(stepA).copy(iteration = 0, nextRequest = "loop")
+          val preIter1 = report(stepA).copy(iteration = 1)
+          // 2nd iteration seed: prior iteration's final report + this iteration's pre-step report.
+          val pm = pmWithSeededRundown(listOf(iter0Final, preIter1))
+          val iter1Final = preIter1.copy(nextRequest = "done")
+          pm.syncProgress(iter1Final)
+          pm.rundown.stepReports shouldHaveSize 2 // iter0Final preserved, preIter1 replaced
+          pm.rundown.stepReports[0] shouldBe iter0Final
+          pm.rundown.stepReports[1] shouldBe iter1Final
+      }
+  }
+  ```
+- [ ] Run on the pre-change tree (expect RED):
+  ```bash
+  ./gradlew test --tests "com.salesforce.revoman.internal.postman.PostmanSDKSyncProgressTest"
+  ```
+  Expected: FAILS — `three syncProgress calls...` sees `stepReports` size 5 (`[a, b, b, b, b]`), not 2. This proves the append bug is real.
+- [ ] `./gradlew spotlessApply` + commit: `test(sandbox): pin syncProgress replace-current-step semantics (E1, red)`
+
+---
+
+## Task 7 — E1 implement: replace instead of append in `syncProgress`
+
+**Files:** `PostmanSDK.kt` (~line 155 `syncProgress`)
+**Interfaces:** none new. STRICTLY scoped to `PostmanSDK.kt` — no `ReVoman.kt` edit.
+
+- [ ] Replace the current step's report (always the LAST entry post-seed) instead of appending. BEFORE (lines 155-158):
+  ```kotlin
+    internal fun syncProgress(stepReport: StepReport) {
+      currentStepReport = stepReport
+      rundown = rundown.copy(stepReports = rundown.stepReports + stepReport)
+    }
+  ```
+  AFTER:
+  ```kotlin
+    /**
+     * Publishes the current step's evolving [StepReport] into [rundown] for mid-run readers (hooks,
+     * the halt predicate). ReVoman seeds [rundown] with this step's pre-step report as the LAST
+     * entry, then calls this 3x per step as the report gains request/response/hook detail. REPLACES
+     * the current step's entry (matched as the last report for the same [Step]) rather than
+     * appending, so a step appears exactly ONCE mid-run — earlier steps and prior loop iterations
+     * (which sit before it) are untouched. Keeps [Rundown] immutable via [Rundown.copy].
+     */
+    internal fun syncProgress(stepReport: StepReport) {
+      currentStepReport = stepReport
+      val reports = rundown.stepReports
+      val updated =
+        if (reports.lastOrNull()?.step == stepReport.step) reports.dropLast(1) + stepReport
+        else reports + stepReport
+      rundown = rundown.copy(stepReports = updated)
+    }
+  ```
+  > Why "last report for the same Step" is correct: `Step` is a `data class(index, rawPMStep, parentFolder, sourceHash)` — its `==` ignores the mutable hook-count vars, so equality is stable across a step's report copies. The `ReVoman.kt:402` seed guarantees the current step's report is LAST when the first `syncProgress` fires; every subsequent `sr` is a `.copy()` of it (same `Step`). Prior steps and prior loop iterations precede it, so `dropLast(1)` never touches them. The `else` branch (append) preserves the defensive path if `syncProgress` were ever called with no matching tail (e.g. a future caller that skips the seed).
+- [ ] Run E1 (expect GREEN now) + the E2E tests that assert `stepReports` shape:
+  ```bash
+  ./gradlew test --tests "com.salesforce.revoman.internal.postman.PostmanSDKSyncProgressTest" --tests "com.salesforce.revoman.PmTestFailureE2ETest" --tests "com.salesforce.revoman.ControlFlowE2ETest" --tests "com.salesforce.revoman.LedgerSkipE2ETest" --tests "com.salesforce.revoman.PmTestPhaseTagE2ETest"
+  ```
+  Expected: `BUILD SUCCESSFUL` — E1 green; the E2E tests (which assert on the FINAL rundown built from `sequenceResult.reports`, unaffected by this change) still pass.
+- [ ] Full gate (this is the highest-risk fix — hooks read mid-run `pm.rundown`):
+  ```bash
+  ./gradlew test integrationTest
+  ```
+  Expected: `BUILD SUCCESSFUL`. If a hook/halt-predicate test regresses, it was relying on the buggy duplicate mid-run entries — use `/systematic-debugging`; do NOT "fix" it by touching `ReVoman.kt`.
+- [ ] `./gradlew spotlessApply` + commit: `perf(sandbox): replace current step's report in syncProgress instead of appending 3x (E1)`
+
+---
+
+## Task 8 — JMH benchmark (measured, not a gate)
+
+**Files:** NEW `src/jmh/kotlin/com/salesforce/revoman/benchmark/SandboxBenchmark.kt`
+**Interfaces:** Consumes WT-0 jmh source set + friend-path to `main`. If NO friend-path (Task 0), use the PUBLIC-API fallback variant below.
+
+- [ ] Write the benchmark (primary: through the sandbox — captures A2 interpreter->JIT + Engine reuse + A3 via `pm.response.json()`). Real APIs confirmed from `PmSandboxScriptApiTest.kt`.
+  ```kotlin
+  /**
+   * ************************************************************************************************
+   * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+   * Version 2.0 For full license text, see the LICENSE file in the repo root or
+   * http://www.apache.org/licenses/LICENSE-2.0
+   * ************************************************************************************************
+   */
+  package com.salesforce.revoman.benchmark
+
+  import com.salesforce.revoman.internal.postman.sandbox.PmExecutionContext
+  import com.salesforce.revoman.internal.postman.sandbox.PmSandbox
+  import com.salesforce.revoman.internal.postman.sandbox.PmScope
+  import com.salesforce.revoman.internal.postman.sandbox.ScriptTarget
+  import java.util.concurrent.TimeUnit
+  import org.openjdk.jmh.annotations.Benchmark
+  import org.openjdk.jmh.annotations.BenchmarkMode
+  import org.openjdk.jmh.annotations.Fork
+  import org.openjdk.jmh.annotations.Level
+  import org.openjdk.jmh.annotations.Measurement
+  import org.openjdk.jmh.annotations.Mode
+  import org.openjdk.jmh.annotations.OutputTimeUnit
+  import org.openjdk.jmh.annotations.Scope
+  import org.openjdk.jmh.annotations.Setup
+  import org.openjdk.jmh.annotations.State
+  import org.openjdk.jmh.annotations.TearDown
+  import org.openjdk.jmh.annotations.Warmup
+
+  /**
+   * Measures the GraalJS sandbox hot path: repeated eval of a representative Postman test script.
+   * Captures A2 (interpreter->JIT once via truffle-runtime + shared-Engine bootcode reuse) and A3
+   * (JSON.parse closure reuse via pm.response.json()). One booted sandbox per trial; each @Benchmark
+   * invocation is one eval — the steady-state per-script latency after warm-up.
+   */
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  @State(Scope.Benchmark)
+  @Fork(1)
+  @Warmup(iterations = 5, time = 1)
+  @Measurement(iterations = 8, time = 1)
+  open class SandboxBenchmark {
+      private lateinit var sandbox: PmSandbox
+
+      private val script =
+          """
+          pm.test('status is ok', () => pm.expect(pm.response.code).to.eql(200));
+          const body = pm.response.json();
+          pm.environment.set('id', body.id);
+          pm.test('has id', () => pm.expect(body.id).to.eql(42));
+          """
+              .trimIndent()
+
+      private fun context() =
+          PmExecutionContext(
+              environment = PmScope("e", emptyMap()),
+              response = mapOf("code" to 200, "status" to "OK", "body" to """{"id":42}"""),
+          )
+
+      @Setup(Level.Trial)
+      fun setup() {
+          sandbox = PmSandbox() // boots lazily on the first execute
+      }
+
+      @TearDown(Level.Trial)
+      fun tearDown() = sandbox.close()
+
+      @Benchmark
+      fun evalPostmanTestScript(): Any? =
+          sandbox.execute(script, ScriptTarget.TEST, context()).environment["id"]
+  }
+  ```
+  **Fallback (only if Task 0 found no friend-path):** replace the body with the public API — construct `PostmanSDK(initMoshi())` in `@Setup`, `@Benchmark` calls `pm.jsonStrToObj("""{"id":42}""").getMember("id")` and `pm.evaluateJS("1 + 1")`. This still captures A2 (JSEvaluator Context shares the same Engine) + A3, just not the 2.2 MB bootcode path.
+- [ ] Run it:
+  ```bash
+  ./gradlew jmh -Pjmh.includes=SandboxBenchmark
+  ```
+  Expected: `BUILD SUCCESSFUL` and a JMH result table, e.g.:
+  ```
+  Benchmark                             Mode  Cnt   Score   Error  Units
+  SandboxBenchmark.evalPostmanTestScript avgt    8  XXX.X ± YY.Y  us/op
+  ```
+  Record the `Score` in the worktree ledger. This is MEASURED, not pass/fail. (WT-0 holds the pre-fix baseline; compare deltas there.)
+- [ ] `./gradlew spotlessApply` + commit: `test(jmh): add SandboxBenchmark for the GraalJS sandbox eval hot path`
+
+---
+
+## Task 9 — WarnInterpreterOnly cleanup (conditional; ties off A1's tail)
+
+**Files:** `SandboxBridge.kt` (the `sharedGraalEngine` `engine.WarnInterpreterOnly` option)
+**Interfaces:** Consumes WT-0's `truffle-runtime`.
+
+- [ ] Check whether the interpreter warning still fires with `truffle-runtime` present. Temporarily remove the `.option("engine.WarnInterpreterOnly", "false")` line from `sharedGraalEngine`, then run a sandbox test capturing stderr/logs:
+  ```bash
+  ./gradlew test --tests "com.salesforce.revoman.internal.postman.sandbox.PmSandboxBootTest" --info 2>&1 | grep -i "interpreter\|fallback runtime\|optimizing runtime" || echo "NO WARNING FIRED"
+  ```
+  Expected with truffle-runtime on the classpath: `NO WARNING FIRED` (the optimizing runtime is found, so the warning is silent).
+- [ ] Branch on the result:
+  - If `NO WARNING FIRED`: keep the line removed — the suppression is now genuinely unneeded (A1's stated cleanup). Full gate `./gradlew test integrationTest` → `BUILD SUCCESSFUL`. Commit: `refactor(sandbox): drop now-unneeded WarnInterpreterOnly suppression (truffle-runtime silences it)`.
+  - If the warning STILL fires: restore the line on `sharedGraalEngine` and add a code comment: `// truffle-runtime present but the interpreter warning still fires on this JVM config — suppression retained (A1).` Commit: `chore(sandbox): retain WarnInterpreterOnly suppression — warning still fires with truffle-runtime`.
+
+---
+
+## Final verification
+
+- [ ] Full suite once more:
+  ```bash
+  ./gradlew test integrationTest
+  ```
+  Expected: `BUILD SUCCESSFUL`.
+- [ ] Benchmark delta recorded vs. WT-0 baseline (informational).
+- [ ] `git log --oneline` shows the A2 -> A3 -> A4 -> E1 -> JMH -> (cleanup) commit sequence, each behind a green gate.
+- [ ] Confirm only the three owned files + new test/benchmark files changed:
+  ```bash
+  git diff --name-only master...HEAD
+  ```
+  Expected: only `SandboxBridge.kt`, `PostmanSDK.kt` (PmJsEval.kt untouched — it builds no Context), the four new test files, and `SandboxBenchmark.kt`. NOTHING else — especially not `ReVoman.kt`.
+
+---
+
+## Cross-worktree coupling note (E1 ↔ WT-4 / `ReVoman.kt`) — READ BEFORE MERGE
+
+`syncProgress` (WT-1) and the `Rundown` seed (WT-4, `ReVoman.kt:402`) are coupled through `pm.rundown.stepReports`:
+
+- **`ReVoman.kt:402-410` seeds** `pm.rundown = Rundown(stepReportsSoFar + preStepReport, ...)` — this is the "4th copy" the spec leaves in place. It puts the current step's pre-step report as the LAST entry. **WT-1's E1 fix depends on this ordering invariant** (the current step is always last when `syncProgress` first fires). If WT-4 ever changes how the seed orders `stepReports` (e.g. stops appending the current step last, or switches to a persistent map that reorders), WT-1's `reports.lastOrNull()?.step == stepReport.step` check must be revisited.
+- **`stepReportsSoFar` is the sequencer's clean `reports` list** (`ReVoman.kt:246,255`), NOT `pm.rundown` — each finished step is appended once. So the append-bug duplication is contained WITHIN one step's `pm.rundown` lifecycle and never leaks into the next step's seed or the FINAL consumer `Rundown` (built at `ReVoman.kt:191` from `sequenceResult.reports`). **E1 therefore changes ONLY the mid-run `pm.rundown` that hooks + the halt predicate observe**, not the returned rundown — which is why the E2E tests asserting on final `stepReports` size (`PmTestFailureE2ETest`, `LedgerSkipE2ETest`, etc.) are unaffected.
+- **Mid-run readers of `pm.rundown`** (all in `ReVoman.kt`, WT-4-owned, passing it down): `preStepHookExe` (:439), `unmarshallRequest` (:433), `unmarshallResponse` (:477), `postStepHookExe` (:485), `executePolling` (:490), and `shouldHaltExecution` (:278 → `Rundown.isStepIgnoredForFailure` → `PostTxnStepPick.pick(stepReport, rundown)`). A consumer `PostTxnStepPick`/hook that read `rundown.stepReports` / `executedStepCount` mid-step previously saw the current step 2-4×; after E1 it sees it once. **This is the intended correctness improvement**, but it is the one consumer-observable behavior change in WT-1 — flag it in the merge PR so WT-4 (and any downstream hook authors) are aware.
+- **E2 (WT-4) will re-back the env with a persistent map** and may further touch the seed. WT-1 and WT-4 do NOT share a file (`PostmanSDK.kt` is WT-1-only; `ReVoman.kt`/`PostmanEnvironment.kt`/`StepReport.kt` are WT-4-only), so the merge is textually conflict-free — but the `pm.rundown.stepReports` ordering invariant above is a SEMANTIC coupling both sides must preserve.

--- a/docs/superpowers/plans/2026-07-13-perf-wt2-marshalling.md
+++ b/docs/superpowers/plans/2026-07-13-perf-wt2-marshalling.md
@@ -1,0 +1,978 @@
+# Perf WT-2: JSON Marshalling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Apply six FP-preserving marshalling hot-path optimizations (B1–B6) — cache enum constants, hoist the epoch digit-check, reuse the DiMorphic label `Options`, bridge `objToJsonStrToObj` through Moshi value-trees, memoize the default `MoshiReVoman`, and render comment-free JSON bodies with the precision-safe `JsonPretty` — each locked by a characterization test and measured by a JMH benchmark.
+
+**Architecture:** All edits are confined to six files. B1/B2/B3 hoist per-parse allocations to construction-time fields inside existing Moshi `JsonAdapter`s (no signature change). B4 swaps a JSON-string round-trip for `dstAdapter.fromJsonValue(srcAdapter.toJsonValue(input))` — same value flow, one fewer serialize/parse pass. B5 memoizes the empty-config `MoshiReVoman` behind a `by lazy` val, keeping the non-empty path fresh. B6 rewrites `Request.toHttpRequest`'s body-cleansing branch so comment-free bodies re-indent via `JsonPretty.pretty` (byte-preserving) while JSON5 comment stripping keeps the Moshi round-trip, gated on `containsComments`.
+
+**Tech Stack:** Kotlin, Moshi (moshix), Okio, JMH
+
+## Global Constraints
+- JDK 21+; branched off WT-0 (has JMH source set at `src/jmh/kotlin/com/salesforce/revoman/benchmark/`)
+- Owns ONLY these 6 files — touch no other source file:
+  `src/main/kotlin/com/salesforce/revoman/internal/json/factories/CaseInsensitiveEnumAdapter.kt`,
+  `src/main/kotlin/com/salesforce/revoman/internal/json/adapters/EpochAdapter.kt`,
+  `src/main/kotlin/com/salesforce/revoman/input/json/factories/DiMorphicAdapter.kt`,
+  `src/main/kotlin/com/salesforce/revoman/internal/json/MoshiReVoman.kt`,
+  `src/main/kotlin/com/salesforce/revoman/input/json/JsonPojoUtils.kt`,
+  `src/main/kotlin/com/salesforce/revoman/internal/postman/template/Template.kt`
+- Correctness gate: `./gradlew test integrationTest` green (non-core; core IT needs `-PincludeCoreIT` + real org)
+- Bench (measured, non-gating): `./gradlew jmh -Pjmh.includes=MarshallingBenchmark`
+- Preserve FP style (STYLE.md): Either/map/flatMap/fold, immutable flow, single-expression fns
+- `./gradlew spotlessApply` before every commit
+---
+
+## Behavior notes read before implementing (two intentional, tested changes)
+
+Most of WT-2 is byte-for-byte behavior-preserving (B1, B2, B3, B5). Two fixes have an
+**observable, intentional** delta that the design explicitly anticipates — both are locked by
+characterization tests and gated on the full suite:
+
+- **B4 (`objToJsonStrToObj`) untyped-number typing.** The old string round-trip serializes then
+  re-parses; when the *target* type is untyped (`Any` / raw `Map`), Moshi parses JSON numbers as
+  `Double` (so an `Int 42` becomes `42.0`). The value-tree bridge (`fromJsonValue(toJsonValue(x))`)
+  carries the boxed number through the tree, so `Int 42` stays `Int 42`. For **concrete** target
+  types (a POJO field typed `Int`/`Long`/`Double`) both paths coerce to the declared type and are
+  identical. The consumers are `PostmanEnvironment.getObj`/`getTypedObj` (lines 160, 184). Task 4
+  characterizes both (concrete = identical; untyped = the documented Double→typed change) and gates
+  on `PostmanEnvironmentTest` + `PostmanEnvironmentEnvVarsTest` + full IT.
+- **B6 (comment-free JSON body render) numeric precision.** The old Moshi round-trip collapses
+  numbers to `Double` (`5`→`5.0`, large ids lose precision — the exact problem `JsonPretty`'s KDoc
+  calls out). Rendering comment-free bodies via `JsonPretty.pretty` copies bytes verbatim, so `5`
+  stays `5` and big ids keep full precision. Comment-bearing (JSON5) bodies still go through the
+  Moshi round-trip (only it strips comments). Task 6 tests both a comment-bearing and a plain body,
+  plus the `moshiReVoman == null` path (`ReVoman.kt:394` calls `toHttpRequest(null)`).
+
+---
+
+## Task 1 — B1: cache enum constants in `CaseInsensitiveEnumAdapter`
+
+**Files:**
+- `src/main/kotlin/com/salesforce/revoman/internal/json/factories/CaseInsensitiveEnumAdapter.kt` (fields ~35–37; `fromJson` uses at lines 42, 47)
+- New test: `src/test/kotlin/com/salesforce/revoman/internal/json/factories/CaseInsensitiveEnumAdapterTest.kt`
+
+**Interfaces:**
+- Consumes: `enumType: Class<T>` (constructor param). Produces: no signature change — an added `private val enumConstants` field reused by `fromJson`.
+
+### 1.1 Characterization test (case-insensitive parse, exact toJson, unknown value throws)
+- [ ] Create `CaseInsensitiveEnumAdapterTest.kt` (the factory is wired into the default Moshi via `addLast(CaseInsensitiveEnumAdapter.FACTORY)`, so `initMoshi()` exercises it):
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.json.factories
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
+import com.squareup.moshi.JsonDataException
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+private enum class Color {
+  RED,
+  GREEN,
+  BLUE,
+}
+
+class CaseInsensitiveEnumAdapterTest {
+  private val moshi = initMoshi()
+
+  @Test
+  fun `parses an exact-case enum name`() {
+    assertThat(moshi.fromJson<Color>("\"RED\"", Color::class.java)).isEqualTo(Color.RED)
+  }
+
+  @Test
+  fun `parses a differently-cased enum name case-insensitively`() {
+    assertThat(moshi.fromJson<Color>("\"green\"", Color::class.java)).isEqualTo(Color.GREEN)
+    assertThat(moshi.fromJson<Color>("\"BlUe\"", Color::class.java)).isEqualTo(Color.BLUE)
+  }
+
+  @Test
+  fun `serializes an enum to its canonical name`() {
+    assertThat(moshi.toJson(Color.GREEN, sourceType = Color::class.java)).isEqualTo("\"GREEN\"")
+  }
+
+  @Test
+  fun `throws JsonDataException for an unknown enum value`() {
+    assertThrows<JsonDataException> { moshi.fromJson<Color>("\"purple\"", Color::class.java) }
+  }
+}
+```
+
+### 1.2 Run against UNCHANGED code
+- [ ] `./gradlew test --tests "com.salesforce.revoman.internal.json.factories.CaseInsensitiveEnumAdapterTest"`
+- [ ] Expected: **PASS** (locks current behavior).
+
+### 1.3 Implement — cache `enumConstants` once, reuse in `fromJson`
+
+Before (lines 33–52):
+```kotlin
+internal class CaseInsensitiveEnumAdapter<T : Enum<T>>(private val enumType: Class<T>) :
+  JsonAdapter<T>() {
+  private val nameStrings =
+    enumType.getEnumConstants().map { Util.jsonName(it.name, enumType.getField(it.name)) }
+  private val options = JsonReader.Options.of(*nameStrings.toTypedArray())
+
+  override fun fromJson(reader: JsonReader): T {
+    val index = reader.selectString(options)
+    return if (index != -1) {
+      enumType.getEnumConstants()[index]
+    } else if (reader.peek() != JsonReader.Token.STRING) {
+      throw JsonDataException("Expected a string but was ${reader.peek()} at path ${reader.path}")
+    } else {
+      val value = reader.nextString()
+      enumType.enumConstants.firstOrNull { it.name.compareTo(value, ignoreCase = true) == 0 }
+        ?: throw JsonDataException(
+          "Expected one of $nameStrings but was $value at path ${reader.path}"
+        )
+    }
+  }
+```
+After:
+```kotlin
+internal class CaseInsensitiveEnumAdapter<T : Enum<T>>(private val enumType: Class<T>) :
+  JsonAdapter<T>() {
+  // * NOTE: getEnumConstants() clones its backing array on every call; cache it once.
+  private val enumConstants: Array<T> = enumType.enumConstants
+  private val nameStrings =
+    enumConstants.map { Util.jsonName(it.name, enumType.getField(it.name)) }
+  private val options = JsonReader.Options.of(*nameStrings.toTypedArray())
+
+  override fun fromJson(reader: JsonReader): T {
+    val index = reader.selectString(options)
+    return if (index != -1) {
+      enumConstants[index]
+    } else if (reader.peek() != JsonReader.Token.STRING) {
+      throw JsonDataException("Expected a string but was ${reader.peek()} at path ${reader.path}")
+    } else {
+      val value = reader.nextString()
+      enumConstants.firstOrNull { it.name.compareTo(value, ignoreCase = true) == 0 }
+        ?: throw JsonDataException(
+          "Expected one of $nameStrings but was $value at path ${reader.path}"
+        )
+    }
+  }
+```
+
+### 1.4 Re-run + gate
+- [ ] `./gradlew test --tests "com.salesforce.revoman.internal.json.factories.CaseInsensitiveEnumAdapterTest"` → **PASS**
+- [ ] `./gradlew test integrationTest` → **PASS**
+
+### 1.5 Format + commit
+- [ ] `./gradlew spotlessApply`
+- [ ] `git commit -am "perf(json): cache enum constants once in CaseInsensitiveEnumAdapter (avoid per-parse array clone)"`
+
+---
+
+## Task 2 — B2: hoist the epoch digit-check regex in `EpochAdapter`
+
+**Files:**
+- `src/main/kotlin/com/salesforce/revoman/internal/json/adapters/EpochAdapter.kt` (line 23)
+- New test: `src/test/kotlin/com/salesforce/revoman/internal/json/adapters/EpochAdapterTest.kt`
+
+**Interfaces:**
+- Consumes: `reader.nextString()`. Produces: no signature change — an object-level `DIGITS_REGEX` reused per `fromJson`.
+
+**Decision (which of the two options):** use a **hoisted `"\\d+".toRegex()` object-level val**, NOT
+`epoch.isNotEmpty() && epoch.all(Char::isDigit)`. Rationale: `\d` in Java regex matches ASCII
+`0-9` only, whereas `Char::isDigit` (i.e. `Character.isDigit`) also matches Unicode digits
+(Arabic-Indic, etc.). The hoisted regex is therefore **byte-for-byte behavior-identical** to the
+current code while removing the per-call `Pattern.compile`. Cleaner in the sense that matters here =
+zero behavior risk.
+
+### 2.1 Characterization test (numeric string → epoch Date; non-numeric ISO string → delegate)
+- [ ] Create `EpochAdapterTest.kt` (EpochAdapter is registered via `.add(EpochAdapter)`; drive it through a bean with a `Date` field):
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.json.adapters
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
+import com.squareup.moshi.JsonClass
+import java.text.SimpleDateFormat
+import java.util.Date
+import org.junit.jupiter.api.Test
+
+@JsonClass(generateAdapter = true) internal data class BeanWithDate(val date: Date)
+
+class EpochAdapterTest {
+  private val moshi = initMoshi()
+
+  @Test
+  fun `numeric string is parsed as epoch millis`() {
+    val epoch = 1604216172747L
+    val bean = moshi.fromJson<BeanWithDate>("{\"date\":\"$epoch\"}", BeanWithDate::class.java)!!
+    assertThat(bean.date.toInstant().toEpochMilli()).isEqualTo(epoch)
+  }
+
+  @Test
+  fun `non-numeric ISO string is delegated to the RFC3339 date adapter`() {
+    val bean = moshi.fromJson<BeanWithDate>("{\"date\":\"2015-09-01\"}", BeanWithDate::class.java)!!
+    assertThat(bean.date).isEqualTo(SimpleDateFormat("yyyy-MM-dd").parse("2015-09-01"))
+  }
+}
+```
+- [ ] Existing coverage that MUST stay green: `JsonPojoUtilsTest.jsonWithEpochDateToPojo` and `jsonWithISODateToPojo` (already exercise both branches through the epoch adapter).
+
+### 2.2 Run against UNCHANGED code
+- [ ] `./gradlew test --tests "com.salesforce.revoman.internal.json.adapters.EpochAdapterTest"` → **PASS**
+
+### 2.3 Implement — hoist the regex to an object-level val
+
+Before (lines 18–29):
+```kotlin
+object EpochAdapter {
+  @OptIn(ExperimentalTime::class)
+  @FromJson
+  fun fromJson(reader: JsonReader, delegate: JsonAdapter<Date>): Date? {
+    val epoch = reader.nextString()
+    return if (epoch.matches("\\d+".toRegex())) {
+      Date.from(Instant.fromEpochMilliseconds(epoch.toLong()).toJavaInstant())
+    } else {
+      delegate.fromJsonValue(epoch)
+    }
+  }
+}
+```
+After:
+```kotlin
+object EpochAdapter {
+  // * NOTE: hoisted so the digit pattern is compiled once, not on every date parse.
+  //   `\d` keeps ASCII-only semantics identical to the previous inline regex.
+  private val DIGITS_REGEX = "\\d+".toRegex()
+
+  @OptIn(ExperimentalTime::class)
+  @FromJson
+  fun fromJson(reader: JsonReader, delegate: JsonAdapter<Date>): Date? {
+    val epoch = reader.nextString()
+    return if (epoch.matches(DIGITS_REGEX)) {
+      Date.from(Instant.fromEpochMilliseconds(epoch.toLong()).toJavaInstant())
+    } else {
+      delegate.fromJsonValue(epoch)
+    }
+  }
+}
+```
+
+### 2.4 Re-run + gate
+- [ ] `./gradlew test --tests "com.salesforce.revoman.internal.json.adapters.EpochAdapterTest"` → **PASS**
+- [ ] `./gradlew test integrationTest` → **PASS**
+
+### 2.5 Format + commit
+- [ ] `./gradlew spotlessApply`
+- [ ] `git commit -am "perf(json): hoist epoch digit-check regex in EpochAdapter (compile once)"`
+
+---
+
+## Task 3 — B3: build the DiMorphic label `Options` once
+
+**Files:**
+- `src/main/kotlin/com/salesforce/revoman/input/json/factories/DiMorphicAdapter.kt` (line 35, inside `findLabelValue`)
+- New test: `src/test/kotlin/com/salesforce/revoman/input/json/factories/DiMorphicAdapterTest.kt`
+
+**Interfaces:**
+- Consumes: `labelKey: String` (constructor param). Produces: no signature change — an added `private val labelOptions: Options` reused per element instead of `Options.of(labelKey)` per `findLabelValue` call.
+
+### 3.1 Characterization test — multi-element list keeps success/error discrimination
+- [ ] The existing `JsonPojoUtilsTest.compositeResponseDiMorphicMarshallUnmarshall` (partial-success fixture = 3 elements ⇒ `findLabelValue` runs repeatedly) and `compositeGraphResponseDiMorphicMarshallUnmarshall` are the primary characterization for B3, plus `CompositeResponseTest`. Add one focused unit test to make the hoist explicit:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.input.json.factories
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.input.json.adapters.salesforce.CompositeResponse
+import com.salesforce.revoman.input.json.adapters.salesforce.CompositeResponse.Response.ErrorResponse
+import com.salesforce.revoman.input.json.adapters.salesforce.CompositeResponse.Response.SuccessResponse
+import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
+import io.vavr.control.Either
+import org.junit.jupiter.api.Test
+
+class DiMorphicAdapterTest {
+  private val moshi =
+    initMoshi(
+      customAdaptersWithType =
+        mapOf(CompositeResponse.Response::class.java to Either.right(CompositeResponse.ADAPTER))
+    )
+
+  @Test
+  fun `discriminates success and error across repeated elements in one list`() {
+    val json =
+      """
+      {
+        "compositeResponse": [
+          {"referenceId":"ok","httpStatusCode":200,"httpHeaders":{},
+           "body":{"done":true,"totalSize":0,"records":[]}},
+          {"referenceId":"bad","httpStatusCode":400,"httpHeaders":{},
+           "body":[{"errorCode":"INVALID","message":"Invalid reference specified"}]}
+        ]
+      }
+      """
+        .trimIndent()
+    val response = moshi.fromJson<CompositeResponse>(json, CompositeResponse::class.java)!!
+    assertThat(response.compositeResponse[0]).isInstanceOf(SuccessResponse::class.java)
+    assertThat(response.compositeResponse[1]).isInstanceOf(ErrorResponse::class.java)
+  }
+}
+```
+- [ ] If the exact success/error body shapes above don't match `CompositeResponse.ADAPTER`'s predicate, prefer relying on the existing green `JsonPojoUtilsTest` DiMorphic tests as the characterization and skip this unit test — do NOT invent a fixture the adapter can't parse.
+
+### 3.2 Run against UNCHANGED code
+- [ ] `./gradlew test --tests "com.salesforce.revoman.input.json.factories.DiMorphicAdapterTest"` (and/or) `./gradlew test integrationTest --tests "com.salesforce.revoman.input.json.JsonPojoUtilsTest"` → **PASS**
+
+### 3.3 Implement — hoist `labelOptions` to a construction-time field
+
+Before (lines 19–43):
+```kotlin
+class DiMorphicAdapter
+private constructor(
+  private val labelKey: String,
+  private val successAdapter: Triple<(JsonReader) -> Boolean, Type, JsonAdapter<Any>>,
+  private val errorAdapter: Pair<Type, JsonAdapter<Any>>,
+) : JsonAdapter<Any>() {
+  override fun fromJson(reader: JsonReader): Any? {
+    val readerAtLabelKey = findLabelValue(reader.peekJson())
+    val jsonAdapter =
+      if (readerAtLabelKey.use(successAdapter.first)) successAdapter.third else errorAdapter.second
+    return jsonAdapter.fromJson(reader)
+  }
+
+  private fun findLabelValue(reader: JsonReader): JsonReader {
+    reader.beginObject()
+    while (reader.hasNext()) {
+      if (reader.selectName(Options.of(labelKey)) == -1) {
+        reader.skipName()
+        reader.skipValue()
+      } else {
+        return reader
+      }
+    }
+    throw JsonDataException("Missing label for $labelKey")
+  }
+```
+After:
+```kotlin
+class DiMorphicAdapter
+private constructor(
+  private val labelKey: String,
+  private val successAdapter: Triple<(JsonReader) -> Boolean, Type, JsonAdapter<Any>>,
+  private val errorAdapter: Pair<Type, JsonAdapter<Any>>,
+) : JsonAdapter<Any>() {
+  // * NOTE: Okio Options are immutable; build the single-name lookup once, not per element.
+  private val labelOptions: Options = Options.of(labelKey)
+
+  override fun fromJson(reader: JsonReader): Any? {
+    val readerAtLabelKey = findLabelValue(reader.peekJson())
+    val jsonAdapter =
+      if (readerAtLabelKey.use(successAdapter.first)) successAdapter.third else errorAdapter.second
+    return jsonAdapter.fromJson(reader)
+  }
+
+  private fun findLabelValue(reader: JsonReader): JsonReader {
+    reader.beginObject()
+    while (reader.hasNext()) {
+      if (reader.selectName(labelOptions) == -1) {
+        reader.skipName()
+        reader.skipValue()
+      } else {
+        return reader
+      }
+    }
+    throw JsonDataException("Missing label for $labelKey")
+  }
+```
+
+### 3.4 Re-run + gate
+- [ ] `./gradlew test --tests "com.salesforce.revoman.input.json.factories.DiMorphicAdapterTest"` → **PASS**
+- [ ] `./gradlew test integrationTest --tests "com.salesforce.revoman.input.json.JsonPojoUtilsTest"` → **PASS**
+- [ ] `./gradlew test integrationTest` → **PASS**
+
+### 3.5 Format + commit
+- [ ] `./gradlew spotlessApply`
+- [ ] `git commit -am "perf(json): build DiMorphic label JsonReader.Options once per adapter, not per element"`
+
+---
+
+## Task 4 — B4: bridge `objToJsonStrToObj` through Moshi value-trees
+
+**Files:**
+- `src/main/kotlin/com/salesforce/revoman/internal/json/MoshiReVoman.kt` (lines 101–107)
+- New test: `src/test/kotlin/com/salesforce/revoman/internal/json/ObjToJsonStrToObjTest.kt`
+
+**Interfaces:**
+- Consumes: `input: Any?`, `targetType: Type`. Produces: same `PojoT?` return; internally replaces `dstAdapter.fromJson(toJson(input))` with `dstAdapter.fromJsonValue(srcAdapter.toJsonValue(input))`. Consumers: `PostmanEnvironment.getTypedObj` (line 160) and `getObj` (line 184).
+
+### 4.1 Characterization tests — concrete-typed equivalence + documented untyped delta
+- [ ] Create `ObjToJsonStrToObjTest.kt`. The helpers replicate the OLD string path and the NEW
+  value-tree path **directly on the public `lenientAdapter` API**, so the equivalence check is
+  independent of the edit (it proves whether the swap is safe for each input shape):
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.json
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
+import com.squareup.moshi.JsonClass
+import org.junit.jupiter.api.Test
+
+@JsonClass(generateAdapter = true)
+internal data class Vals(
+  val i: Int,
+  val l: Long,
+  val d: Double,
+  val b: Boolean,
+  val nested: Map<String, Int>,
+)
+
+class ObjToJsonStrToObjTest {
+  private val moshi = initMoshi()
+
+  private inline fun <reified T : Any> stringRoundTrip(input: Any?): T? =
+    moshi
+      .lenientAdapter<T>()
+      .fromJson(moshi.lenientAdapter<Any>(input?.javaClass ?: Any::class.java).toJson(input))
+
+  private inline fun <reified T : Any> valueTreeBridge(input: Any?): T? =
+    moshi
+      .lenientAdapter<T>()
+      .fromJsonValue(
+        moshi.lenientAdapter<Any>(input?.javaClass ?: Any::class.java).toJsonValue(input)
+      )
+
+  @Test
+  fun `concrete-typed target - value-tree bridge equals string round-trip`() {
+    val src = Vals(i = 42, l = 9_000_000_000L, d = 3.5, b = true, nested = mapOf("x" to 7))
+    assertThat(valueTreeBridge<Vals>(src)).isEqualTo(stringRoundTrip<Vals>(src))
+    assertThat(valueTreeBridge<Vals>(src)).isEqualTo(src)
+  }
+
+  @Test
+  fun `the actual method round-trips a PostmanEnvironment-style map into a concrete POJO`() {
+    val src = mapOf("i" to 42, "l" to 9_000_000_000L, "d" to 3.5, "b" to true, "nested" to mapOf("x" to 7))
+    val out = moshi.objToJsonStrToObj<Vals>(src, Vals::class.java)!!
+    assertThat(out).isEqualTo(Vals(42, 9_000_000_000L, 3.5, true, mapOf("x" to 7)))
+  }
+
+  @Test
+  fun `DOCUMENTED - untyped Any target - string path yields Double, value-tree preserves Int`() {
+    // Locks the observable delta B4 introduces for UNTYPED retrieval. Run this against BOTH the
+    // unchanged and changed tree; the two helpers are edit-independent so it stays green either way.
+    // If the observed types differ from the prediction below, UPDATE the assertions to the observed
+    // values (this test's job is to pin reality, not the prediction) and re-check the risk note.
+    val src = mapOf("i" to 42)
+    val fromString = stringRoundTrip<Map<String, Any?>>(src)!!
+    val fromTree = valueTreeBridge<Map<String, Any?>>(src)!!
+    assertThat(fromString["i"]).isInstanceOf(java.lang.Double::class.java) // 42.0
+    assertThat(fromTree["i"]).isInstanceOf(java.lang.Integer::class.java) // 42
+  }
+}
+```
+- [ ] Consumer-path gate (concrete targets are the real usage): `PostmanEnvironmentTest`,
+  `PostmanEnvironmentEnvVarsTest`, `PostmanEnvironmentUnsteppedTest`, `RegexReplacerScopesTest`
+  (`environment numeric value resolves and is coerced back to Int on setback`) MUST stay green.
+
+### 4.2 Run against UNCHANGED code
+- [ ] `./gradlew test --tests "com.salesforce.revoman.internal.json.ObjToJsonStrToObjTest"` → **PASS**
+  (proves the equivalence helpers characterize real Moshi behavior). If the DOCUMENTED test's
+  observed instance types differ from the prediction, adjust the two `isInstanceOf` assertions to
+  match what the run reports, then continue.
+
+### 4.3 Implement — value-tree bridge
+
+Before (lines 101–107):
+```kotlin
+  fun <PojoT : Any> objToJsonStrToObj(
+    input: Any?,
+    targetType: Type = input?.javaClass ?: Any::class.java,
+  ): PojoT? = lenientAdapter<PojoT>(targetType).fromJson(toJson(input))
+
+  inline fun <reified PojoT : Any> objToJsonStrToObj(input: Any?): PojoT? =
+    lenientAdapter<PojoT>().fromJson(toJson(input))
+```
+After:
+```kotlin
+  // * NOTE: bridge source->target through a Moshi value-tree instead of a JSON-string round-trip;
+  //   avoids one full serialize+parse pass. For concrete target types this is identical to the
+  //   string path; for UNTYPED (Any/raw Map) targets it preserves the boxed number type (Int stays
+  //   Int) instead of coercing to Double. See PostmanEnvironment.getObj/getTypedObj consumers.
+  fun <PojoT : Any> objToJsonStrToObj(
+    input: Any?,
+    targetType: Type = input?.javaClass ?: Any::class.java,
+  ): PojoT? =
+    lenientAdapter<PojoT>(targetType)
+      .fromJsonValue(lenientAdapter<Any>(input?.javaClass ?: Any::class.java).toJsonValue(input))
+
+  inline fun <reified PojoT : Any> objToJsonStrToObj(input: Any?): PojoT? =
+    lenientAdapter<PojoT>()
+      .fromJsonValue(lenientAdapter<Any>(input?.javaClass ?: Any::class.java).toJsonValue(input))
+```
+
+### 4.4 Re-run + gate (this is the B4 risk gate)
+- [ ] `./gradlew test --tests "com.salesforce.revoman.internal.json.ObjToJsonStrToObjTest"` → **PASS**
+- [ ] `./gradlew test --tests "com.salesforce.revoman.output.postman.PostmanEnvironmentTest" --tests "com.salesforce.revoman.output.postman.PostmanEnvironmentEnvVarsTest" --tests "com.salesforce.revoman.output.postman.PostmanEnvironmentUnsteppedTest" --tests "com.salesforce.revoman.internal.postman.RegexReplacerScopesTest"` → **PASS**
+- [ ] `./gradlew test integrationTest` → **PASS**. If a test asserts the old untyped-`Double` form and now fails, that is the anticipated B4 delta: decide (a) update the assertion to the value-tree-preserved type (intended), or (b) if a real consumer depends on `Double`, add a `targetType == Any::class.java` guard that keeps the string round-trip for the untyped case only. Record the decision in the ledger.
+
+### 4.5 Format + commit
+- [ ] `./gradlew spotlessApply`
+- [ ] `git commit -am "perf(json): bridge objToJsonStrToObj via Moshi value-tree instead of JSON-string round-trip"`
+
+---
+
+## Task 5 — B5: memoize the default `MoshiReVoman` in `JsonPojoUtils`
+
+**Files:**
+- `src/main/kotlin/com/salesforce/revoman/input/json/JsonPojoUtils.kt` (private `initMoshi`, lines 144–151; consumers at 39, 79, 121)
+- New test: `src/test/kotlin/com/salesforce/revoman/input/json/JsonPojoUtilsMemoTest.kt`
+
+**Interfaces:**
+- Consumes: `customAdapters`, `customAdaptersWithType`, `skipTypes`, `pojoType`. Produces: a `JsonAdapter<PojoT>` — from a memoized default `MoshiReVoman` when all three config args are empty, or a freshly built one otherwise. No public signature change.
+
+### 5.1 Characterization test — empty-config reuse + non-empty freshness
+- [ ] Existing coverage already exercises BOTH branches and MUST stay green:
+  empty-config (`JsonPojoUtilsTest.jsonFileToPojo`, `simpleJsonToMap`, `pojoToJson`,
+  `jsonWithEpochDateToPojo`, `jsonWithISODateToPojo`) and non-empty-config
+  (`compositeResponseDiMorphicMarshallUnmarshall`, `compositeGraphResponseDiMorphicMarshallUnmarshall`,
+  `sObjectGraphMarshallToPQPayload` — all pass a `customAdapter`).
+- [ ] Add an explicit reuse/isolation test:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.input.json
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class JsonPojoUtilsMemoTest {
+  @Test
+  fun `repeated empty-config parses produce identical results`() {
+    val json = """{"key1":"value1","key2":"value2"}"""
+    val first = jsonToPojo<Map<String, String>>(Map::class.java, json)
+    val second = jsonToPojo<Map<String, String>>(Map::class.java, json)
+    assertThat(first).isEqualTo(second)
+    assertThat(second).containsExactlyEntriesIn(mapOf("key1" to "value1", "key2" to "value2"))
+  }
+
+  @Test
+  fun `empty-config and non-empty-config calls interleave without interference`() {
+    val json = """{"a":"b"}"""
+    val empty1 = jsonToPojo<Map<String, String>>(Map::class.java, json)
+    // A non-empty config call must not mutate the memoized default used by empty1/empty2.
+    val nested =
+      jsonToPojo<Map<String, String>>(
+        Map::class.java,
+        json,
+        customAdapters = emptyList(),
+        customAdaptersWithType = emptyMap(),
+        skipTypes = setOf(String::class.java),
+      )
+    val empty2 = jsonToPojo<Map<String, String>>(Map::class.java, json)
+    assertThat(empty1).isEqualTo(empty2)
+    assertThat(nested).isNotNull()
+  }
+}
+```
+
+### 5.2 Run against UNCHANGED code
+- [ ] `./gradlew test --tests "com.salesforce.revoman.input.json.JsonPojoUtilsMemoTest"` → **PASS**
+
+### 5.3 Implement — FP-clean `by lazy` memoization for the empty-config case
+- [ ] The memoized default is safe to share because the empty-config branch never calls
+  `addAdapters` (the only mutator on `MoshiReVoman.moshi`); `adapter(pojoType)` is read-only. The
+  imported companion `initMoshi()` (no-arg) resolves unambiguously — the private overload requires a
+  `pojoType` arg, so it cannot bind here. No new import needed (type is inferred).
+
+Before (lines 144–151):
+```kotlin
+@SuppressWarnings("kotlin:S3923")
+private fun <PojoT : Any> initMoshi(
+  customAdapters: List<Any> = emptyList(),
+  customAdaptersWithType: Map<Type, Either<JsonAdapter<out Any>, Factory>> = emptyMap(),
+  skipTypes: Set<Class<out Any>> = emptySet(),
+  pojoType: Type,
+): JsonAdapter<PojoT> =
+  initMoshi(customAdapters, customAdaptersWithType, skipTypes).adapter(pojoType)
+```
+After:
+```kotlin
+// * NOTE: the empty-config MoshiReVoman never has adapters added (addAdapters is the only mutator),
+//   so a single memoized instance is safely shared across all default-config marshalling calls.
+private val defaultMoshiReVoman by lazy { initMoshi() }
+
+@SuppressWarnings("kotlin:S3923")
+private fun <PojoT : Any> initMoshi(
+  customAdapters: List<Any> = emptyList(),
+  customAdaptersWithType: Map<Type, Either<JsonAdapter<out Any>, Factory>> = emptyMap(),
+  skipTypes: Set<Class<out Any>> = emptySet(),
+  pojoType: Type,
+): JsonAdapter<PojoT> =
+  (if (customAdapters.isEmpty() && customAdaptersWithType.isEmpty() && skipTypes.isEmpty())
+      defaultMoshiReVoman
+    else initMoshi(customAdapters, customAdaptersWithType, skipTypes))
+    .adapter(pojoType)
+```
+
+### 5.4 Re-run + gate
+- [ ] `./gradlew test --tests "com.salesforce.revoman.input.json.JsonPojoUtilsMemoTest"` → **PASS**
+- [ ] `./gradlew test integrationTest --tests "com.salesforce.revoman.input.json.JsonPojoUtilsTest" --tests "com.salesforce.revoman.input.json.JsonPojoUtils2Test"` → **PASS**
+- [ ] `./gradlew test integrationTest` → **PASS**
+
+### 5.5 Format + commit
+- [ ] `./gradlew spotlessApply`
+- [ ] `git commit -am "perf(json): memoize the empty-config MoshiReVoman in JsonPojoUtils"`
+
+---
+
+## Task 6 — B6: render comment-free JSON bodies via precision-safe `JsonPretty`
+
+**Files:**
+- `src/main/kotlin/com/salesforce/revoman/internal/postman/template/Template.kt` (`Request.toHttpRequest`, body-cleansing branch lines 67–91; `containsComments`/`COMMENT_PATTERN` at 106–115)
+- New test: `src/test/kotlin/com/salesforce/revoman/internal/postman/template/RequestToHttpRequestTest.kt`
+
+**Interfaces:**
+- Consumes: `body: Body?`, `header: List<Header>`, `moshiReVoman: MoshiReVoman?`. Produces: same `org.http4k.core.Request`; comment-free JSON bodies are re-indented byte-for-byte via `JsonPretty.pretty`, JSON5 comment-bearing bodies still stripped via the Moshi round-trip. The JSON-detection side effect (setting `Content-Type: application/json` when absent) is preserved by validating with `moshiReVoman.fromJson<Any>` before rendering. `toHttpRequest(null)` (ReVoman.kt:394 null-body path) keeps its current behavior.
+
+### 6.1 Characterization tests — comment body, plain body precision, non-JSON, null moshi
+- [ ] Create `RequestToHttpRequestTest.kt` (`Request`/`Header`/`Body` are public data classes;
+  `toHttpRequest` is `internal`, visible to same-module tests):
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.postman.template
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
+import org.junit.jupiter.api.Test
+
+class RequestToHttpRequestTest {
+  private val moshi = initMoshi()
+
+  private fun request(contentType: String?, rawBody: String): Request =
+    Request(
+      method = "POST",
+      header =
+        contentType?.let { listOf(Header(key = "Content-Type", value = it)) } ?: emptyList(),
+      body = Body(mode = "raw", raw = rawBody),
+    )
+
+  @Test
+  fun `comment-free JSON body with no content-type is pretty-printed byte-for-byte and content-type is set`() {
+    val raw = """{"n":5,"id":1234567890123}"""
+    val http = request(contentType = null, rawBody = raw).toHttpRequest(moshi)
+    // Precision preserved: 5 stays 5 (not 5.0), large id keeps full precision.
+    assertThat(http.bodyString()).contains("\"n\": 5")
+    assertThat(http.bodyString()).contains("\"id\": 1234567890123")
+    assertThat(http.bodyString()).doesNotContain("5.0")
+    assertThat(http.header("Content-Type")).isEqualTo("application/json")
+  }
+
+  @Test
+  fun `comment-bearing JSON body is round-tripped so comments are stripped`() {
+    val raw =
+      """
+      {
+        // a line comment
+        "a": 1
+      }
+      """
+        .trimIndent()
+    val http = request(contentType = "application/json", rawBody = raw).toHttpRequest(moshi)
+    assertThat(http.bodyString()).doesNotContain("// a line comment")
+    assertThat(http.bodyString()).contains("\"a\"")
+  }
+
+  @Test
+  fun `non-JSON body with no content-type is left unchanged and no content-type is added`() {
+    val raw = "plain text body, not json"
+    val http = request(contentType = null, rawBody = raw).toHttpRequest(moshi)
+    assertThat(http.bodyString()).isEqualTo(raw)
+    assertThat(http.header("Content-Type")).isNull()
+  }
+
+  @Test
+  fun `null moshiReVoman with a JSON body and no content-type still adds the content-type header`() {
+    // Mirrors ReVoman.kt:394 toHttpRequest(null). Body passes through unchanged (no moshi to render).
+    val raw = """{"a":1}"""
+    val http = request(contentType = null, rawBody = raw).toHttpRequest(null)
+    assertThat(http.bodyString()).isEqualTo(raw)
+    assertThat(http.header("Content-Type")).isEqualTo("application/json")
+  }
+}
+```
+- [ ] Integration coverage that MUST stay green (request-body rendering end to end): the Pokemon /
+  restfulapi.dev collections that POST JSON bodies (run via `./gradlew integrationTest`). If any
+  asserts the old `Double`-coerced body form, that is the intended B6 precision fix — update it.
+
+### 6.2 Run against UNCHANGED code
+- [ ] `./gradlew test --tests "com.salesforce.revoman.internal.postman.template.RequestToHttpRequestTest"`
+- [ ] Expected: the comment-body, non-JSON, and null-moshi tests **PASS**; the
+  `comment-free ... byte-for-byte` test **FAILS** against unchanged code (old round-trip renders
+  `5.0` / precision-lost id). This RED is intended — it is the failing test that drives B6.
+
+### 6.3 Implement — gate rendering on `containsComments`; validate-then-JsonPretty for comment-free
+- [ ] Add the `JsonPretty` import and rewrite the body-cleansing `let` block. Comment-bearing bodies
+  keep the Moshi round-trip (it strips comments). Comment-free bodies validate as JSON via
+  `moshiReVoman.fromJson<Any>` (same strictness that drove the old detection) and render via
+  `JsonPretty.pretty` (byte-preserving). `moshiReVoman == null` returns the raw body and still lets
+  `onSuccess` set the content-type — identical to today.
+
+Add import (with the other imports at top of file):
+```kotlin
+import com.salesforce.revoman.output.json.JsonPretty
+```
+
+Before (lines 67–91):
+```kotlin
+    val cleansedRawBody =
+      body?.raw?.trim()?.let {
+        when {
+          it.isBlank() -> it
+          else ->
+            // ! TODO 15 Mar 2025 gopala.akshintala: Detect the right content type if absent
+            when {
+              contentTypeHeader?.value == null ||
+                (APPLICATION_JSON.value.equals(contentTypeHeader.value, true) &&
+                  containsComments(it)) -> {
+                runCatching { moshiReVoman?.jsonToObjToPrettyJson(it, true) ?: it }
+                  .onSuccess {
+                    if (contentTypeHeader == null) {
+                      logger.info {
+                        "Detected JSON Content type, adding $APPLICATION_JSON as content-type Header"
+                      }
+                      contentTypeHeader = APPLICATION_JSON
+                    }
+                  }
+                  .getOrDefault(it)
+              }
+              else -> it
+            }
+        }
+      } ?: ""
+```
+After:
+```kotlin
+    val cleansedRawBody =
+      body?.raw?.trim()?.let { rawBody ->
+        when {
+          rawBody.isBlank() -> rawBody
+          else -> {
+            // ! TODO 15 Mar 2025 gopala.akshintala: Detect the right content type if absent
+            val hasComments = containsComments(rawBody)
+            when {
+              contentTypeHeader?.value == null ||
+                (APPLICATION_JSON.value.equals(contentTypeHeader.value, true) && hasComments) ->
+                runCatching {
+                    when {
+                      // JSON5 comment stripping needs the Moshi round-trip.
+                      hasComments -> moshiReVoman?.jsonToObjToPrettyJson(rawBody, true) ?: rawBody
+                      // Comment-free: validate as JSON (drives detection), render precision-safe.
+                      else ->
+                        moshiReVoman?.let { m ->
+                          m.fromJson<Any>(rawBody)
+                          JsonPretty.pretty(rawBody)
+                        } ?: rawBody
+                    }
+                  }
+                  .onSuccess {
+                    if (contentTypeHeader == null) {
+                      logger.info {
+                        "Detected JSON Content type, adding $APPLICATION_JSON as content-type Header"
+                      }
+                      contentTypeHeader = APPLICATION_JSON
+                    }
+                  }
+                  .getOrDefault(rawBody)
+              else -> rawBody
+            }
+          }
+        }
+      } ?: ""
+```
+- [ ] NOTE: `m.fromJson<Any>(rawBody)` throws exactly where the old `jsonToObjToPrettyJson` threw
+  (same lenient parse), so a non-JSON body with no content-type still lands in `getOrDefault(rawBody)`
+  and does NOT get `application/json` — behavior preserved. `JsonPretty.pretty` never throws (it
+  passes malformed input through), so the strict JSON gate MUST remain the Moshi parse, not
+  JsonPretty's first-char heuristic.
+
+### 6.4 Re-run + gate
+- [ ] `./gradlew test --tests "com.salesforce.revoman.internal.postman.template.RequestToHttpRequestTest"` → **PASS** (the previously-RED byte-for-byte test now passes)
+- [ ] `./gradlew test integrationTest` → **PASS** (green, non-core). Investigate any body-assertion diff as the intended precision fix per 6.1.
+
+### 6.5 Format + commit
+- [ ] `./gradlew spotlessApply`
+- [ ] `git commit -am "perf(template): render comment-free JSON bodies via precision-safe JsonPretty; keep round-trip only to strip comments"`
+
+---
+
+## Task 7 — JMH benchmark (measured, not gated)
+
+**Files:**
+- Create: `src/jmh/kotlin/com/salesforce/revoman/benchmark/MarshallingBenchmark.kt`
+
+**Interfaces:**
+- Consumes: WT-0's `jmh` source set + `-Pjmh.includes` wiring. Produces: `fromJson`/`toJson`
+  average-time numbers over a representative Salesforce composite response (polymorphic via
+  DiMorphic — exercises B3) plus an enum+date bean (exercises B1/B2), driven through the public
+  `JsonPojoUtils` entry points (exercises B5). Public API avoids `internal`-visibility concerns.
+
+### 7.1 Write the benchmark
+- [ ] Create `src/jmh/kotlin/com/salesforce/revoman/benchmark/MarshallingBenchmark.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.benchmark
+
+import com.salesforce.revoman.input.json.adapters.salesforce.CompositeResponse
+import com.salesforce.revoman.input.json.jsonToPojo
+import com.salesforce.revoman.input.json.pojoToJson
+import io.vavr.control.Either
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import org.openjdk.jmh.infra.Blackhole
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+open class MarshallingBenchmark {
+
+  // Representative composite query response: polymorphic elements (SuccessResponse/ErrorResponse),
+  // records with attributes, nested bodies -> exercises DiMorphicAdapter (B3) + the default adapter
+  // stack (B1 enum factory, B2 epoch adapter) via the memoized MoshiReVoman (B5).
+  private val compositeJson =
+    """
+    {
+      "compositeResponse": [
+        {"referenceId":"ok1","httpStatusCode":200,"httpHeaders":{},
+         "body":{"done":true,"totalSize":1,"records":[
+           {"attributes":{"type":"Account","url":"/services/data/v58.0/sobjects/Account/001"},
+            "Id":"001xx000003DGbXXXX","Name":"Acme","CreatedDate":"2015-09-01T00:00:00.000+0000"}]}},
+        {"referenceId":"bad1","httpStatusCode":400,"httpHeaders":{},
+         "body":[{"errorCode":"INVALID","message":"Invalid reference specified"}]}
+      ]
+    }
+    """
+      .trimIndent()
+
+  private lateinit var composite: CompositeResponse
+
+  @Setup
+  fun setup() {
+    composite =
+      jsonToPojo<CompositeResponse>(
+        CompositeResponse::class.java,
+        compositeJson,
+        customAdaptersWithType =
+          mapOf(CompositeResponse.Response::class.java to Either.right(CompositeResponse.ADAPTER)),
+      )!!
+  }
+
+  @Benchmark
+  fun compositeFromJson(bh: Blackhole) {
+    bh.consume(
+      jsonToPojo<CompositeResponse>(
+        CompositeResponse::class.java,
+        compositeJson,
+        customAdaptersWithType =
+          mapOf(CompositeResponse.Response::class.java to Either.right(CompositeResponse.ADAPTER)),
+      )
+    )
+  }
+
+  @Benchmark
+  fun compositeToJson(bh: Blackhole) {
+    bh.consume(
+      pojoToJson<CompositeResponse>(
+        CompositeResponse::class.java,
+        composite,
+        customAdaptersWithType =
+          mapOf(CompositeResponse.Response::class.java to Either.right(CompositeResponse.ADAPTER)),
+      )
+    )
+  }
+}
+```
+- [ ] Verify the `jsonToPojo` / `pojoToJson` overloads accept the `customAdaptersWithType` named arg
+  as written (they do — see `JsonPojoUtils.kt`). If the `jmh` source set cannot see
+  `CompositeResponse.ADAPTER`/`CompositeResponse`, confirm they are public (they are used from Java
+  tests as `CompositeResponse.class` / `CompositeResponse.ADAPTER`), or fall back to a plain
+  `Map`-typed body that still exercises B1/B2/B5 (drop the DiMorphic arg).
+
+### 7.2 Run the benchmark (measure, do not gate)
+- [ ] `./gradlew jmh -Pjmh.includes=MarshallingBenchmark`
+- [ ] Record the `compositeFromJson` / `compositeToJson` average-time numbers in the worktree ledger.
+  Compare against WT-0's baseline snapshot if present. Expected direction: `fromJson` improves
+  (cached enum constants B1, hoisted epoch regex B2, single DiMorphic `Options` B3, memoized default
+  B5); `toJson` improves modestly (B1 `toJson` still uses `nameStrings`, B5 default reuse).
+
+### 7.3 Format + commit
+- [ ] `./gradlew spotlessApply`
+- [ ] `git commit -am "test(bench): add MarshallingBenchmark for composite fromJson/toJson hot path"`
+
+---
+
+## Task 8 — Final full gate
+
+- [ ] `./gradlew spotlessApply`
+- [ ] `./gradlew build` (full unit build incl. detekt + assembly)
+- [ ] `./gradlew test integrationTest` → **PASS** (green, non-core)
+- [ ] Confirm ONLY the six owned source files + the added test/benchmark files changed:
+  `git diff --name-only <base>..HEAD` shows only
+  `CaseInsensitiveEnumAdapter.kt`, `EpochAdapter.kt`, `DiMorphicAdapter.kt`, `MoshiReVoman.kt`,
+  `JsonPojoUtils.kt`, `Template.kt`, the new `*Test.kt` files, and `MarshallingBenchmark.kt`.
+- [ ] Record the JMH deltas + the final green gate in the worktree ledger for the merge report.

--- a/docs/superpowers/plans/2026-07-13-perf-wt3-regex-templates.md
+++ b/docs/superpowers/plans/2026-07-13-perf-wt3-regex-templates.md
@@ -1,0 +1,510 @@
+# Perf WT-3: Regex / Templates / Vars Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Apply five FP-preserving, behavior-identical micro-optimizations (C1–C5) to the regex/template/variable hot paths — a `{{` fast-path guard, a static-entry skip in the env rescan, a reused SnakeYAML reader, a single `metadataOrNull` stat per child, and JDK 21 `HexFormat` encoding — and measure the wins with a JMH benchmark.
+
+**Architecture:** All changes are localized to four files (`RegexReplacer.kt`, `V3YamlReader.kt`, `V3Loader.kt`, `DynamicVariableGenerator.kt`). Each fix is a guard/refactor inside an existing `?.let` / `associate` / `filter` / pure-function pipeline — no signatures change, no call sites change (only `ReVoman.kt:411` and `V3Loader`'s own walk consume these, and their contracts are preserved byte-for-byte). Correctness is locked by characterization tests written *before* each edit; JMH numbers are measured, not gated.
+
+**Tech Stack:** Kotlin, SnakeYAML, Okio FileSystem, JDK 21 HexFormat, JMH
+
+## Global Constraints
+- JDK 21+; branched off WT-0 (has JMH source set at `src/jmh/kotlin`)
+- Owns ONLY these 4 files — touch no other source file:
+  `src/main/kotlin/com/salesforce/revoman/internal/postman/RegexReplacer.kt`,
+  `src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3YamlReader.kt`,
+  `src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3Loader.kt`,
+  `src/main/kotlin/com/salesforce/revoman/internal/postman/DynamicVariableGenerator.kt`
+- Correctness gate: `./gradlew test integrationTest` green (non-core). Bench (measured, non-gating): `./gradlew jmh -Pjmh.includes=RegexVarBenchmark`
+- C1 must be byte-for-byte behavior-identical (the guard only short-circuits strings that cannot match — the pattern `\{\{(?<variableKey>[^{}]*?)}}` requires a literal `{{`)
+- `postManVariableRegex` (top-level val, `RegexReplacer.kt:17`) is ALREADY hoisted — do NOT "fix" it
+- Preserve FP style (STYLE.md): the existing `?.let` / `associate` / `map` / `filter` pipelines stay; add guards, don't rewrite
+- Do NOT touch `V3YamlWriter` (needs its own `DumperOptions` — different file, different worktree concern)
+- `./gradlew spotlessApply` before every commit
+---
+
+## Behavior-identity proof for C1 (read before implementing)
+
+The private `replaceVariablesRecursively` resolves `{{key}}` tokens via `postManVariableRegex.replace(it) { … }`. The regex is `"\\{\\{(?<variableKey>[^{}]*?)}}"` — it **cannot** match unless the input contains a literal `{{`. Therefore `if (!it.contains("{{")) return@let it` returns exactly what `postManVariableRegex.replace(it) { … }` would return for such a string (the replace is a no-op → returns the same instance/content).
+
+Recursion cannot defeat the guard: every recursive call (`cdvg.generate(...)` result, `dynamicVariableGenerator(...)` result, and each `resolveFromScopes` value) is itself fed back through the *same* guarded function. A resolved value that contains `{{` still hits the regex on that recursive call; a resolved value with no `{{` genuinely has nothing to resolve. Resolution never *synthesizes* a `{{` inside a string that lacked one — substitution only ever *removes* `{{…}}` tokens or leaves them literal. So no no-`{{` string ever needs processing. Result: identical output, identical side effects (`recordConsumed` / `setItBackInEnvironment` fire only when the regex actually matches, which requires `{{`).
+
+---
+
+## Task 1 — C1: `{{` fast-path guard in `replaceVariablesRecursively`
+
+### 1.1 Characterization test (lock current behavior + the no-`{{` identity path)
+- [ ] Append to `src/test/kotlin/com/salesforce/revoman/internal/postman/RegexReplacerTest.kt`:
+
+```kotlin
+  @Test
+  fun `string without double-brace is returned unchanged`() {
+    val regexReplacer = RegexReplacer()
+    val pm = PostmanSDK(moshiReVoman, null, regexReplacer)
+    val plain = """{ "a": 1, "b": "no placeholders here", "c": "{ single brace }" }"""
+    regexReplacer.replaceVariablesRecursively(plain, pm) shouldBe plain
+  }
+
+  @Test
+  fun `null input stays null`() {
+    val regexReplacer = RegexReplacer()
+    val pm = PostmanSDK(moshiReVoman, null, regexReplacer)
+    regexReplacer.replaceVariablesRecursively(null, pm) shouldBe null
+  }
+
+  @Test
+  fun `single unmatched brace pair is not treated as a placeholder`() {
+    val regexReplacer = RegexReplacer()
+    val pm = PostmanSDK(moshiReVoman, null, regexReplacer)
+    // Contains "{{" so it enters the regex path, but "{{ }" has no closing "}}" -> left literal.
+    regexReplacer.replaceVariablesRecursively("prefix {{ } suffix", pm) shouldBe "prefix {{ } suffix"
+  }
+```
+- [ ] Existing tests already cover the matched/recursive/cyclic paths and MUST keep passing:
+  `dynamic variables replacement in JSON string and dynamic env`, `self-referencing variable does not cause StackOverflowError`, `mutually cyclic variables do not cause StackOverflowError`, `two-level indirection still resolves correctly`, plus all of `RegexReplacerScopesTest`.
+
+### 1.2 Run test against UNCHANGED code (proves the test captures real behavior)
+- [ ] `./gradlew test --tests "com.salesforce.revoman.internal.postman.RegexReplacerTest"`
+- [ ] Expected: **PASS** (these characterize behavior that already holds).
+
+### 1.3 Implement the guard
+- [ ] In `RegexReplacer.kt`, the private overload (currently lines 37–69). Add the guard as the first line inside the `?.let` lambda, preserving the pipeline exactly.
+
+Before:
+```kotlin
+  ): String? = stringWithRegex?.let {
+    postManVariableRegex.replace(it) { variable ->
+```
+After:
+```kotlin
+  ): String? = stringWithRegex?.let {
+    if (!it.contains("{{")) return@let it
+    postManVariableRegex.replace(it) { variable ->
+```
+
+### 1.4 Re-run + correctness gate
+- [ ] `./gradlew test --tests "com.salesforce.revoman.internal.postman.RegexReplacerTest"` → **PASS**
+- [ ] `./gradlew test integrationTest` → **PASS** (green, non-core)
+
+### 1.5 Format + commit
+- [ ] `./gradlew spotlessApply`
+- [ ] `git commit -am "perf(regex): fast-path guard skips regex scan for strings without {{"`
+
+---
+
+## Task 2 — C2: skip static entries in `replaceVariablesInEnv`
+
+### 2.1 Characterization test (mixed placeholder / static / typed entries)
+- [ ] Append to `RegexReplacerTest.kt`:
+
+```kotlin
+  @Test
+  fun `replaceVariablesInEnv resolves placeholder entries and passes static + typed entries through`() {
+    val regexReplacer = RegexReplacer()
+    val pm = PostmanSDK(moshiReVoman, null, regexReplacer)
+    pm.environment["base"] = "example.com"
+    pm.environment["url"] = "https://{{base}}/api"   // value placeholder
+    pm.environment["staticStr"] = "no placeholders"   // static string -> unchanged
+    pm.environment["count"] = 42                       // non-string -> passed through as-is
+    pm.environment["flag"] = true                      // non-string -> passed through as-is
+    val result = regexReplacer.replaceVariablesInEnv(pm)
+    result shouldContainAll
+      mapOf(
+        "base" to "example.com",
+        "url" to "https://example.com/api",
+        "staticStr" to "no placeholders",
+        "count" to 42,
+        "flag" to true,
+      )
+  }
+
+  @Test
+  fun `replaceVariablesInEnv resolves a placeholder in the key`() {
+    val regexReplacer = RegexReplacer()
+    val pm = PostmanSDK(moshiReVoman, null, regexReplacer)
+    pm.environment["name"] = "userName"
+    pm.environment["{{name}}"] = "value"  // key placeholder -> remapped to resolved key
+    val result = regexReplacer.replaceVariablesInEnv(pm)
+    result shouldContain ("userName" to "value")
+  }
+```
+- [ ] Existing `unmarshall Env File with Regex and Dynamic variable` (uses `env-with-regex.json`, key `{{un}}` → `userName`, value `user-{{$epoch}}@xyz.com`) MUST keep passing — it exercises BOTH a key placeholder and a value placeholder.
+
+### 2.2 Run against UNCHANGED code
+- [ ] `./gradlew test --tests "com.salesforce.revoman.internal.postman.RegexReplacerTest"` → **PASS**
+
+### 2.3 Implement — guard per entry, keep the `associate` FP style + `.toMap()` snapshot
+- [ ] In `RegexReplacer.kt`, `replaceVariablesInEnv` (currently lines 135–145). Keep `.toMap()` (write-back at `ReVoman.kt:411` `putAll` depends on the snapshot). Only remap entries whose key or (string) value contains `{{`; pass everything else through unchanged.
+
+Before:
+```kotlin
+  internal fun replaceVariablesInEnv(pm: PostmanSDK): Map<String, Any?> =
+    pm.environment
+      .toMap()
+      .entries
+      .associateBy(
+        { replaceVariablesRecursively(it.key, pm)!! },
+        {
+          if (it.value is String?) replaceVariablesRecursively(it.value as String?, pm)
+          else it.value
+        },
+      )
+```
+After:
+```kotlin
+  internal fun replaceVariablesInEnv(pm: PostmanSDK): Map<String, Any?> =
+    pm.environment.toMap().entries.associate { (key, value) ->
+      val valueHasPlaceholder = value is String && value.contains("{{")
+      if (!key.contains("{{") && !valueHasPlaceholder) {
+        key to value
+      } else {
+        replaceVariablesRecursively(key, pm)!! to
+          (if (value is String?) replaceVariablesRecursively(value, pm) else value)
+      }
+    }
+```
+- [ ] NOTE for reviewer: static entries were already side-effect-free in the old code (the regex only matches — and only fires `recordConsumed`/`setItBackInEnvironment` — when a `{{…}}` is present). The C1 guard already short-circuits the string scan; this C2 change additionally avoids the per-entry lambda + `is String?` dispatch for static entries. Output map is identical (same keys, same values, same types).
+
+### 2.4 Re-run + gate
+- [ ] `./gradlew test --tests "com.salesforce.revoman.internal.postman.RegexReplacerTest"` → **PASS**
+- [ ] `./gradlew test integrationTest` → **PASS**. RISK per spec: verify no test relies on every value being round-tripped through type-coercion each step. The env-related integration coverage that MUST stay green: `com.salesforce.revoman.integration.restfulapidev.v3.LedgerRoundTripKtTest`, `com.salesforce.revoman.integration.jarmode.JarModeRevUpKtTest`, plus `RegexReplacerScopesTest` (`environment numeric value resolves and is coerced back to Int on setback`) and `RegexReplacerConsumedTest`.
+
+### 2.5 Format + commit
+- [ ] `./gradlew spotlessApply`
+- [ ] `git commit -am "perf(regex): pass static env entries through without regex remap in replaceVariablesInEnv"`
+
+---
+
+## Task 3 — C5: `HexFormat` encoding + `CharArray` alphanumeric
+
+### 3.1 Characterization test — hex/sha output identical to old `String.format`
+- [ ] Append to `src/test/kotlin/com/salesforce/revoman/internal/postman/DynamicVariableGeneratorTest.kt`
+  (`getRandomHex` and `randomAlphanumeric` are top-level in package `com.salesforce.revoman.internal.postman`):
+
+```kotlin
+  @Test
+  fun `getRandomHex output equals the legacy percent-02X formatting for all byte values`() {
+    // Locks the exact rendering the old `"%02X".format(v)` produced across the full range.
+    (0..255).forEach { v ->
+      val legacy = "%02X".format(v)
+      val formatted = java.util.HexFormat.of().withUpperCase().toHexDigits(v.toByte())
+      assertThat(formatted).isEqualTo(legacy)
+    }
+  }
+
+  @Test
+  fun `randomAlphanumeric returns the requested length using only a-zA-Z0-9`() {
+    listOf(0, 1, 15, 64).forEach { len ->
+      val out = randomAlphanumeric(len)
+      assertThat(out).hasLength(len)
+      assertThat(out).matches("[a-zA-Z0-9]*")
+    }
+  }
+```
+- [ ] Add a SHA-256 known-vector test in `src/test/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3LoaderTest.kt`
+  (`sha256Hex` is a top-level `internal fun` in package `…template.v3`; add the import
+  `import com.salesforce.revoman.internal.postman.template.v3.sha256Hex` is unneeded — same package):
+
+```kotlin
+  @Test
+  fun sha256HexMatchesKnownVectors() {
+    // FIPS-180-2 vectors; also locks lowercase, zero-padded, 64-char output.
+    assertThat(sha256Hex("abc"))
+      .isEqualTo("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
+    assertThat(sha256Hex(""))
+      .isEqualTo("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+  }
+```
+- [ ] Existing `getRandomHex …` tests (length 2, `[0-9A-F]{2}`, range 00–FF) and `StepSourceHashTest` (`sha256Hex` determinism/inequality) MUST keep passing.
+
+### 3.2 Run against UNCHANGED code
+- [ ] `./gradlew test --tests "com.salesforce.revoman.internal.postman.DynamicVariableGeneratorTest" --tests "com.salesforce.revoman.internal.postman.template.v3.V3LoaderTest"` → **PASS**
+  (verified out-of-band: old `%02x` sha == `HexFormat.of().formatHex`, old `%02X` == `HexFormat.of().withUpperCase().toHexDigits(byte)` for all 0..255).
+
+### 3.3 Implement `DynamicVariableGenerator.kt` (lines 65, 69)
+- [ ] Add hoisted upper-case formatter + rewrite the two pure functions.
+
+Before:
+```kotlin
+fun getRandomHex(): String = "%02X".format(nextInt(256))
+
+private val charPool = ('a'..'z') + ('A'..'Z') + ('0'..'9')
+
+fun randomAlphanumeric(length: Int) =
+  (1..length).map { charPool[nextInt(0, charPool.size)] }.joinToString("")
+```
+After:
+```kotlin
+private val upperHexFormat = java.util.HexFormat.of().withUpperCase()
+
+fun getRandomHex(): String = upperHexFormat.toHexDigits(nextInt(256).toByte())
+
+private val charPool = ('a'..'z') + ('A'..'Z') + ('0'..'9')
+
+fun randomAlphanumeric(length: Int): String =
+  CharArray(length) { charPool[nextInt(0, charPool.size)] }.concatToString()
+```
+- [ ] NOTE: `CharArray(length) { … }` invokes the init lambda for indices `0 until length` in order, one `nextInt` per char — same count/order of RNG draws as the old `(1..length).map`, same charset, same length. Byte-for-byte identical distribution.
+
+### 3.4 Implement `V3Loader.kt` (line 108 `sha256Hex`)
+- [ ] Replace the `joinToString`/`%02x` tail with `HexFormat` (lowercase == default).
+
+Before:
+```kotlin
+internal fun sha256Hex(s: String): String =
+  java.security.MessageDigest.getInstance("SHA-256")
+    .digest(s.toByteArray(Charsets.UTF_8))
+    .joinToString("") { "%02x".format(it) }
+```
+After:
+```kotlin
+internal fun sha256Hex(s: String): String =
+  java.util.HexFormat.of()
+    .formatHex(
+      java.security.MessageDigest.getInstance("SHA-256").digest(s.toByteArray(Charsets.UTF_8))
+    )
+```
+
+### 3.5 Re-run + gate
+- [ ] `./gradlew test --tests "com.salesforce.revoman.internal.postman.DynamicVariableGeneratorTest" --tests "com.salesforce.revoman.internal.postman.template.v3.V3LoaderTest"` → **PASS**
+- [ ] `./gradlew test integrationTest` → **PASS**
+
+### 3.6 Format + commit
+- [ ] `./gradlew spotlessApply`
+- [ ] `git commit -am "perf(vars): use JDK 21 HexFormat for hex/sha encoding and CharArray for randomAlphanumeric"`
+
+---
+
+## Task 4 — C3: reuse one SnakeYAML reader instance in `V3YamlReader`
+
+### 4.1 Characterization test — sequential reuse parses each doc independently (no state bleed)
+- [ ] Append to `src/test/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3YamlReaderTest.kt` (guards the shared-instance risk: a reused `Yaml` must not carry anchors/state across `load()` calls):
+
+```kotlin
+  @Test
+  fun sequentialReadsThroughSharedYamlAreIndependent() {
+    val first = V3YamlReader.readRequest(
+      """
+      ${'$'}kind: http-request
+      url: "{{baseUrl}}/one"
+      method: GET
+      """
+        .trimIndent()
+    )
+    val second = V3YamlReader.readRequest(
+      """
+      ${'$'}kind: http-request
+      url: "{{baseUrl}}/two"
+      method: POST
+      """
+        .trimIndent()
+    )
+    // Re-read the first shape after the second to prove no cross-call carryover.
+    val firstAgain = V3YamlReader.readRequest(
+      """
+      ${'$'}kind: http-request
+      url: "{{baseUrl}}/one"
+      method: GET
+      """
+        .trimIndent()
+    )
+    assertThat(first.url).isEqualTo("{{baseUrl}}/one")
+    assertThat(first.method).isEqualTo("GET")
+    assertThat(second.url).isEqualTo("{{baseUrl}}/two")
+    assertThat(second.method).isEqualTo("POST")
+    assertThat(firstAgain.url).isEqualTo("{{baseUrl}}/one")
+    assertThat(firstAgain.method).isEqualTo("GET")
+  }
+```
+- [ ] All existing `V3YamlReaderTest` cases (collectionDef, request, env, YAML 1.1 boolean coercion) MUST keep passing.
+
+### 4.2 Run against UNCHANGED code
+- [ ] `./gradlew test --tests "com.salesforce.revoman.internal.postman.template.v3.V3YamlReaderTest"` → **PASS**
+
+### 4.3 Implement — one reader instance (ThreadLocal, future-proof; walk is sequential today)
+- [ ] In `V3YamlReader.kt`, hoist a per-thread `Yaml` and use it in `parseYaml` (line ~120). `Yaml` is not thread-safe; `ThreadLocal` keeps reuse safe even if reads are ever parallelized, at zero cost for the sequential walk.
+
+Before:
+```kotlin
+  private fun parseYaml(yaml: String): Map<String, Any?> {
+    @Suppress("UNCHECKED_CAST")
+    return (Yaml().load<Any?>(yaml) as? Map<String, Any?>) ?: emptyMap()
+  }
+```
+After:
+```kotlin
+  private val yamlReader: ThreadLocal<Yaml> = ThreadLocal.withInitial { Yaml() }
+
+  private fun parseYaml(yaml: String): Map<String, Any?> {
+    @Suppress("UNCHECKED_CAST")
+    return (yamlReader.get().load<Any?>(yaml) as? Map<String, Any?>) ?: emptyMap()
+  }
+```
+- [ ] Do NOT touch `V3YamlWriter` (separate file/worktree; needs its own `DumperOptions`).
+
+### 4.4 Re-run + gate
+- [ ] `./gradlew test --tests "com.salesforce.revoman.internal.postman.template.v3.V3YamlReaderTest"` → **PASS**
+- [ ] `./gradlew test integrationTest` → **PASS**
+
+### 4.5 Format + commit
+- [ ] `./gradlew spotlessApply`
+- [ ] `git commit -am "perf(templates): reuse a per-thread SnakeYAML reader instead of new Yaml() per parse"`
+
+---
+
+## Task 5 — C4: single `metadataOrNull` stat per child in `V3Loader.walk`
+
+### 5.1 Characterization test — walk output unchanged (files + subfolders, ordering, auth)
+- [ ] The existing `V3LoaderTest` suite already exercises `walk` end-to-end with mixed files/folders, ordering, and auth inheritance:
+  `testLoadFlatCollectionOrdersByOrderField` (order among files),
+  `testLoadNestedCollectionWithAuthInheritanceAndOverride` (folder + file mix, nesting),
+  `testLoadMixedBodies`, `testLoadSubfolderInheritsAuthFromGrandparentDefinition`,
+  `testEmptyAuthListDoesNotBlockGrandparentInheritance`.
+  These ARE the characterization tests for C4 — no new test needed (a stat-count refactor is invisible to output; the fixtures already cover regular-file entries, directory entries, and their interleaved ordering).
+- [ ] (Optional guard) confirm `testLoadFlatCollectionOrdersByOrderField` covers a folder having only request files (no subfolders) and `testLoadNestedCollectionWithAuthInheritanceAndOverride` covers both partitions in one directory.
+
+### 5.2 Run against UNCHANGED code
+- [ ] `./gradlew test --tests "com.salesforce.revoman.internal.postman.template.v3.V3LoaderTest"` → **PASS**
+
+### 5.3 Implement — materialize `(child, metadata)` once, then filter both partitions
+- [ ] In `V3Loader.kt`, `walk` (lines 59–93). Compute metadata once per child; keep the declarative `filter`/`map` style.
+
+Before:
+```kotlin
+    val children = fs.list(dir)
+    val requestEntries: List<Pair<Item, Int>> =
+      children
+        .filter { fs.metadataOrNull(it)?.isRegularFile == true && it.name.endsWith(REQUEST_SUFFIX) }
+        .map { file ->
+          ...
+        }
+
+    val folderEntries: List<Pair<Item, Int>> =
+      children
+        .filter { fs.metadataOrNull(it)?.isDirectory == true && hasDef(it, fs) }
+        .map { sub ->
+          ...
+        }
+```
+After:
+```kotlin
+    val childrenWithMeta = fs.list(dir).map { it to fs.metadataOrNull(it) }
+    val requestEntries: List<Pair<Item, Int>> =
+      childrenWithMeta
+        .filter { (path, meta) -> meta?.isRegularFile == true && path.name.endsWith(REQUEST_SUFFIX) }
+        .map { (file, _) ->
+          ...
+        }
+
+    val folderEntries: List<Pair<Item, Int>> =
+      childrenWithMeta
+        .filter { (path, meta) -> meta?.isDirectory == true && hasDef(path, fs) }
+        .map { (sub, _) ->
+          ...
+        }
+```
+- [ ] Keep the `.map` bodies verbatim (only the destructured parameter name changes: `file`→`(file, _)`, `sub`→`(sub, _)`). This drops each child from up-to-2 `metadataOrNull` stat calls to exactly 1.
+
+### 5.4 Re-run + gate
+- [ ] `./gradlew test --tests "com.salesforce.revoman.internal.postman.template.v3.V3LoaderTest"` → **PASS**
+- [ ] Also run the jar-mode walk coverage: `./gradlew test --tests "com.salesforce.revoman.internal.postman.template.v3.V3LoaderJarTest"` → **PASS**
+- [ ] `./gradlew test integrationTest` → **PASS**
+
+### 5.5 Format + commit
+- [ ] `./gradlew spotlessApply`
+- [ ] `git commit -am "perf(templates): stat each walk child once and partition, instead of 2x metadataOrNull"`
+
+---
+
+## Task 6 — JMH benchmark (measured, not gated)
+
+### 6.1 Write the benchmark
+- [ ] Create `src/jmh/kotlin/com/salesforce/revoman/benchmark/RegexVarBenchmark.kt` (WT-0 provides the `jmh` source set + plugin). Measures the two hot paths C1/C2 touch: `replaceVariablesRecursively` over a mix of placeholder / no-placeholder strings, and `replaceVariablesInEnv` over a large env.
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.benchmark
+
+import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
+import com.salesforce.revoman.internal.postman.PostmanSDK
+import com.salesforce.revoman.internal.postman.RegexReplacer
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import org.openjdk.jmh.infra.Blackhole
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+open class RegexVarBenchmark {
+
+  private lateinit var regexReplacer: RegexReplacer
+  private lateinit var pm: PostmanSDK
+
+  // ~90% of real strings carry no placeholder (headers, static URL segments, literal body fields)
+  // -> C1's fast-path guard should dominate the win here.
+  private val mixedStrings: List<String> =
+    (0 until 100).map { i ->
+      if (i % 10 == 0) """{ "id": "{{policyId}}", "when": "{{$'$'}isoTimestamp}}" }"""
+      else """{ "field$i": "static-value-$i", "note": "no placeholders in this line" }"""
+    }
+
+  @Setup
+  fun setup() {
+    regexReplacer = RegexReplacer()
+    pm = PostmanSDK(initMoshi(), null, regexReplacer)
+    pm.environment["policyId"] = "0Pol000000000001"
+    // Large env: mostly static entries + a few placeholder entries (exercises C2 static skip).
+    (0 until 500).forEach { i ->
+      if (i % 25 == 0) pm.environment["k$i"] = "prefix-{{policyId}}-suffix"
+      else pm.environment["k$i"] = "static-value-$i"
+    }
+  }
+
+  @Benchmark
+  fun replaceVariablesRecursivelyOverMixedStrings(bh: Blackhole) {
+    mixedStrings.forEach { bh.consume(regexReplacer.replaceVariablesRecursively(it, pm)) }
+  }
+
+  @Benchmark
+  fun replaceVariablesInEnvOverLargeEnv(bh: Blackhole) {
+    bh.consume(regexReplacer.replaceVariablesInEnv(pm))
+  }
+}
+```
+- [ ] NOTE: replace the `$'$'` marker above with a literal `$` — it denotes the Postman dynamic-var token `{{$isoTimestamp}}` inside a Kotlin triple-quoted string (use `${'$'}` escaping in the actual file). Verify the `jmh` source set can see `internal` symbols; if WT-0 configured `jmh` to depend on `main` output only, `internal` visibility is preserved within the same module/compilation. If the benchmark cannot access `internal`, fall back to driving through the public `PostmanSDK.regexReplacer` accessor (as `RegexReplacerTest` does via `pm.regexReplacer`).
+
+### 6.2 Run the benchmark (measure, do not gate)
+- [ ] `./gradlew jmh -Pjmh.includes=RegexVarBenchmark`
+- [ ] Record the two average-time numbers in the worktree ledger as the post-fix measurement. Compare against WT-0's baseline capture if present. Expected direction: `replaceVariablesRecursivelyOverMixedStrings` improves substantially (guard skips ~90% of regex scans); `replaceVariablesInEnvOverLargeEnv` improves (static entries skip the per-entry regex path).
+
+### 6.3 Format + commit
+- [ ] `./gradlew spotlessApply`
+- [ ] `git commit -am "test(bench): add RegexVarBenchmark for replaceVariablesRecursively + replaceVariablesInEnv"`
+
+---
+
+## Task 7 — Final full gate
+
+- [ ] `./gradlew spotlessApply`
+- [ ] `./gradlew build` (full build incl. all unit + assembly)
+- [ ] `./gradlew test integrationTest` → **PASS** (green, non-core)
+- [ ] Confirm all four owned files changed and NO other source file changed: `git diff --name-only <base>..HEAD` shows only `RegexReplacer.kt`, `V3YamlReader.kt`, `V3Loader.kt`, `DynamicVariableGenerator.kt`, the added test files, and `RegexVarBenchmark.kt`.
+- [ ] Record the JMH deltas + the final green gate in the worktree ledger for the merge report.

--- a/docs/superpowers/plans/2026-07-13-perf-wt4-exe-output-env.md
+++ b/docs/superpowers/plans/2026-07-13-perf-wt4-exe-output-env.md
@@ -1,0 +1,743 @@
+# Perf WT-4: Exe Engine + Output + Persistent Env Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Apply the six behavior-preserving exe-engine/output micro-fixes (D1–D6) and then back the Postman environment with a persistent map (E2) so each `pmEnvSnapshot` is an O(1) structural share instead of an O(E) copy — turning per-step env accumulation from O(M·E) into O(M) — without changing any consumer-visible behavior or the deliberate FP style.
+
+**Architecture:** One memoized Apache http4k client per TLS variant (secure/insecure) replaces per-request client construction; picked pre/post hooks are materialized to a `List` once so pick predicates run once; the response body + content-type are decoded once in `unmarshallResponse`; the two `Step`-keyed ledger-capture maps in `PostmanEnvironment` are re-keyed internally by `step.path` (the existing unique step identity used by the ledger) behind unchanged `Step`-taking method signatures; and finally the env is backed by a `PersistentMap` via a swap-on-write `MutableMap` adapter so a snapshot merely captures the current immutable reference (O(1)) while the external mutable-map contract that `RegexReplacer.setItBackInEnvironment` and `putAll`/`env[k]=v` rely on is fully preserved.
+
+**Tech Stack:** Kotlin, http4k/Apache, kotlinx.collections.immutable, Moshi, JMH
+
+## Global Constraints
+- JDK 21+; branched off WT-0 (has `libs.kotlinx.collections.immutable` [implementation] + the `src/jmh` source set and the `./gradlew jmh -Pjmh.includes=<Name>` invocation contract).
+- Owns ONLY these 9 files — touch no other source file:
+  `ReVoman.kt`, `HttpRequest.kt`, `Polling.kt`, `PreStepHook.kt`, `PostStepHook.kt`, `UnmarshallResponse.kt`, `PostmanEnvironment.kt`, `TxnInfo.kt`, `StepReport.kt` (plus new test files and one new `src/jmh` benchmark).
+- `PostmanSDK.kt` is WT-1's; `RegexReplacer.kt` is WT-3's; `PmJsEval.kt` is not ours. Keep `PostmanEnvironment`'s **primary-ctor shape** (`mutableEnv: MutableMap<String, ValueT>` first, positional) and its **method signatures** (`producedKeysFor(step: Step)`, `consumedKeysFor(step: Step)`, `valuesForKeysStartingWith(type, prefix)`) stable, and keep it IS-A `MutableMap`, so WT-1/WT-3 callers and `pm.environment.mutableEnv` reads (`PmJsEval.kt`) are unaffected.
+- Correctness gate: `./gradlew test integrationTest` green (non-core) — **RUN AFTER EVERY TASK** (highest-risk worktree). Core (`PQE2EWithSMTest`, WFS) tests need a live org and are out of scope for the gate; run them opportunistically only.
+- Preserve FP style (STYLE.md) AND the deliberate immutability contract — E2 keeps the env's mutable-map external interface, swaps a persistent map internally.
+- **E2 (persistent env) is the LAST task group so it can be reverted independently** (see Task Ordering Note).
+- `./gradlew spotlessApply` before every commit.
+---
+
+## Task Ordering Note (why this order)
+
+Ordered low-risk → high-risk so each commit is independently revertible and the correctness gate localizes any regression:
+
+1. **D5, D3, D1, D2, D6** — pure, local, byte-for-byte behavior-preserving. No shared state, no cross-file coupling.
+2. **D4** (`Step`-key → `step.path`) — touches the two `private` ledger-capture maps in `PostmanEnvironment` only; method signatures unchanged. Medium risk: looped-step (same path, N iterations) semantics.
+3. **JMH `EnvAccumBenchmark`** — added here so it can be run on the post-D4 tree to MEASURE D4, then again after E2 to MEASURE E2. Not gated.
+4. **E2** split into **E2a** (introduce the persistent-backed adapter + unit-test it in isolation, wired to nothing) and **E2b** (flip the live env seed + O(1) snapshot). If E2b destabilizes, revert E2b (and E2a) alone; D1–D4 stay landed.
+
+Each task: write characterization/behavior test (REAL Kotlin) → run it (exact cmd + expected) → implement (REAL before/after) → run the new test + `./gradlew test integrationTest` (expected PASS) → `./gradlew spotlessApply` + commit.
+
+---
+
+## Task D5: `TxnInfo.containsHeader` — avoid `headers.toMap()` allocation (behavior-preserving)
+
+**File:** `src/main/kotlin/com/salesforce/revoman/output/report/TxnInfo.kt` (~line 71)
+
+**Nuance (READ FIRST):** the spec suggests `httpMsg.header(key) != null`, but that is NOT byte-for-byte:
+- `headers.toMap().containsKey(key)` is **case-SENSITIVE** (exact key) and true even for a present-but-null-valued header.
+- http4k's `header(key)` is **case-INSENSITIVE** and returns the first value, so `header(key) != null` is `false` for a present null-valued header and `true` for a differently-cased key.
+
+The behavior-preserving fix that also kills the `toMap()` allocation is `httpMsg.headers.any { it.first == key }` (case-sensitive, present-regardless-of-value, single pass, no map built). Use that.
+
+- [ ] **Step 1: Characterization test.** Create `src/test/kotlin/com/salesforce/revoman/output/report/TxnInfoContainsHeaderTest.kt`:
+  ```kotlin
+  package com.salesforce.revoman.output.report
+
+  import com.google.common.truth.Truth.assertThat
+  import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
+  import org.http4k.core.Method.GET
+  import org.http4k.core.Request
+  import org.junit.jupiter.api.Test
+
+  class TxnInfoContainsHeaderTest {
+      private val moshiReVoman = initMoshi()
+
+      private fun txn(request: Request): TxnInfo<Request> =
+          TxnInfo(httpMsg = request, moshiReVoman = moshiReVoman)
+
+      @Test
+      fun `containsHeader true when header present`() {
+          val info = txn(Request(GET, "https://x.y/z").header("X-Trace", "abc"))
+          assertThat(info.containsHeader("X-Trace")).isTrue()
+      }
+
+      @Test
+      fun `containsHeader false when header absent`() {
+          val info = txn(Request(GET, "https://x.y/z").header("X-Trace", "abc"))
+          assertThat(info.containsHeader("X-Missing")).isFalse()
+      }
+
+      @Test
+      fun `containsHeader is case-sensitive on the key (preserves toMap semantics)`() {
+          val info = txn(Request(GET, "https://x.y/z").header("X-Trace", "abc"))
+          assertThat(info.containsHeader("x-trace")).isFalse()
+      }
+  }
+  ```
+- [ ] **Step 2: Run against current code.** `./gradlew test --tests "com.salesforce.revoman.output.report.TxnInfoContainsHeaderTest"` — Expected: **all 3 PASS** (they pin the current `toMap().containsKey` semantics, which the test asserts).
+- [ ] **Step 3: Implement.** In `TxnInfo.kt`:
+  - BEFORE:
+    ```kotlin
+    fun containsHeader(key: String): Boolean = httpMsg.headers.toMap().containsKey(key)
+    ```
+  - AFTER:
+    ```kotlin
+    fun containsHeader(key: String): Boolean = httpMsg.headers.any { it.first == key }
+    ```
+  Leave the `containsHeader(key, value)` overload (line 73) untouched.
+- [ ] **Step 4: Re-run the new test + gate.** `./gradlew test --tests "...TxnInfoContainsHeaderTest"` then `./gradlew test integrationTest` — Expected: **PASS** (case-sensitive semantics preserved).
+- [ ] **Step 5:** `./gradlew spotlessApply` then commit:
+  ```
+  git commit -am "perf(D5): TxnInfo.containsHeader avoids headers.toMap() allocation"
+  ```
+
+---
+
+## Task D3: `unmarshallResponse` — decode body + content-type once
+
+**File:** `src/main/kotlin/com/salesforce/revoman/internal/exe/UnmarshallResponse.kt` (~line 35, 49)
+
+Currently `httpResponse.bodyString()` is called twice (line 35 guard + line 49 decode) and `httpResponse.contentType()` twice (line 36 + line 69). Hoist both.
+
+- [ ] **Step 1: Characterization test.** Create `src/test/kotlin/com/salesforce/revoman/internal/exe/UnmarshallResponseBodyTest.kt`. A JSON body unmarshals once to the configured/`Any` type; a blank body / non-JSON content-type yields `isJson = false`. Use the existing `Kick` builder + a minimal `StepReport` (mirror `PollingTest.kt`/`StepReportTest.kt` construction — `StepReport(step = ..., responseInfo = Right(TxnInfo(...)), requestInfo = Right(TxnInfo(...)), pmEnvSnapshot = PostmanEnvironment())`). Assert:
+  - JSON `Response(OK).header("Content-Type","application/json").body("""{"a":1}""")` → `Right`, `txnObj` is a `Map` with `a`.
+  - Blank body → `Right`, `isJson == false`.
+  - Non-JSON content-type with a body → `Right`, `isJson == false`.
+  Keep the test at the `unmarshallResponse(kick, moshiReVoman, currentStepReport, rundown)` entry point (build `rundown` as the other exe tests do).
+- [ ] **Step 2: Run against current code.** `./gradlew test --tests "...UnmarshallResponseBodyTest"` — Expected: **PASS** (pins current behavior).
+- [ ] **Step 3: Implement.** In `unmarshallResponse`, right after `val httpResponse = ...`:
+  - BEFORE (the `when` head + decode + else log):
+    ```kotlin
+    val httpResponse = currentStepReport.responseInfo!!.get().httpMsg
+    return when {
+      httpResponse.bodyString().isNotBlank() &&
+        APPLICATION_JSON.value.equals(httpResponse.contentType()?.value, true) -> {
+        ...
+        runCatching(currentStep, UNMARSHALL_RESPONSE) {
+            moshiReVoman.fromJson<Any>(httpResponse.bodyString(), responseType)
+          }
+        ...
+      }
+      else -> {
+        logger.info {
+          "${currentStepReport.step} Blank Response body or ${httpResponse.contentType()?.value} didn't match ${APPLICATION_JSON.value}"
+        }
+        ...
+      }
+    }
+    ```
+  - AFTER:
+    ```kotlin
+    val httpResponse = currentStepReport.responseInfo!!.get().httpMsg
+    val body: String = httpResponse.bodyString()
+    val contentType: String? = httpResponse.contentType()?.value
+    return when {
+      body.isNotBlank() && APPLICATION_JSON.value.equals(contentType, true) -> {
+        ...
+        runCatching(currentStep, UNMARSHALL_RESPONSE) {
+            moshiReVoman.fromJson<Any>(body, responseType)
+          }
+        ...
+      }
+      else -> {
+        logger.info {
+          "${currentStepReport.step} Blank Response body or $contentType didn't match ${APPLICATION_JSON.value}"
+        }
+        ...
+      }
+    }
+    ```
+    (Replace both `httpResponse.bodyString()` uses with `body` and both `httpResponse.contentType()?.value` uses with `contentType`.)
+- [ ] **Step 4: Re-run new test + gate.** `./gradlew test --tests "...UnmarshallResponseBodyTest"` then `./gradlew test integrationTest` — Expected: **PASS**.
+- [ ] **Step 5:** `./gradlew spotlessApply` then commit:
+  ```
+  git commit -am "perf(D3): unmarshallResponse decodes body + content-type once"
+  ```
+
+---
+
+## Task D1: Memoize one Apache http client per TLS variant
+
+**Files:** `src/main/kotlin/com/salesforce/revoman/internal/exe/HttpRequest.kt` (~line 40, 62); `Polling.kt` (~line 43, benefits transitively).
+
+`prepareHttpClient(insecureHttp)` currently builds a fresh `ApacheClient` (secure) or a fresh pooled `ApacheClient(client = insecureApacheHttpClient())` (insecure) on EVERY request and Polling iteration, discarding it (per-run client leak). Auth is carried per-`Request`, so a single client per variant is safe to share.
+
+- [ ] **Step 1: Behavior test (shared client serves two requests).** Create `src/test/kotlin/com/salesforce/revoman/internal/exe/PrepareHttpClientTest.kt`. Stand up an in-process http4k server (dependency `org.http4k:http4k-core` is on the classpath; use `org.http4k.server` if a server backend is available, else assert client identity + a live call to a public echo is out of scope). Minimal, network-free assertion that is robust:
+  ```kotlin
+  package com.salesforce.revoman.internal.exe
+
+  import com.google.common.truth.Truth.assertThat
+  import org.junit.jupiter.api.Test
+
+  class PrepareHttpClientTest {
+      @Test
+      fun `secure variant returns the same memoized handler across calls`() {
+          assertThat(prepareHttpClient(false)).isSameInstanceAs(prepareHttpClient(false))
+      }
+
+      @Test
+      fun `insecure variant returns the same memoized handler across calls`() {
+          assertThat(prepareHttpClient(true)).isSameInstanceAs(prepareHttpClient(true))
+      }
+
+      @Test
+      fun `secure and insecure are distinct handlers`() {
+          assertThat(prepareHttpClient(false)).isNotSameInstanceAs(prepareHttpClient(true))
+      }
+  }
+  ```
+  (Two-requests-succeed-with-shared-client is covered end-to-end by the existing `PokemonTest`/`ApigeeKtTest` integration tests, which fire multiple real requests through `prepareHttpClient`; the gate exercises the shared client for real.)
+- [ ] **Step 2: Run against current code.** `./gradlew test --tests "...PrepareHttpClientTest"` — Expected: the two "same instance" tests **FAIL** (current code builds fresh each call), the "distinct" test PASSES. This is the RED that proves the fix is needed.
+- [ ] **Step 3: Implement.** In `HttpRequest.kt`:
+  - BEFORE:
+    ```kotlin
+    internal fun prepareHttpClient(insecureHttp: Boolean): HttpHandler =
+      if (insecureHttp) ApacheClient(client = insecureApacheHttpClient()) else ApacheClient()
+    ```
+  - AFTER:
+    ```kotlin
+    // One http4k/Apache client per TLS variant, memoized for the life of the JVM. Auth is carried
+    // per-Request (each Request builds its own Authorization header), so a single shared, pooled
+    // client is safe across steps/runs — and avoids building + discarding a pooled client (and its
+    // connection manager) on every request, which also fixes the per-run client leak.
+    private val secureHttpClient: HttpHandler by lazy { ApacheClient() }
+
+    private val insecureHttpClient: HttpHandler by lazy {
+      ApacheClient(client = insecureApacheHttpClient())
+    }
+
+    internal fun prepareHttpClient(insecureHttp: Boolean): HttpHandler =
+      if (insecureHttp) insecureHttpClient else secureHttpClient
+    ```
+    Also delete the now-stale per-step comment block above the `prepareHttpClient(insecureHttp)(httpRequest)` call in `fireHttpRequest` (the "Preparing httpClient for each step" NOTE at ~line 37) since it no longer describes the code; replace with a one-line note that the client is shared and auth is per-Request. `Polling.kt:43` (`val httpClient = prepareHttpClient(insecureHttp)`) needs no change — it now receives the memoized handler.
+- [ ] **Step 4: Re-run new test + gate.** `./gradlew test --tests "...PrepareHttpClientTest"` (Expected: all 3 PASS) then `./gradlew test integrationTest` (Expected: PASS — Pokemon/Apigee fire multiple real requests through the shared client).
+- [ ] **Step 5:** `./gradlew spotlessApply` then commit:
+  ```
+  git commit -am "perf(D1): memoize one Apache http client per TLS variant (fixes per-request client leak)"
+  ```
+
+---
+
+## Task D2: Materialize picked hooks to a `List` once (Pre + Post)
+
+**Files:** `PreStepHook.kt` (~line 46), `PostStepHook.kt` (~line 47).
+
+`pickPreStepHooks`/`pickPostStepHooks` return a `Sequence`; the `.also { ... it.iterator().hasNext(); it.count(); it.count() }` re-runs the filter/map pick predicate up to 3× per step. Materialize to a `List` once and use `.isNotEmpty()`/`.size`.
+
+- [ ] **Step 1: Characterization test (predicate runs once; count correct).** Create `src/test/kotlin/com/salesforce/revoman/internal/exe/PickHooksMaterializeTest.kt`. Build a `Kick` with two `PreStepHook`s whose `PreTxnStepPick` increments an `AtomicInteger` and returns true, and assert after `preStepHookExe` that (a) the picked count set on `currentStep.preStepHookCount == 2` and (b) each pick predicate ran exactly once (counter == number of configured hooks, not 3–4×). Mirror the existing hook-config construction in `RundownScopesTest`/`StepReportTest`; use `Item(name=...)` for the `Step` as `PostmanEnvironmentEnvVarsTest` does. If wiring a full `Kick` is heavy, assert the invariant at the `pickPreStepHooks`/`pickPostStepHooks` boundary via a focused test that counts predicate invocations.
+- [ ] **Step 2: Run against current code.** `./gradlew test --tests "...PickHooksMaterializeTest"` — Expected: the "predicate runs once" assertion **FAILS** (current sequence re-evaluates), confirming the waste.
+- [ ] **Step 3: Implement.** In `PreStepHook.kt`:
+  - BEFORE:
+    ```kotlin
+    private fun pickPreStepHooks(...): Sequence<PreStepHook> =
+      preStepHooks
+        .asSequence()
+        .filter { (it.pick as PreTxnStepPick).pick(currentStep, requestInfo, rundown) }
+        .map { it.stepHook as PreStepHook }
+        .also {
+          if (it.iterator().hasNext()) {
+            logger.info { "$currentStep Picked Pre hook count : ${it.count()}" }
+            currentStep.preStepHookCount = it.count()
+          }
+        }
+    ```
+  - AFTER:
+    ```kotlin
+    private fun pickPreStepHooks(...): List<PreStepHook> =
+      preStepHooks
+        .filter { (it.pick as PreTxnStepPick).pick(currentStep, requestInfo, rundown) }
+        .map { it.stepHook as PreStepHook }
+        .also {
+          if (it.isNotEmpty()) {
+            logger.info { "$currentStep Picked Pre hook count : ${it.size}" }
+            currentStep.preStepHookCount = it.size
+          }
+        }
+    ```
+  The consumer `preStepHookExe` chains `.map { ... }.firstOrNull { it.isLeft() }?.leftOrNull()` — unchanged, works identically on a `List`. Apply the same shape to `PostStepHook.kt` (`pickPostStepHooks` → `List<PostStepHook>`, `it.isNotEmpty()`, `it.size`, `currentStepReport.step.postStepHookCount = it.size`).
+- [ ] **Step 4: Re-run new test + gate.** `./gradlew test --tests "...PickHooksMaterializeTest"` (Expected: PASS) then `./gradlew test integrationTest` (Expected: PASS).
+- [ ] **Step 5:** `./gradlew spotlessApply` then commit:
+  ```
+  git commit -am "perf(D2): materialize picked pre/post hooks to a List once"
+  ```
+
+---
+
+## Task D6: `valuesForKeysStartingWith(type, prefix)` delegates to the vararg sibling
+
+**File:** `PostmanEnvironment.kt` (~line 214 single-prefix; ~line 217 vararg sibling).
+
+The single-prefix overload builds a whole `PostmanEnvironment` via `mutableEnvCopyWithKeysStartingWith` (filter + mapValues + toMutableMap + object alloc) then reads `.mutableEnv.values.toSet()` — a double pass plus a throwaway object. The vararg sibling already does a single sequence pass. Delegate.
+
+- [ ] **Step 1: Characterization test.** Create `src/test/kotlin/com/salesforce/revoman/output/postman/ValuesForKeysStartingWithTest.kt`:
+  ```kotlin
+  package com.salesforce.revoman.output.postman
+
+  import com.google.common.truth.Truth.assertThat
+  import org.junit.jupiter.api.Test
+
+  class ValuesForKeysStartingWithTest {
+      private val env =
+          PostmanEnvironment<Any?>(
+              mutableMapOf("saId1" to "a", "saId2" to "b", "other" to "c", "num" to 1))
+
+      @Test
+      fun `single prefix returns typed values for matching keys`() {
+          assertThat(env.valuesForKeysStartingWith(String::class.java, "saId"))
+              .containsExactly("a", "b")
+      }
+
+      @Test
+      fun `single prefix filters by type`() {
+          assertThat(env.valuesForKeysStartingWith(Integer::class.java, "num")).containsExactly(1)
+      }
+
+      @Test
+      fun `single prefix no match is empty`() {
+          assertThat(env.valuesForKeysStartingWith(String::class.java, "zzz")).isEmpty()
+      }
+  }
+  ```
+- [ ] **Step 2: Run against current code.** `./gradlew test --tests "...ValuesForKeysStartingWithTest"` — Expected: **PASS** (pins current output).
+- [ ] **Step 3: Implement.** In `PostmanEnvironment.kt`:
+  - BEFORE:
+    ```kotlin
+    fun <T> valuesForKeysStartingWith(type: Class<T>, prefix: String): Set<T> =
+      mutableEnvCopyWithKeysStartingWith(type, prefix).mutableEnv.values.toSet()
+    ```
+  - AFTER:
+    ```kotlin
+    fun <T> valuesForKeysStartingWith(type: Class<T>, prefix: String): Set<T> =
+      valuesForKeysStartingWith(type, *arrayOf(prefix))
+    ```
+  (The vararg overload at ~line 217 returns `Set<T>` via a single `asSequence().filter{}.mapNotNull{}.toSet()`. Signature of the single-prefix overload is unchanged — external callers unaffected.)
+- [ ] **Step 4: Re-run new test + gate.** `./gradlew test --tests "...ValuesForKeysStartingWithTest"` then `./gradlew test integrationTest` — Expected: **PASS**.
+- [ ] **Step 5:** `./gradlew spotlessApply` then commit:
+  ```
+  git commit -am "perf(D6): single-prefix valuesForKeysStartingWith delegates to vararg sibling (single pass)"
+  ```
+
+---
+
+## Task D4: Key the two ledger-capture maps by `step.path` internally
+
+**File:** `PostmanEnvironment.kt` (~line 36–37 map decls; ~line 39/41 readers; ~line 46 `recordConsumed`; ~line 64 `set`; ~line 74 `unset`).
+
+`producedKeysByStep`/`consumedKeysByStep` are `private MutableMap<Step, MutableSet<String>>`. `Step`'s `hashCode`/`equals` (data class) recurse through `rawPMStep: Item` — the full request body + all JS scripts — so every map op hashes the entire step. `step.path` is the existing unique step identity: the ledger keys `learnedLedger` by `step.path` (ReVoman.kt:189), looks up `ledger.steps[step.path]` (ReVoman.kt:343), and tracks `iterationByPath` by path — so the whole engine already treats path as the step key. Re-key these two maps by `String` (`step.path`) internally, keeping the `producedKeysFor(step: Step)` / `consumedKeysFor(step: Step)` **signatures unchanged**.
+
+**Coupling check (verified against real code):** these two maps are the ONLY `producedKeysByStep`/`consumedKeysByStep` in the repo (grep-confirmed) and are `private`, reached only via `set`/`unset`/`recordConsumed` (all use the internal `currentStep` field or a passed `Step`) and the two `*For(step)` readers. WT-1's `PostmanSDK.kt` does NOT reference these maps (its line-96 map is `pmTestAssertionsByStep`, a separate `Step`-keyed map that stays WT-1's concern). So D4 here needs **no** signature change and **no** WT-1 coordination.
+
+**Looped-step risk:** the existing comment documents that these maps are NOT reset between iterations, so a step running twice accumulates the UNION of both iterations' keys. In the sequencer the SAME `Step` instance (`pickedSteps[cursor]`) is reused across iterations, and its `path` is stable, so path-keying yields the IDENTICAL union accumulation. The characterization test must prove this.
+
+- [ ] **Step 1: Characterization test (looped step; union across iterations by path).** Add to `src/test/kotlin/com/salesforce/revoman/output/postman/PostmanEnvironmentEnvVarsTest.kt` (or a new `PostmanEnvironmentPathKeyTest.kt`):
+  ```kotlin
+  @Test
+  fun `two set()s on the same step accumulate the union (path-keyed)`() {
+      val env = PostmanEnvironment<Any?>()
+      val step = Step(index = "1", rawPMStep = Item(name = "create-sa"))
+      env.currentStep = step
+      env.set("saId1", "a")
+      env.set("saId2", "b")
+      assertThat(env.producedKeysFor(step)).containsExactly("saId1", "saId2")
+  }
+
+  @Test
+  fun `producedKeysFor resolves by path (distinct Step instance, same path)`() {
+      val env = PostmanEnvironment<Any?>()
+      val step1 = Step(index = "1", rawPMStep = Item(name = "create-sa"))
+      env.currentStep = step1
+      env.set("saId1", "a")
+      // A different Step instance with the SAME path (the engine reuses the same instance, but this
+      // pins that lookups are by path identity, matching the ledger's step.path keying).
+      val step1Again = Step(index = "1", rawPMStep = Item(name = "create-sa"))
+      assertThat(env.producedKeysFor(step1Again)).containsExactly("saId1")
+  }
+  ```
+  (Keep the existing `PostmanEnvironmentEnvVarsTest` tests — they pass a step whose path equals its name for root steps, so they remain green.)
+- [ ] **Step 2: Run against current code.** `./gradlew test --tests "...PostmanEnvironmentEnvVarsTest" --tests "...PostmanEnvironmentPathKeyTest"` — Expected: the "distinct Step instance, same path" test **FAILS** under the current `Step`-keyed map (two equal-by-value data-class instances actually ARE `.equals()`, so it may pass — if so, this test documents the equivalence; the union test passes). The union test PASSES on current code. Note in the ledger the reused-instance case is what runs; this test locks path-identity behavior for the refactor.
+- [ ] **Step 3: Implement.** In `PostmanEnvironment.kt`:
+  - Map decls (BEFORE → AFTER):
+    ```kotlin
+    private val producedKeysByStep: MutableMap<Step, MutableSet<String>> = mutableMapOf()
+    private val consumedKeysByStep: MutableMap<Step, MutableSet<String>> = mutableMapOf()
+    ```
+    →
+    ```kotlin
+    // Keyed by step.path (String), NOT the whole Step: Step's data-class hashCode/equals recurse
+    // through rawPMStep (request body + every JS script). path is the step's unique identity used
+    // everywhere else by the ledger (learnedLedger, ledger.steps lookup, iterationByPath).
+    private val producedKeysByStepPath: MutableMap<String, MutableSet<String>> = mutableMapOf()
+    private val consumedKeysByStepPath: MutableMap<String, MutableSet<String>> = mutableMapOf()
+    ```
+  - Readers (signatures UNCHANGED, body switches to `step.path`):
+    ```kotlin
+    fun producedKeysFor(step: Step): Set<String> =
+      producedKeysByStepPath[step.path]?.toSet() ?: emptySet()
+
+    fun consumedKeysFor(step: Step): Set<String> =
+      consumedKeysByStepPath[step.path]?.toSet() ?: emptySet()
+    ```
+  - `recordConsumed` (BEFORE `consumedKeysByStep.getOrPut(currentStep)`):
+    ```kotlin
+    if (::currentStep.isInitialized) {
+      consumedKeysByStepPath.getOrPut(currentStep.path) { mutableSetOf() }.add(key)
+    }
+    ```
+  - `set` (BEFORE `producedKeysByStep.getOrPut(step)`):
+    ```kotlin
+    if (step != null) producedKeysByStepPath.getOrPut(step.path) { mutableSetOf() }.add(key)
+    ```
+  - `unset` (BEFORE `producedKeysByStep[step]?.remove(key)`):
+    ```kotlin
+    if (step != null) producedKeysByStepPath[step.path]?.remove(key)
+    ```
+  (The `set`/`unset`/log lines still interpolate the `Step?` object for the log message — leave that; only the map key changes.)
+- [ ] **Step 4: Re-run tests + gate.** `./gradlew test --tests "...PostmanEnvironmentEnvVarsTest" --tests "...PostmanEnvironmentPathKeyTest"` (Expected: PASS) then `./gradlew test integrationTest` — Expected: **PASS**. Pay attention to `LedgerRoundTripKtTest` (integration) and `RundownScopesTest`/`StepReportEnvVarsTest` which exercise produced/consumed capture — they must stay green.
+- [ ] **Step 5:** `./gradlew spotlessApply` then commit:
+  ```
+  git commit -am "perf(D4): key PostmanEnvironment ledger-capture maps by step.path (avoids Step deep-hash)"
+  ```
+
+---
+
+## Task JMH: `EnvAccumBenchmark` — measure D4 (and, after E2, E2)
+
+**File (new):** `src/jmh/kotlin/com/salesforce/revoman/benchmark/EnvAccumBenchmark.kt` (source set + `./gradlew jmh -Pjmh.includes=<Name>` provided by WT-0).
+
+Simulates M steps of `set` + `pmEnvSnapshot` against a growing env of E entries — the exact O(M·E)→O(M) shape D4+E2 target. MEASURED, not gated.
+
+- [ ] **Step 1: Create the benchmark.**
+  ```kotlin
+  package com.salesforce.revoman.benchmark
+
+  import com.salesforce.revoman.internal.postman.template.Item
+  import com.salesforce.revoman.output.postman.PostmanEnvironment
+  import com.salesforce.revoman.output.report.Step
+  import java.util.concurrent.TimeUnit
+  import org.openjdk.jmh.annotations.Benchmark
+  import org.openjdk.jmh.annotations.BenchmarkMode
+  import org.openjdk.jmh.annotations.Fork
+  import org.openjdk.jmh.annotations.Measurement
+  import org.openjdk.jmh.annotations.Mode
+  import org.openjdk.jmh.annotations.OutputTimeUnit
+  import org.openjdk.jmh.annotations.Param
+  import org.openjdk.jmh.annotations.Scope
+  import org.openjdk.jmh.annotations.Setup
+  import org.openjdk.jmh.annotations.State
+  import org.openjdk.jmh.annotations.Warmup
+  import org.openjdk.jmh.infra.Blackhole
+
+  /**
+   * M steps, each: set a fresh key + capture a per-step env snapshot (mirrors ReVoman.runStep's
+   * pmEnvSnapshot). Measures env-accumulation cost — O(M*E) with a copy-on-snapshot backing,
+   * O(M) once E2's persistent map makes the snapshot an O(1) structural share.
+   */
+  @State(Scope.Thread)
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  @Warmup(iterations = 3, time = 1)
+  @Measurement(iterations = 5, time = 1)
+  @Fork(1)
+  open class EnvAccumBenchmark {
+      @Param("50", "200", "800") open var steps: Int = 0
+
+      private lateinit var stepList: List<Step>
+
+      @Setup
+      fun setUp() {
+          stepList = (0 until steps).map { Step(index = "$it", rawPMStep = Item(name = "s$it")) }
+      }
+
+      @Benchmark
+      open fun accumulateAndSnapshot(bh: Blackhole) {
+          val env = PostmanEnvironment<Any?>()
+          stepList.forEach { step ->
+              env.currentStep = step
+              env.set("key_${step.name}", step.name)
+              // Mirror ReVoman.runStep's per-step snapshot capture:
+              bh.consume(env.copy(mutableEnv = env.mutableEnv.toMutableMap()))
+          }
+          bh.consume(env)
+      }
+  }
+  ```
+  (After E2b lands, update the snapshot line to the O(1) helper — see E2b Step 4 — and re-run to record the delta.)
+- [ ] **Step 2: Compile + run.** `./gradlew compileJmhKotlin` (Expected: BUILD SUCCESSFUL), then `./gradlew jmh -Pjmh.includes=EnvAccumBenchmark` — Expected: a results table with `EnvAccumBenchmark.accumulateAndSnapshot` rows per `steps` param; snapshot per-run under `build/results/jmh/results.txt`. Record the numbers (this is the post-D4 baseline for the snapshot cost). Not a gate — do not fail the task on timing.
+- [ ] **Step 3:** commit:
+  ```
+  git add src/jmh/kotlin/com/salesforce/revoman/benchmark/EnvAccumBenchmark.kt
+  git commit -m "test(jmh): EnvAccumBenchmark for env set + snapshot (measures D4/E2)"
+  ```
+
+---
+
+## Task E2a: Introduce the persistent-map-backed `MutableMap` adapter (wired to nothing)
+
+**File:** `PostmanEnvironment.kt` (new internal class, no behavior wiring yet — lowest-risk first half of E2).
+
+The adapter implements `MutableMap<String, ValueT>` over a `var current: PersistentMap<String, ValueT>`, swapping on every write, so that a captured reference is a true point-in-time immutable view. Critical design points learned from the code:
+- `pm.environment.keys` is read EVERY step (ReVoman.kt:344, then `containsAll`/iterate). `keys`/`entries`/`values` MUST be non-copying read-through views (mutators throw — nothing in the codebase mutates through them, grep-verified) so per-step `.keys` stays O(1) and E2 actually reaches O(M).
+- Must support null VALUES (env stores `key5 to null`; ledger keeps existing values). kotlinx `persistentMapOf`/`PersistentMap.put(k, null)` accepts null values — the E2a test pins this.
+- `equals`/`hashCode` follow the `Map` contract (delegate to `current`) so `data class PostmanEnvironment` equality and `shouldContainExactly`/`.mutableEnv shouldContainExactly` assertions still hold.
+
+- [ ] **Step 1: Unit test the adapter in isolation.** Create `src/test/kotlin/com/salesforce/revoman/output/postman/PersistentBackedMutableMapTest.kt`:
+  ```kotlin
+  package com.salesforce.revoman.output.postman
+
+  import com.google.common.truth.Truth.assertThat
+  import org.junit.jupiter.api.Test
+
+  class PersistentBackedMutableMapTest {
+      @Test
+      fun `put get remove behave like a map`() {
+          val m = PersistentBackedMutableMap<Any?>()
+          m["a"] = 1
+          m["b"] = 2
+          assertThat(m["a"]).isEqualTo(1)
+          assertThat(m.size).isEqualTo(2)
+          m.remove("a")
+          assertThat(m.containsKey("a")).isFalse()
+      }
+
+      @Test
+      fun `supports null values`() {
+          val m = PersistentBackedMutableMap<Any?>()
+          m["k"] = null
+          assertThat(m.containsKey("k")).isTrue()
+          assertThat(m["k"]).isNull()
+      }
+
+      @Test
+      fun `snapshot is an O(1) point-in-time view unaffected by later writes`() {
+          val m = PersistentBackedMutableMap<Any?>()
+          m["a"] = 1
+          val snap = m.snapshotView()
+          m["b"] = 2 // mutate the live map AFTER snapshot
+          assertThat(snap).containsExactlyEntriesIn(mapOf("a" to 1))
+          assertThat(m).containsExactlyEntriesIn(mapOf("a" to 1, "b" to 2))
+      }
+
+      @Test
+      fun `equals and hashCode follow Map contract`() {
+          val m = PersistentBackedMutableMap<Any?>()
+          m["a"] = 1
+          assertThat(m).isEqualTo(mapOf("a" to 1))
+          assertThat(m.hashCode()).isEqualTo(mapOf("a" to 1).hashCode())
+      }
+
+      @Test
+      fun `keys view reflects live state without copying`() {
+          val m = PersistentBackedMutableMap<Any?>()
+          m["a"] = 1
+          val keys = m.keys
+          m["b"] = 2
+          // read-through view: sees the new key
+          assertThat(keys).containsExactly("a", "b")
+      }
+  }
+  ```
+- [ ] **Step 2: Run (RED — class does not exist).** `./gradlew test --tests "...PersistentBackedMutableMapTest"` — Expected: **compile error / FAIL** (adapter not yet written).
+- [ ] **Step 3: Implement the adapter** in `PostmanEnvironment.kt` (top-level `internal class`, plus imports `kotlinx.collections.immutable.PersistentMap`, `kotlinx.collections.immutable.persistentMapOf`, `kotlinx.collections.immutable.toPersistentMap`):
+  ```kotlin
+  /**
+   * A [MutableMap] backed by an immutable [PersistentMap] that is SWAPPED on every write. Because the
+   * backing is immutable, [snapshotView] captures the current reference in O(1) and later writes to
+   * this instance (which install a NEW persistent map) never mutate that captured view — the
+   * point-in-time invariant [StepReport.pmEnvSnapshot] relies on. Reads/keys/entries/values are
+   * non-copying read-through views over the current backing (mutators on those views throw; nothing
+   * in ReVoman mutates through them), so the per-step `pm.environment.keys` access stays O(1).
+   */
+  internal class PersistentBackedMutableMap<V>
+  private constructor(private var current: PersistentMap<String, V>) : MutableMap<String, V> {
+
+      constructor() : this(persistentMapOf())
+
+      constructor(seed: Map<String, V>) : this(seed.toPersistentMap())
+
+      /** O(1): a NEW instance sharing this instance's current immutable backing. */
+      fun snapshotView(): PersistentBackedMutableMap<V> = PersistentBackedMutableMap(current)
+
+      override val size: Int get() = current.size
+      override fun isEmpty(): Boolean = current.isEmpty()
+      override fun containsKey(key: String): Boolean = current.containsKey(key)
+      override fun containsValue(value: V): Boolean = current.containsValue(value)
+      override fun get(key: String): V? = current[key]
+
+      override fun put(key: String, value: V): V? {
+          val prev = current[key]
+          current = current.put(key, value)
+          return prev
+      }
+
+      override fun remove(key: String): V? {
+          val prev = current[key]
+          current = current.remove(key)
+          return prev
+      }
+
+      override fun putAll(from: Map<out String, V>) {
+          current = current.putAll(from)
+      }
+
+      override fun clear() {
+          current = persistentMapOf()
+      }
+
+      // Read-through views over the current backing. kotlinx immutable views are Set/Collection; wrap
+      // them so the MutableMap type is satisfied. Mutators throw — no ReVoman code path mutates
+      // through env.keys/entries/values (grep-verified); the swap-on-write API above is the only
+      // supported mutation surface.
+      override val keys: MutableSet<String>
+          get() = object : AbstractMutableSet<String>() {
+              override val size: Int get() = current.size
+              override fun iterator(): MutableIterator<String> =
+                  current.keys.iterator().asReadOnlyMutable()
+              override fun add(element: String): Boolean = throw UnsupportedOperationException()
+          }
+
+      override val values: MutableCollection<V>
+          get() = object : AbstractMutableCollection<V>() {
+              override val size: Int get() = current.size
+              override fun iterator(): MutableIterator<V> =
+                  current.values.iterator().asReadOnlyMutable()
+              override fun add(element: V): Boolean = throw UnsupportedOperationException()
+          }
+
+      override val entries: MutableSet<MutableMap.MutableEntry<String, V>>
+          get() = object : AbstractMutableSet<MutableMap.MutableEntry<String, V>>() {
+              override val size: Int get() = current.size
+              override fun iterator(): MutableIterator<MutableMap.MutableEntry<String, V>> =
+                  current.entries
+                      .map { it as MutableMap.MutableEntry<String, V> }
+                      .iterator()
+                      .asReadOnlyMutable()
+              override fun add(element: MutableMap.MutableEntry<String, V>): Boolean =
+                  throw UnsupportedOperationException()
+          }
+
+      override fun equals(other: Any?): Boolean = current == other
+      override fun hashCode(): Int = current.hashCode()
+      override fun toString(): String = current.toString()
+  }
+
+  private fun <T> Iterator<T>.asReadOnlyMutable(): MutableIterator<T> =
+      object : MutableIterator<T> {
+          override fun hasNext(): Boolean = this@asReadOnlyMutable.hasNext()
+          override fun next(): T = this@asReadOnlyMutable.next()
+          override fun remove(): Unit = throw UnsupportedOperationException()
+      }
+  ```
+  (If `AbstractMutableSet`/`AbstractMutableCollection` prove awkward with the read-only iterator under the compiler's contract checks, fall back to the simplest correct form: return `current.keys.toMutableSet()` etc. ONLY as a last resort, and if so RE-CONFIRM via the JMH benchmark that per-step `.keys` did not reintroduce O(E) — the read-through view is the intended design precisely because `.keys` is on the per-step hot path.)
+- [ ] **Step 4: Run adapter test + gate.** `./gradlew test --tests "...PersistentBackedMutableMapTest"` (Expected: PASS) then `./gradlew test integrationTest` (Expected: PASS — adapter is not yet wired into `PostmanEnvironment`, so this only proves it compiles and nothing broke).
+- [ ] **Step 5:** `./gradlew spotlessApply` then commit:
+  ```
+  git commit -am "perf(E2a): add PersistentBackedMutableMap adapter (swap-on-write, O(1) snapshotView)"
+  ```
+
+---
+
+## Task E2b: Flip the live env to the persistent backing + O(1) snapshots
+
+**Files:** `ReVoman.kt` (seed at ~line 168; snapshot at ~line 498), `StepReport.kt` (snapshots at ~line 152, 171), `PostmanEnvironment.kt` (add an O(1) snapshot helper).
+
+**Seam (verified):** the live env's seed originates in `ReVoman.kt:168` — `PostmanSDK(..., environment.toMutableMap())` — and `PostmanSDK.kt:40` forwards that `MutableMap` unchanged into `PostmanEnvironment(mutableEnv, moshiReVoman)`, which delegates `MutableMap by mutableEnv`. So seeding a `PersistentBackedMutableMap` from `ReVoman.kt` makes the LIVE env persistent-backed WITHOUT touching WT-1's `PostmanSDK.kt`. Snapshots then capture the current immutable reference in O(1). `collectionVariables`/`globals` (seeded `mutableMapOf()` in PostmanSDK) stay plain-backed — they are never per-step snapshotted, so no perf concern and identical behavior.
+
+- [ ] **Step 1: Snapshot-immutability characterization test (the E2 invariant).** Create `src/test/kotlin/com/salesforce/revoman/output/postman/EnvSnapshotImmutabilityTest.kt`:
+  ```kotlin
+  package com.salesforce.revoman.output.postman
+
+  import com.google.common.truth.Truth.assertThat
+  import org.junit.jupiter.api.Test
+
+  class EnvSnapshotImmutabilityTest {
+      @Test
+      fun `snapshot is a point-in-time view - later env writes do not change it`() {
+          val env = PostmanEnvironment<Any?>(PersistentBackedMutableMap(mapOf("a" to 1)))
+          val snapshot = env.o1Snapshot()
+          env["b"] = 2 // mutate live env AFTER the snapshot (regex write-back path)
+          env.putAll(mapOf("c" to 3))
+          assertThat(snapshot.mutableEnv).containsExactlyEntriesIn(mapOf("a" to 1))
+          assertThat(env.mutableEnv).containsExactlyEntriesIn(mapOf("a" to 1, "b" to 2, "c" to 3))
+      }
+
+      @Test
+      fun `o1Snapshot preserves value including nulls`() {
+          val env = PostmanEnvironment<Any?>(PersistentBackedMutableMap(mapOf("n" to null)))
+          val snapshot = env.o1Snapshot()
+          assertThat(snapshot.containsKey("n")).isTrue()
+          assertThat(snapshot["n"]).isNull()
+      }
+  }
+  ```
+- [ ] **Step 2: Run (RED — `o1Snapshot` missing).** `./gradlew test --tests "...EnvSnapshotImmutabilityTest"` — Expected: **compile error / FAIL**.
+- [ ] **Step 3: Add the O(1) snapshot helper** to `PostmanEnvironment.kt`:
+  ```kotlin
+  /**
+   * A point-in-time snapshot of this environment. When the backing is a [PersistentBackedMutableMap]
+   * this is O(1) — the snapshot shares the current immutable persistent map and later writes to this
+   * (live) env install a new map, leaving the snapshot untouched. Falls back to a defensive copy for
+   * a plain map backing (e.g. collectionVariables/globals or test-constructed envs), preserving the
+   * historical `copy(mutableEnv = mutableEnv.toMutableMap())` semantics.
+   */
+  fun o1Snapshot(): PostmanEnvironment<ValueT> =
+    copy(
+      mutableEnv =
+        (mutableEnv as? PersistentBackedMutableMap<ValueT>)?.snapshotView()
+          ?: mutableEnv.toMutableMap()
+    )
+  ```
+- [ ] **Step 4: Replace the O(E) snapshot copies** with `o1Snapshot()` and seed the live env persistently:
+  - `ReVoman.kt:168` (BEFORE → AFTER):
+    ```kotlin
+    val pm = PostmanSDK(moshiReVoman, kick.nodeModulesPath(), regexReplacer, environment.toMutableMap())
+    ```
+    →
+    ```kotlin
+    // Persistent-backed so every per-step pmEnvSnapshot is an O(1) structural share (see E2). The
+    // MutableMap contract is preserved, so PostmanSDK/RegexReplacer writes are unaffected.
+    val pm =
+      PostmanSDK(
+        moshiReVoman,
+        kick.nodeModulesPath(),
+        regexReplacer,
+        PersistentBackedMutableMap(environment),
+      )
+    ```
+    (add `import com.salesforce.revoman.output.postman.PersistentBackedMutableMap`; `environment` is a `Map<String, Any?>` so the `Map`-seed ctor applies. `PostmanSDK`'s param is `MutableMap<String, Any?>` and `PersistentBackedMutableMap<Any?>` IS-A one — no PostmanSDK change.)
+  - `ReVoman.kt:498` (inside `runStep`'s final `.copy(...)`):
+    ```kotlin
+    pmEnvSnapshot = pm.environment.copy(mutableEnv = pm.environment.mutableEnv.toMutableMap()),
+    ```
+    →
+    ```kotlin
+    pmEnvSnapshot = pm.environment.o1Snapshot(),
+    ```
+  - `StepReport.kt:152` and `:171` (in `ledgerSkipped` / `requestSkipped`):
+    ```kotlin
+    pmEnvSnapshot = env.copy(mutableEnv = env.mutableEnv.toMutableMap()),
+    ```
+    →
+    ```kotlin
+    pmEnvSnapshot = env.o1Snapshot(),
+    ```
+  - Update `EnvAccumBenchmark.accumulateAndSnapshot` to call `env.o1Snapshot()` instead of the `copy(mutableEnv = ...toMutableMap())` line, and seed via `PostmanEnvironment(PersistentBackedMutableMap<Any?>())` so it measures the persistent path.
+- [ ] **Step 5: Run the invariant test + FULL gate.** `./gradlew test --tests "...EnvSnapshotImmutabilityTest"` (Expected: PASS) then `./gradlew test integrationTest` — Expected: **PASS**. Watch especially:
+  - `PostmanEnvironmentKtTest` / `PostmanEnvironmentUnsteppedTest` (`.mutableEnv shouldContainExactly`, null values, JSON format) — the adapter's `equals`/null-handling must satisfy these.
+  - `RundownJsonWriterTest` / `RundownScopesTest` / `StepReport*Test` (they construct `PostmanEnvironment()` directly — those stay plain-backed via the `o1Snapshot` fallback, no behavior change).
+  - `LedgerRoundTripKtTest`, `ControlFlowE2ETest`, `LedgerSkipE2ETest`, `MultiKickEnvTypesE2ETest` (integration) — the per-step snapshots feed VERBOSE JSON + sinks + multi-kick env threading; the immutability invariant is exactly what they depend on.
+- [ ] **Step 6: Re-measure.** `./gradlew jmh -Pjmh.includes=EnvAccumBenchmark` — Expected: `accumulateAndSnapshot` time now scales ~O(M) (flat per-step snapshot cost across `steps=50/200/800`) versus the pre-E2 ~O(M·E) growth. Record the delta in the commit message; not a gate.
+- [ ] **Step 7:** `./gradlew spotlessApply` then commit:
+  ```
+  git commit -am "perf(E2): back env with a persistent map — O(1) pmEnvSnapshot (O(M*E) -> O(M))"
+  ```
+
+---
+
+## Final verification
+- [ ] `./gradlew spotlessApply build` — Expected: BUILD SUCCESSFUL (compiles, spotless clean, unit tests pass).
+- [ ] `./gradlew test integrationTest` — Expected: green (non-core).
+- [ ] `./gradlew jmh -Pjmh.includes=EnvAccumBenchmark` — capture final numbers; attach the D4+E2 delta to the worktree summary.
+- [ ] Confirm no file outside the 9 owned source files (+ new tests + the one benchmark) was modified: `git diff --name-only <wt0-base>..HEAD`.

--- a/docs/superpowers/specs/2026-07-13-perf-improvements-design.md
+++ b/docs/superpowers/specs/2026-07-13-perf-improvements-design.md
@@ -1,0 +1,186 @@
+# ReVoman Performance Improvements — Design
+
+**Date:** 2026-07-13
+**Status:** Approved (design), pending implementation plan
+**Author:** perf audit (5 parallel subagent audits) + brainstorming
+
+## Goal
+
+Apply the concrete, FP-preserving performance improvements surfaced by a 5-domain
+parallel code audit of the ReVoman library, **without mangling the functional
+programming style** (the deliberate `Either`/`map`/`flatMap`/immutable-flow design
+from `STYLE.md`). Every change either preserves the FP style or improves it.
+
+## Non-goals
+
+- No de-functionalizing clean pipelines for micro-perf.
+- No unrelated refactoring.
+- No behavior change visible to consumers (except the intentional `truffle-runtime`
+  classpath addition and measured latency reduction).
+
+## Constraints verified during brainstorming
+
+- `graal-js = org.graalvm.js:js-language` only — no optimizing Truffle runtime on
+  the classpath today ⇒ GraalJS runs interpreter-only (~10× slower per eval).
+- `arrow-core` is present, but Arrow 2.x **dropped persistent collections** — so the
+  persistent-map fix genuinely requires a new `kotlinx.collections.immutable`
+  dependency.
+- No JMH / benchmark infrastructure exists yet.
+- Single git worktree today (`master`).
+- Collision files across fixes: `PostmanSDK.kt`, `ReVoman.kt`, `Template.kt`,
+  `RegexReplacer.kt`, `PostmanEnvironment.kt` — partition assigns each to exactly one
+  worktree.
+
+## User decisions (brainstorming forks)
+
+1. **Scope:** ALL tiers, including the high-risk Tier 5 (`pmEnvSnapshot` persistent map).
+2. **Verification:** full JMH benchmark module (new source set + Gradle plugin).
+3. **Graal dependency:** add `truffle-runtime` as an `api` dependency — every
+   consumer of ReVoman inherits the optimizing runtime (jargraal) by default.
+
+---
+
+## Fix inventory (17 fixes, 5 domains)
+
+Deduplicated across the 5 audits. Each fix is FP-preserving; risk noted where relevant.
+
+### Domain A — GraalJS sandbox (`WT-1`)
+
+| # | File:line | Fix | Risk |
+|---|-----------|-----|------|
+| A1 | `build.gradle.kts:33` / `libs.versions.toml:60` | Add `org.graalvm.truffle:truffle-runtime:25.1.3` (version.ref = existing `graal`) as an `api` dep alongside the existing `js-language` — chosen over the `js-community` meta-artifact, which would redundantly re-pull `js-language`. jargraal engages on stock JDK 21. Remove now-unneeded `WarnInterpreterOnly=false` suppressions (`SandboxBridge.kt:50`, `PostmanSDK.kt:130`) **only if** the interpreter warning no longer fires; otherwise keep them. | dep size (accepted) |
+| A2 | `SandboxBridge.kt:45` + `PostmanSDK.kt:132` | Introduce ONE shared immutable `Engine` (top-level `object`/lazy val), pass to both `Context.newBuilder(...).engine(shared)`. Keep `Context` **per-run** — never share Context (guest-state bleed). Reuses parsed 2.2 MB bootcode Source across runs + across the two contexts. | state-bleed if Context shared — mitigate by sharing Engine only |
+| A3 | `PostmanSDK.kt:226` | `jsonStrToObj`: memoize the `JSON.parse` arrow closure as `by lazy` `Value`, reuse. Stateless guest fn. | none |
+| A4 | `PostmanSDK.kt:146` | `evaluateJS`: hoist constant `imports` prefix; optional small memo `Map<String,Value>` for repeated identical scripts. | none |
+
+### Domain B — JSON marshalling (`WT-2`)
+
+| # | File:line | Fix | Risk |
+|---|-----------|-----|------|
+| B1 | `CaseInsensitiveEnumAdapter.kt:41,47` | Cache `private val enumConstants = enumType.enumConstants` (avoid `getEnumConstants()` array clone per enum parse). | none |
+| B2 | `EpochAdapter.kt:23` | Hoist `"\d+".toRegex()` to an `object`-level `val` (or `epoch.isNotEmpty() && epoch.all(Char::isDigit)`). | none |
+| B3 | `DiMorphicAdapter.kt:35` | `private val labelOptions = Options.of(labelKey)` — build Okio options once, not per composite element. | none |
+| B4 | `MoshiReVoman.kt:101` | `objToJsonStrToObj`: replace string round-trip with `fromJsonValue(toJsonValue(x))` value tree. | number-typing may differ — verify `PostmanEnvironment` tests |
+| B5 | `JsonPojoUtils.kt:39,79,121` | Memoize a default `MoshiReVoman` for the empty-config case; build fresh only for non-default configs. | none |
+| B6 | `Template.kt:77` | Prefer `JsonPretty.pretty()` (whitespace-only, precision-safe) for comment-free bodies; keep the Moshi round-trip only to strip JSON5 comments (gate on `containsComments`). | comment-stripping nuance — verify request-marshal tests |
+
+### Domain C — regex / templates / vars (`WT-3`)
+
+| # | File:line | Fix | Risk |
+|---|-----------|-----|------|
+| C1 | `RegexReplacer.kt:41` | `{{` fast-path guard: `if (!it.contains("{{")) return@let it` before the regex scan. Byte-for-byte identical (pattern can't match without `{{`). Also discounts the per-step env rescan. | none |
+| C2 | `RegexReplacer.kt:135` | `replaceVariablesInEnv`: only remap entries whose key/value contains `{{`; pass static entries through. Keep `.toMap()` snapshot (write-back requires it). | verify no test relies on per-step type round-trip |
+| C3 | `V3YamlReader.kt:120` | Reuse one `Yaml` (SnakeYAML) instance for reading (walk is sequential; `ThreadLocal` if ever parallelized). Cold path. | none |
+| C4 | `V3Loader.kt:66,83` | `walk`: materialize `metadataOrNull` once per child, then partition (avoid 2× stat per entry). Cold path. | none |
+| C5 | `V3Loader.kt:108` + `DynamicVariableGenerator.kt:65,69` | Replace `String.format`-based hex/sha encoding with JDK 21 `HexFormat`; `randomAlphanumeric` via `CharArray`. | none |
+
+### Domain D — exe engine + output + persistent env (`WT-4`)
+
+| # | File:line | Fix | Risk |
+|---|-----------|-----|------|
+| D1 | `HttpRequest.kt:40,62` + `Polling.kt:43` | Memoize one Apache HTTP client per variant (secure/insecure) via `by lazy`; stop building a fresh pooled client + discarding it per request. Auth is per-`Request`, so sharing is safe. Also fixes the per-run client leak. | none |
+| D2 | `PreStepHook.kt:46` + `PostStepHook.kt:47` | Materialize the picked-hooks `Sequence` to a `List` once (tiny lists); use `.size`/`.isNotEmpty()` — predicates run once, not 3–4×. | none (improves FP) |
+| D3 | `UnmarshallResponse.kt:35,49` | Hoist `val body = httpResponse.bodyString()` + `contentType` — decode body once, not twice. | none |
+| D4 | `PostmanEnvironment.kt:36-37,46,64,74` + `PostmanSDK.kt:96` | Key the 6 `Step`-keyed maps by `step.path` (String) instead of the whole `Step` (whose `hashCode` recurses through body + all JS scripts). `path` is the existing unique identity. | none |
+| D5 | `TxnInfo.kt:71` | `containsHeader`: `httpMsg.header(key) != null` instead of `headers.toMap().containsKey`. | none |
+| D6 | `PostmanEnvironment.kt:214` | Single-prefix `valuesForKeysStartingWith` delegates to the sequence-based vararg sibling (kill double-pass). | none |
+
+### Domain E — high-effort (split across WT-1 and WT-4)
+
+| # | File:line | Fix | Risk | Worktree |
+|---|-----------|-----|------|----------|
+| E1 | `PostmanSDK.kt:157` (`syncProgress` ONLY) | `syncProgress`: **replace** the current step's report instead of appending it 3×/step (kills 3 of 4 O(M) copies per step + the duplicate current-step entries). Keep `Rundown` immutable at the boundary. **Scoped strictly to `PostmanSDK.kt`** to preserve disjoint worktree ownership — the 4th copy (the `ReVoman.kt:402` seed `stepReportsSoFar + preStepReport`) is left as-is in this pass; fully eliminating it would touch `ReVoman.kt` (WT-4) and is deferred to avoid cross-worktree collision. | hook-visible `Rundown` shape — verify behavior | WT-1 (owns `PostmanSDK.kt`) |
+| E2 | `ReVoman.kt:498` + `StepReport.kt:152,171` + `PostmanEnvironment.kt:27` | Back the env with a **persistent map** (`kotlinx.collections.immutable`) so each `pmEnvSnapshot` is O(1) structural-share instead of a full O(E) copy per step (O(M·E) → O(M)). Adjust `setItBackInEnvironment` write path. | most invasive — heavy test-verification burden | WT-4 (owns `ReVoman.kt`, `PostmanEnvironment.kt`, `StepReport.kt`) |
+
+---
+
+## Worktree partition (disjoint file ownership)
+
+Each source file is owned by exactly ONE worktree ⇒ conflict-free parallel merges.
+
+```
+WT-0  foundation  — lands FIRST, others branch off it
+   libs.versions.toml   (+truffle-runtime, +jmh, +kotlinx-collections-immutable)
+   build.gradle.kts     (api truffle-runtime, impl kotlinx.immutable, jmh plugin + sourceSet)
+   new JMH benchmark source set + component benchmarks + baseline capture
+
+WT-1  sandbox / GraalJS            [depends on WT-0 deps]   fixes A2,A3,A4,E1
+   SandboxBridge.kt · PmJsEval.kt · PostmanSDK.kt (entire file — incl. syncProgress E1)
+
+WT-2  JSON marshalling             [independent]            fixes B1..B6
+   CaseInsensitiveEnumAdapter.kt · EpochAdapter.kt · DiMorphicAdapter.kt
+   MoshiReVoman.kt · JsonPojoUtils.kt · Template.kt
+
+WT-3  regex / templates / vars     [independent]            fixes C1..C5
+   RegexReplacer.kt · V3YamlReader.kt · V3Loader.kt · DynamicVariableGenerator.kt
+
+WT-4  exe engine + output + env    [depends on WT-0 kotlinx.immutable]  fixes D1..D6,E2
+   ReVoman.kt · HttpRequest.kt · Polling.kt · PreStepHook.kt · PostStepHook.kt
+   UnmarshallResponse.kt · PostmanEnvironment.kt · TxnInfo.kt · StepReport.kt
+```
+
+**No file appears in two worktrees.** `PostmanSDK.kt` → WT-1 only. `ReVoman.kt` →
+WT-4 only. The shared GraalJS `Engine` is a top-level `object` val requiring no
+`ReVoman.kt` edit. `Template.kt` → WT-2 only. `RegexReplacer.kt` → WT-3 only.
+`PostmanEnvironment.kt` → WT-4 only.
+
+**A1** (the Truffle dependency) lands in WT-0, so WT-1's Engine work builds against it.
+
+### Ordering
+
+1. **WT-0 first** — deps + JMH module + baseline must exist before anything else.
+2. **WT-1 / WT-2 / WT-3 / WT-4 fan out in parallel**, each branched from WT-0.
+3. Merge order after green: WT-2, WT-3 (independent) → WT-1, WT-4 (dep on WT-0).
+
+---
+
+## Verification
+
+### JMH benchmarks (component-level, offline, repeatable)
+
+Full end-to-end collection runs need live network/orgs (Pokemon, restfulapidev,
+apigee) or a Salesforce org (core WFS/PQ) — not JMH-repeatable. So benchmark the
+**isolated hot paths** instead, which is exactly where the audit found the wins:
+
+- **Regex/vars:** `RegexReplacer.replaceVariablesRecursively` over a mix of
+  placeholder / no-placeholder strings; `replaceVariablesInEnv` over a large env.
+- **Marshalling:** `MoshiReVoman.fromJson`/`toJson` over a representative Salesforce
+  composite response (enums + dates + polymorphic elements) — exercises B1/B2/B3.
+- **GraalJS:** eval a representative Postman test script through the sandbox N times
+  (measures A1 interpreter→JIT + A2 Engine reuse + A3 `json()`).
+- **Env accumulation:** simulate M steps of `set` + `pmEnvSnapshot` to measure
+  D4 (Step-key) + E2 (persistent map) O(M·E) → O(M).
+
+Optional stretch: a mock-server (http4k) end-to-end benchmark for D1 (client reuse).
+
+### Baseline + gates
+
+- Capture baseline on `master` in WT-0 before any fix.
+- Re-run the relevant domain benchmark after each worktree lands; record deltas.
+- **Correctness gate (every worktree, non-negotiable):** `./gradlew test integrationTest`
+  green. Highest burden on WT-1 (Engine state-bleed) and WT-4 (persistent map).
+
+---
+
+## Execution model
+
+Per `/subagent-driven-development` + `/dispatching-parallel-agents`:
+
+- One implementation subagent per worktree; each receives its file-set, exact fix
+  list (from the inventory above), and the "run tests, report diff + benchmark delta"
+  contract.
+- Navigation/refactor via the `intellij-index` MCP (`/ide-index-mcp`) — e.g. the D4
+  `Step`-key→`path` change uses find-references + rename, not grep.
+- Test failures → `/systematic-debugging` + `jetbrains-debugger` MCP.
+- Each worktree externalizes progress to a ledger so a reset is safe.
+
+## Risks (summary)
+
+| Risk | Mitigation |
+|------|------------|
+| GraalJS Engine sharing → guest-state bleed | Share Engine ONLY; Context stays per-run. Test gate catches bleed. |
+| Persistent-map rewrite of `PostmanEnvironment` (most invasive) | Isolate in WT-4; full `test integrationTest` gate; incremental — get maps green before swapping the backing store. |
+| `objToJsonStrToObj` value-tree number-typing (B4) | Verify against existing `PostmanEnvironment` tests before merge. |
+| `Rundown` replace-not-append changes hook-visible state (E1) | Verify hooks that read `rundown.stepReports` still see correct per-step view. |
+| `truffle-runtime` `api` grows every consumer's artifact | Accepted by user decision; benchmark confirms the win justifies it. |
+```


### PR DESCRIPTION
## Summary

Lands the **planning + design documentation** for the ReVoman performance-improvement effort under `docs/superpowers/`. Docs only — no code changes.

## Contents (6 files, ~3.4k lines)

- `specs/2026-07-13-perf-improvements-design.md` — the approved design: 17 fixes across 5 domains, partitioned into 5 disjoint worktrees.
- `plans/2026-07-13-perf-wt0-foundation.md` — WT-0 build foundation (**already implemented + merged** via #395).
- `plans/2026-07-13-perf-wt1-sandbox.md` — GraalJS Engine reuse + syncProgress.
- `plans/2026-07-13-perf-wt2-marshalling.md` — Moshi adapter hoists + value-tree + JsonPretty.
- `plans/2026-07-13-perf-wt3-regex-templates.md` — `{{` guard, YAML reuse, HexFormat.
- `plans/2026-07-13-perf-wt4-exe-output-env.md` — http client, path-keyed maps, persistent env.

## Status

- **WT-0** foundation: done, merged to master (#395).
- **WT-1..WT-4**: not yet implemented; these plans are the execution spec. Each will land as its own PR to master.

Merging the plans to master makes the design/roadmap visible and reviewable alongside the code.
