### PR TITLE
perf(json): WT-2 marshalling hot-path optimizations (B1–B6) + JMH benchmark

### DIFF
--- a/src/jmh/kotlin/com/salesforce/revoman/benchmark/MarshallingBenchmark.kt
+++ b/src/jmh/kotlin/com/salesforce/revoman/benchmark/MarshallingBenchmark.kt
@@ -1,0 +1,89 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.benchmark
+
+import com.salesforce.revoman.input.json.adapters.salesforce.CompositeResponse
+import com.salesforce.revoman.input.json.jsonToPojo
+import com.salesforce.revoman.input.json.pojoToJson
+import io.vavr.control.Either
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import org.openjdk.jmh.infra.Blackhole
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+open class MarshallingBenchmark {
+
+  // Representative composite query response: polymorphic elements (SuccessResponse/ErrorResponse),
+  // records with attributes, nested bodies -> exercises DiMorphicAdapter (B3) + the default adapter
+  // stack (B1 enum factory, B2 epoch adapter) via the memoized MoshiReVoman (B5).
+  private val compositeJson =
+    """
+    {
+      "compositeResponse": [
+        {"referenceId":"ok1","httpStatusCode":200,"httpHeaders":{},
+         "body":{"done":true,"totalSize":1,"records":[
+           {"attributes":{"type":"Account","url":"/services/data/v58.0/sobjects/Account/001"},
+            "Id":"001xx000003DGbXXXX","Name":"Acme","CreatedDate":"2015-09-01T00:00:00.000+0000"}]}},
+        {"referenceId":"bad1","httpStatusCode":400,"httpHeaders":{},
+         "body":[{"errorCode":"INVALID","message":"Invalid reference specified"}]}
+      ]
+    }
+    """
+      .trimIndent()
+
+  private lateinit var composite: CompositeResponse
+
+  @Setup
+  fun setup() {
+    composite =
+      jsonToPojo<CompositeResponse>(
+        CompositeResponse::class.java,
+        compositeJson,
+        customAdaptersWithType =
+          mapOf(CompositeResponse.Response::class.java to Either.right(CompositeResponse.ADAPTER)),
+      )!!
+  }
+
+  @Benchmark
+  fun compositeFromJson(bh: Blackhole) {
+    bh.consume(
+      jsonToPojo<CompositeResponse>(
+        CompositeResponse::class.java,
+        compositeJson,
+        customAdaptersWithType =
+          mapOf(CompositeResponse.Response::class.java to Either.right(CompositeResponse.ADAPTER)),
+      )
+    )
+  }
+
+  @Benchmark
+  fun compositeToJson(bh: Blackhole) {
+    bh.consume(
+      pojoToJson<CompositeResponse>(
+        CompositeResponse::class.java,
+        composite,
+        customAdaptersWithType =
+          mapOf(CompositeResponse.Response::class.java to Either.right(CompositeResponse.ADAPTER)),
+      )
+    )
+  }
+}

--- a/src/jmh/kotlin/com/salesforce/revoman/benchmark/MarshallingBenchmark.kt
+++ b/src/jmh/kotlin/com/salesforce/revoman/benchmark/MarshallingBenchmark.kt
@@ -33,8 +33,8 @@ import org.openjdk.jmh.infra.Blackhole
 open class MarshallingBenchmark {
 
   // Representative composite query response: polymorphic elements (SuccessResponse/ErrorResponse),
-  // records with attributes, nested bodies -> exercises DiMorphicAdapter (B3) + the default adapter
-  // stack (B1 enum factory, B2 epoch adapter) via the memoized MoshiReVoman (B5).
+  // records with attributes, nested bodies -> exercises DiMorphicAdapter (B3) for polymorphic
+  // discrimination and the composite fromJson/toJson hot path through JsonPojoUtils entry points.
   private val compositeJson =
     """
     {

--- a/src/main/kotlin/com/salesforce/revoman/input/json/JsonPojoUtils.kt
+++ b/src/main/kotlin/com/salesforce/revoman/input/json/JsonPojoUtils.kt
@@ -141,6 +141,10 @@ inline fun <reified PojoT : Any> pojoToJson(
 ): String? =
   pojoToJson(PojoT::class.java, pojo, customAdapters, customAdaptersWithType, skipTypes, indent)
 
+// * NOTE: the empty-config MoshiReVoman never has adapters added (addAdapters is the only mutator),
+//   so a single memoized instance is safely shared across all default-config marshalling calls.
+private val defaultMoshiReVoman by lazy { initMoshi() }
+
 @SuppressWarnings("kotlin:S3923")
 private fun <PojoT : Any> initMoshi(
   customAdapters: List<Any> = emptyList(),
@@ -148,7 +152,10 @@ private fun <PojoT : Any> initMoshi(
   skipTypes: Set<Class<out Any>> = emptySet(),
   pojoType: Type,
 ): JsonAdapter<PojoT> =
-  initMoshi(customAdapters, customAdaptersWithType, skipTypes).adapter(pojoType)
+  (if (customAdapters.isEmpty() && customAdaptersWithType.isEmpty() && skipTypes.isEmpty())
+      defaultMoshiReVoman
+    else initMoshi(customAdapters, customAdaptersWithType, skipTypes))
+    .adapter(pojoType)
 
 @PojoConfig
 @Value.Immutable

--- a/src/main/kotlin/com/salesforce/revoman/input/json/factories/DiMorphicAdapter.kt
+++ b/src/main/kotlin/com/salesforce/revoman/input/json/factories/DiMorphicAdapter.kt
@@ -22,6 +22,9 @@ private constructor(
   private val successAdapter: Triple<(JsonReader) -> Boolean, Type, JsonAdapter<Any>>,
   private val errorAdapter: Pair<Type, JsonAdapter<Any>>,
 ) : JsonAdapter<Any>() {
+  // * NOTE: Okio Options are immutable; build the single-name lookup once, not per element.
+  private val labelOptions: Options = Options.of(labelKey)
+
   override fun fromJson(reader: JsonReader): Any? {
     val readerAtLabelKey = findLabelValue(reader.peekJson())
     val jsonAdapter =
@@ -32,7 +35,7 @@ private constructor(
   private fun findLabelValue(reader: JsonReader): JsonReader {
     reader.beginObject()
     while (reader.hasNext()) {
-      if (reader.selectName(Options.of(labelKey)) == -1) {
+      if (reader.selectName(labelOptions) == -1) {
         reader.skipName()
         reader.skipValue()
       } else {

--- a/src/main/kotlin/com/salesforce/revoman/internal/json/MoshiReVoman.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/json/MoshiReVoman.kt
@@ -98,13 +98,22 @@ open class MoshiReVoman(builder: Moshi.Builder) {
     indent: String = "  ",
   ): String = lenientAdapter<PojoT>(serializeNulls).indent(indent).toJson(input)
 
+  // * NOTE: bridge source->target through a Moshi value-tree instead of a JSON-string round-trip;
+  //   avoids one full serialize+parse pass. Verified behaviour-equivalent to the old string path
+  //   (see ObjToJsonStrToObjTest): for concrete target types both paths are identical, and for
+  //   UNTYPED (Any/raw Map) targets both coerce numbers to Double alike (Moshi's untyped adapter
+  //   reads every number token via nextDouble() on both the string reader and the value-tree
+  //   reader), so there is NO behaviour delta. See PostmanEnvironment.getObj/getTypedObj consumers.
   fun <PojoT : Any> objToJsonStrToObj(
     input: Any?,
     targetType: Type = input?.javaClass ?: Any::class.java,
-  ): PojoT? = lenientAdapter<PojoT>(targetType).fromJson(toJson(input))
+  ): PojoT? =
+    lenientAdapter<PojoT>(targetType)
+      .fromJsonValue(lenientAdapter<Any>(input?.javaClass ?: Any::class.java).toJsonValue(input))
 
   inline fun <reified PojoT : Any> objToJsonStrToObj(input: Any?): PojoT? =
-    lenientAdapter<PojoT>().fromJson(toJson(input))
+    lenientAdapter<PojoT>()
+      .fromJsonValue(lenientAdapter<Any>(input?.javaClass ?: Any::class.java).toJsonValue(input))
 
   fun jsonToObjToPrettyJson(input: String?, serializeNulls: Boolean = false): String? = input?.let {
     toPrettyJson(fromJson(it), serializeNulls)

--- a/src/main/kotlin/com/salesforce/revoman/internal/json/MoshiReVoman.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/json/MoshiReVoman.kt
@@ -76,6 +76,13 @@ open class MoshiReVoman(builder: Moshi.Builder) {
     lenientAdapter<PojoT>().fromJson(it)
   }
 
+  // * NOTE: strict (non-lenient) parse probe. Gates the byte-for-byte JsonPretty render, which
+  //   only understands STRICT JSON; a JSON5-lenient body (single-quoted strings / unquoted names)
+  //   must instead go through the normalizing round-trip, else JsonPretty mangles structural chars
+  //   inside a lenient string literal. `adapter<Any>()` (no `.lenient()`) rejects JSON5 and any
+  //   unconsumed trailing content.
+  fun isStrictJson(json: String): Boolean = runCatching { adapter<Any>().fromJson(json) }.isSuccess
+
   fun <PojoT : Any> toJson(
     input: PojoT?,
     serializeNulls: Boolean = false,

--- a/src/main/kotlin/com/salesforce/revoman/internal/json/adapters/EpochAdapter.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/json/adapters/EpochAdapter.kt
@@ -16,11 +16,15 @@ import kotlin.time.Instant
 import kotlin.time.toJavaInstant
 
 object EpochAdapter {
+  // * NOTE: hoisted so the digit pattern is compiled once, not on every date parse.
+  //   `\d` keeps ASCII-only semantics identical to the previous inline regex.
+  private val DIGITS_REGEX = "\\d+".toRegex()
+
   @OptIn(ExperimentalTime::class)
   @FromJson
   fun fromJson(reader: JsonReader, delegate: JsonAdapter<Date>): Date? {
     val epoch = reader.nextString()
-    return if (epoch.matches("\\d+".toRegex())) {
+    return if (epoch.matches(DIGITS_REGEX)) {
       Date.from(Instant.fromEpochMilliseconds(epoch.toLong()).toJavaInstant())
     } else {
       delegate.fromJsonValue(epoch)

--- a/src/main/kotlin/com/salesforce/revoman/internal/json/factories/CaseInsensitiveEnumAdapter.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/json/factories/CaseInsensitiveEnumAdapter.kt
@@ -32,19 +32,20 @@ import java.lang.reflect.Type
  */
 internal class CaseInsensitiveEnumAdapter<T : Enum<T>>(private val enumType: Class<T>) :
   JsonAdapter<T>() {
-  private val nameStrings =
-    enumType.getEnumConstants().map { Util.jsonName(it.name, enumType.getField(it.name)) }
+  // * NOTE: getEnumConstants() clones its backing array on every call; cache it once.
+  private val enumConstants: Array<T> = enumType.enumConstants
+  private val nameStrings = enumConstants.map { Util.jsonName(it.name, enumType.getField(it.name)) }
   private val options = JsonReader.Options.of(*nameStrings.toTypedArray())
 
   override fun fromJson(reader: JsonReader): T {
     val index = reader.selectString(options)
     return if (index != -1) {
-      enumType.getEnumConstants()[index]
+      enumConstants[index]
     } else if (reader.peek() != JsonReader.Token.STRING) {
       throw JsonDataException("Expected a string but was ${reader.peek()} at path ${reader.path}")
     } else {
       val value = reader.nextString()
-      enumType.enumConstants.firstOrNull { it.name.compareTo(value, ignoreCase = true) == 0 }
+      enumConstants.firstOrNull { it.name.compareTo(value, ignoreCase = true) == 0 }
         ?: throw JsonDataException(
           "Expected one of $nameStrings but was $value at path ${reader.path}"
         )

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/template/Template.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/template/Template.kt
@@ -8,6 +8,7 @@
 package com.salesforce.revoman.internal.postman.template
 
 import com.salesforce.revoman.internal.json.MoshiReVoman
+import com.salesforce.revoman.output.json.JsonPretty
 import com.squareup.moshi.JsonClass
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.util.regex.Pattern
@@ -65,16 +66,27 @@ data class Request(
     var contentTypeHeader =
       header.firstOrNull { CONTENT_TYPE.meta.name.equals(it.key, true) }?.value?.let { Text(it) }
     val cleansedRawBody =
-      body?.raw?.trim()?.let {
+      body?.raw?.trim()?.let { rawBody ->
         when {
-          it.isBlank() -> it
-          else ->
+          rawBody.isBlank() -> rawBody
+          else -> {
             // ! TODO 15 Mar 2025 gopala.akshintala: Detect the right content type if absent
+            val hasComments = containsComments(rawBody)
             when {
               contentTypeHeader?.value == null ||
-                (APPLICATION_JSON.value.equals(contentTypeHeader.value, true) &&
-                  containsComments(it)) -> {
-                runCatching { moshiReVoman?.jsonToObjToPrettyJson(it, true) ?: it }
+                (APPLICATION_JSON.value.equals(contentTypeHeader.value, true) && hasComments) ->
+                runCatching {
+                    when {
+                      // JSON5 comment stripping needs the Moshi round-trip.
+                      hasComments -> moshiReVoman?.jsonToObjToPrettyJson(rawBody, true) ?: rawBody
+                      // Comment-free: validate as JSON (drives detection), render precision-safe.
+                      else ->
+                        moshiReVoman?.let { m ->
+                          m.fromJson<Any>(rawBody)
+                          JsonPretty.pretty(rawBody)
+                        } ?: rawBody
+                    }
+                  }
                   .onSuccess {
                     if (contentTypeHeader == null) {
                       logger.info {
@@ -83,10 +95,10 @@ data class Request(
                       contentTypeHeader = APPLICATION_JSON
                     }
                   }
-                  .getOrDefault(it)
-              }
-              else -> it
+                  .getOrDefault(rawBody)
+              else -> rawBody
             }
+          }
         }
       } ?: ""
     val request =

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/template/Template.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/template/Template.kt
@@ -82,8 +82,12 @@ data class Request(
                       // Comment-free: validate as JSON (drives detection), render precision-safe.
                       else ->
                         moshiReVoman?.let { m ->
-                          m.fromJson<Any>(rawBody)
-                          JsonPretty.pretty(rawBody)
+                          // JsonPretty is byte-for-byte precision-safe but only understands STRICT
+                          // JSON; take the precision-safe fast path only for already-strict JSON,
+                          // and normalize a lenient-but-valid JSON5 body via the round-trip so its
+                          // string literals aren't mangled.
+                          if (m.isStrictJson(rawBody)) JsonPretty.pretty(rawBody)
+                          else m.jsonToObjToPrettyJson(rawBody, true) ?: rawBody
                         } ?: rawBody
                     }
                   }

--- a/src/test/kotlin/com/salesforce/revoman/input/json/JsonPojoUtilsMemoTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/input/json/JsonPojoUtilsMemoTest.kt
@@ -1,0 +1,43 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.input.json
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class JsonPojoUtilsMemoTest {
+  @Test
+  fun `repeated empty-config parses produce identical results`() {
+    val json = """{"key1":"value1","key2":"value2"}"""
+    val first = jsonToPojo<Map<String, String>>(Map::class.java, json)
+    val second = jsonToPojo<Map<String, String>>(Map::class.java, json)
+    assertThat(first).isEqualTo(second)
+    assertThat(second).containsExactlyEntriesIn(mapOf("key1" to "value1", "key2" to "value2"))
+  }
+
+  @Test
+  fun `empty-config and non-empty-config calls interleave without interference`() {
+    val json = """{"a":"b"}"""
+    val empty1 = jsonToPojo<Map<String, String>>(Map::class.java, json)
+    // A non-empty config call must not mutate the memoized default used by empty1/empty2.
+    // NOTE: skip a type ABSENT from the payload (Long) so the non-empty-config branch is exercised
+    //   (routing through a freshly built MoshiReVoman) without nulling out the Map<String,String>
+    //   entries — skipping String here would null the map keys and NPE, independent of memoization.
+    val nested =
+      jsonToPojo<Map<String, String>>(
+        Map::class.java,
+        json,
+        customAdapters = emptyList(),
+        customAdaptersWithType = emptyMap(),
+        skipTypes = setOf(Long::class.javaObjectType),
+      )
+    val empty2 = jsonToPojo<Map<String, String>>(Map::class.java, json)
+    assertThat(empty1).isEqualTo(empty2)
+    assertThat(nested).isNotNull()
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/input/json/factories/DiMorphicAdapterTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/input/json/factories/DiMorphicAdapterTest.kt
@@ -1,0 +1,43 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.input.json.factories
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.input.json.adapters.salesforce.CompositeResponse
+import com.salesforce.revoman.input.json.adapters.salesforce.CompositeResponse.Response.ErrorResponse
+import com.salesforce.revoman.input.json.adapters.salesforce.CompositeResponse.Response.SuccessResponse
+import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
+import io.vavr.control.Either
+import org.junit.jupiter.api.Test
+
+class DiMorphicAdapterTest {
+  private val moshi =
+    initMoshi(
+      customAdaptersWithType =
+        mapOf(CompositeResponse.Response::class.java to Either.right(CompositeResponse.ADAPTER))
+    )
+
+  @Test
+  fun `discriminates success and error across repeated elements in one list`() {
+    val json =
+      """
+      {
+        "compositeResponse": [
+          {"referenceId":"ok","httpStatusCode":200,"httpHeaders":{},
+           "body":{"done":true,"totalSize":0,"records":[]}},
+          {"referenceId":"bad","httpStatusCode":400,"httpHeaders":{},
+           "body":[{"errorCode":"INVALID","message":"Invalid reference specified"}]}
+        ]
+      }
+      """
+        .trimIndent()
+    val response = moshi.fromJson<CompositeResponse>(json, CompositeResponse::class.java)!!
+    assertThat(response.compositeResponse[0]).isInstanceOf(SuccessResponse::class.java)
+    assertThat(response.compositeResponse[1]).isInstanceOf(ErrorResponse::class.java)
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/internal/json/ObjToJsonStrToObjTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/json/ObjToJsonStrToObjTest.kt
@@ -1,0 +1,70 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.json
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
+import com.squareup.moshi.JsonClass
+import org.junit.jupiter.api.Test
+
+@JsonClass(generateAdapter = true)
+internal data class Vals(
+  val i: Int,
+  val l: Long,
+  val d: Double,
+  val b: Boolean,
+  val nested: Map<String, Int>,
+)
+
+class ObjToJsonStrToObjTest {
+  private val moshi = initMoshi()
+
+  private inline fun <reified T : Any> stringRoundTrip(input: Any?): T? =
+    moshi
+      .lenientAdapter<T>()
+      .fromJson(moshi.lenientAdapter<Any>(input?.javaClass ?: Any::class.java).toJson(input))
+
+  private inline fun <reified T : Any> valueTreeBridge(input: Any?): T? =
+    moshi
+      .lenientAdapter<T>()
+      .fromJsonValue(
+        moshi.lenientAdapter<Any>(input?.javaClass ?: Any::class.java).toJsonValue(input)
+      )
+
+  @Test
+  fun `concrete-typed target - value-tree bridge equals string round-trip`() {
+    val src = Vals(i = 42, l = 9_000_000_000L, d = 3.5, b = true, nested = mapOf("x" to 7))
+    assertThat(valueTreeBridge<Vals>(src)).isEqualTo(stringRoundTrip<Vals>(src))
+    assertThat(valueTreeBridge<Vals>(src)).isEqualTo(src)
+  }
+
+  @Test
+  fun `the actual method round-trips a PostmanEnvironment-style map into a concrete POJO`() {
+    val src =
+      mapOf("i" to 42, "l" to 9_000_000_000L, "d" to 3.5, "b" to true, "nested" to mapOf("x" to 7))
+    val out = moshi.objToJsonStrToObj<Vals>(src, Vals::class.java)!!
+    assertThat(out).isEqualTo(Vals(42, 9_000_000_000L, 3.5, true, mapOf("x" to 7)))
+  }
+
+  @Test
+  fun `DOCUMENTED - untyped Any target - both string path and value-tree bridge coerce numbers to Double`() {
+    // Pins the observable behaviour of B4 for UNTYPED retrieval. Run against BOTH the unchanged and
+    // changed tree; the two helpers are edit-independent so it stays green either way.
+    // OBSERVED REALITY (differs from the brief's original prediction of Int-preservation): Moshi's
+    // untyped `Any`/`Object` adapter reads every number token via `nextDouble()` in BOTH the
+    // JSON-string reader AND the value-tree reader, so the untyped `Int 42` becomes `Double 42.0`
+    // on BOTH paths. There is therefore NO behaviour delta for the untyped case in this repo's
+    // Moshi configuration — the value-tree bridge is fully equivalent to the string round-trip.
+    val src = mapOf("i" to 42)
+    val fromString = stringRoundTrip<Map<String, Any?>>(src)!!
+    val fromTree = valueTreeBridge<Map<String, Any?>>(src)!!
+    assertThat(fromString["i"]).isInstanceOf(java.lang.Double::class.java) // 42.0
+    assertThat(fromTree["i"])
+      .isInstanceOf(java.lang.Double::class.java) // 42.0 (no Int-preservation)
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/internal/json/adapters/EpochAdapterTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/json/adapters/EpochAdapterTest.kt
@@ -1,0 +1,34 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.json.adapters
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
+import com.squareup.moshi.JsonClass
+import java.text.SimpleDateFormat
+import java.util.Date
+import org.junit.jupiter.api.Test
+
+@JsonClass(generateAdapter = true) internal data class BeanWithDate(val date: Date)
+
+class EpochAdapterTest {
+  private val moshi = initMoshi()
+
+  @Test
+  fun `numeric string is parsed as epoch millis`() {
+    val epoch = 1604216172747L
+    val bean = moshi.fromJson<BeanWithDate>("{\"date\":\"$epoch\"}", BeanWithDate::class.java)!!
+    assertThat(bean.date.toInstant().toEpochMilli()).isEqualTo(epoch)
+  }
+
+  @Test
+  fun `non-numeric ISO string is delegated to the RFC3339 date adapter`() {
+    val bean = moshi.fromJson<BeanWithDate>("{\"date\":\"2015-09-01\"}", BeanWithDate::class.java)!!
+    assertThat(bean.date).isEqualTo(SimpleDateFormat("yyyy-MM-dd").parse("2015-09-01"))
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/internal/json/factories/CaseInsensitiveEnumAdapterTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/json/factories/CaseInsensitiveEnumAdapterTest.kt
@@ -1,0 +1,45 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.json.factories
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
+import com.squareup.moshi.JsonDataException
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+private enum class Color {
+  RED,
+  GREEN,
+  BLUE,
+}
+
+class CaseInsensitiveEnumAdapterTest {
+  private val moshi = initMoshi()
+
+  @Test
+  fun `parses an exact-case enum name`() {
+    assertThat(moshi.fromJson<Color>("\"RED\"", Color::class.java)).isEqualTo(Color.RED)
+  }
+
+  @Test
+  fun `parses a differently-cased enum name case-insensitively`() {
+    assertThat(moshi.fromJson<Color>("\"green\"", Color::class.java)).isEqualTo(Color.GREEN)
+    assertThat(moshi.fromJson<Color>("\"BlUe\"", Color::class.java)).isEqualTo(Color.BLUE)
+  }
+
+  @Test
+  fun `serializes an enum to its canonical name`() {
+    assertThat(moshi.toJson(Color.GREEN, sourceType = Color::class.java)).isEqualTo("\"GREEN\"")
+  }
+
+  @Test
+  fun `throws JsonDataException for an unknown enum value`() {
+    assertThrows<JsonDataException> { moshi.fromJson<Color>("\"purple\"", Color::class.java) }
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/template/RequestToHttpRequestTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/template/RequestToHttpRequestTest.kt
@@ -50,10 +50,11 @@ class RequestToHttpRequestTest {
 
   @Test
   fun `malformed non-JSON body with no content-type is left unchanged and no content-type is added`() {
-    // A '{'-leading but malformed body: JsonPretty's first-char heuristic would ACCEPT it, but the
-    // gate is the strict lenient Moshi parse (m.fromJson<Any>) which throws, so the body lands in
-    // getOrDefault(rawBody) unchanged and the application/json detection side effect does NOT fire.
-    // This proves the JSON gate is the Moshi parse, not JsonPretty's heuristic (brief 6.3 note).
+    // A '{'-leading but malformed body: JsonPretty's first-char heuristic would ACCEPT it, but it
+    // fails isStrictJson (not strict JSON) AND the fallback round-trip's lenient Moshi parse
+    // throws,
+    // so the body lands in getOrDefault(rawBody) unchanged and the application/json detection side
+    // effect does NOT fire. This proves the JSON gate is a Moshi parse, not JsonPretty's heuristic.
     val raw = """{"a":}"""
     val http = request(contentType = null, rawBody = raw).toHttpRequest(moshi)
     assertThat(http.bodyString()).isEqualTo(raw)

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/template/RequestToHttpRequestTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/template/RequestToHttpRequestTest.kt
@@ -1,0 +1,73 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.postman.template
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
+import org.junit.jupiter.api.Test
+
+class RequestToHttpRequestTest {
+  private val moshi = initMoshi()
+
+  private fun request(contentType: String?, rawBody: String): Request =
+    Request(
+      method = "POST",
+      header = contentType?.let { listOf(Header(key = "Content-Type", value = it)) } ?: emptyList(),
+      body = Body(mode = "raw", raw = rawBody),
+    )
+
+  @Test
+  fun `comment-free JSON body with no content-type is pretty-printed byte-for-byte and content-type is set`() {
+    val raw = """{"n":5,"id":1234567890123}"""
+    val http = request(contentType = null, rawBody = raw).toHttpRequest(moshi)
+    // Precision preserved: 5 stays 5 (not 5.0), large id keeps full precision.
+    assertThat(http.bodyString()).contains("\"n\": 5")
+    assertThat(http.bodyString()).contains("\"id\": 1234567890123")
+    assertThat(http.bodyString()).doesNotContain("5.0")
+    // http4k's APPLICATION_JSON carries a UTF-8 charset; the detection side effect still fires.
+    assertThat(http.header("Content-Type")).isEqualTo("application/json; charset=utf-8")
+  }
+
+  @Test
+  fun `comment-bearing JSON body is round-tripped so comments are stripped`() {
+    val raw =
+      """
+      {
+        // a line comment
+        "a": 1
+      }
+      """
+        .trimIndent()
+    val http = request(contentType = "application/json", rawBody = raw).toHttpRequest(moshi)
+    assertThat(http.bodyString()).doesNotContain("// a line comment")
+    assertThat(http.bodyString()).contains("\"a\"")
+  }
+
+  @Test
+  fun `malformed non-JSON body with no content-type is left unchanged and no content-type is added`() {
+    // A '{'-leading but malformed body: JsonPretty's first-char heuristic would ACCEPT it, but the
+    // gate is the strict lenient Moshi parse (m.fromJson<Any>) which throws, so the body lands in
+    // getOrDefault(rawBody) unchanged and the application/json detection side effect does NOT fire.
+    // This proves the JSON gate is the Moshi parse, not JsonPretty's heuristic (brief 6.3 note).
+    val raw = """{"a":}"""
+    val http = request(contentType = null, rawBody = raw).toHttpRequest(moshi)
+    assertThat(http.bodyString()).isEqualTo(raw)
+    assertThat(http.header("Content-Type")).isNull()
+  }
+
+  @Test
+  fun `null moshiReVoman with a JSON body and no content-type still adds the content-type header`() {
+    // Mirrors ReVoman.kt:394 toHttpRequest(null). Body passes through unchanged (no moshi to
+    // render).
+    val raw = """{"a":1}"""
+    val http = request(contentType = null, rawBody = raw).toHttpRequest(null)
+    assertThat(http.bodyString()).isEqualTo(raw)
+    // http4k's APPLICATION_JSON carries a UTF-8 charset.
+    assertThat(http.header("Content-Type")).isEqualTo("application/json; charset=utf-8")
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/template/RequestToHttpRequestTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/template/RequestToHttpRequestTest.kt
@@ -61,6 +61,20 @@ class RequestToHttpRequestTest {
   }
 
   @Test
+  fun `JSON5-lenient body with a single-quoted value is normalized not mangled`() {
+    // Regression: JsonPretty only understands strict JSON; a single-quoted value with an interior
+    // comma must NOT be split into structural pieces. The lenient body normalizes via round-trip.
+    val raw = "{'k':'a,b'}"
+    val http = request(contentType = null, rawBody = raw).toHttpRequest(moshi)
+    // The value "a,b" must survive intact as a single JSON string value.
+    assertThat(http.bodyString()).contains("\"k\"")
+    assertThat(http.bodyString()).contains("a,b")
+    // And it must be VALID strict JSON now (re-parseable), unlike the mangled single-quote output.
+    assertThat(moshi.fromJson<Any>(http.bodyString())).isEqualTo(mapOf("k" to "a,b"))
+    assertThat(http.header("Content-Type")).isEqualTo("application/json; charset=utf-8")
+  }
+
+  @Test
   fun `null moshiReVoman with a JSON body and no content-type still adds the content-type header`() {
     // Mirrors ReVoman.kt:394 toHttpRequest(null). Body passes through unchanged (no moshi to
     // render).


### PR DESCRIPTION
## What

WT-2 of the ReVoman perf-improvements effort: six FP-preserving JSON-marshalling hot-path optimizations, each locked by a characterization test, plus a JMH benchmark for the composite hot path.

| ID | Change | File |
|----|--------|------|
| **B1** | Cache `enumConstants` once (avoid per-parse array clone) | `CaseInsensitiveEnumAdapter.kt` |
| **B2** | Hoist epoch digit-check regex (compile once; ASCII-only `\d` preserved) | `EpochAdapter.kt` |
| **B3** | Build DiMorphic label `JsonReader.Options` once per adapter, not per element | `DiMorphicAdapter.kt` |
| **B4** | Bridge `objToJsonStrToObj` via a Moshi value-tree instead of a JSON-string round-trip | `MoshiReVoman.kt` |
| **B5** | Memoize the empty-config `MoshiReVoman` | `JsonPojoUtils.kt` |
| **B6** | Render comment-free JSON request bodies via precision-safe `JsonPretty`; keep the Moshi round-trip only to strip JSON5 comments | `Template.kt` |

Plus `MarshallingBenchmark.kt` (measured, non-gating).

## Behavior notes

- **B1/B2/B3/B5** are byte-for-byte behavior-preserving.
- **B4**: for concrete target types, identical to the old path. For untyped (`Any`/raw `Map`) targets, both the old string round-trip and the new value-tree bridge coerce numbers to `Double` (Moshi's untyped adapter reads number tokens via `nextDouble()` on both readers) — so there is **no** observable delta. (The plan predicted an `Int`-preservation delta; the characterization test empirically pins reality — no delta — and the source comment was corrected accordingly.)
- **B6**: comment-free JSON bodies now render precision-safe (`5` stays `5`, large ids keep full precision) instead of being `Double`-collapsed. Comment-bearing (JSON5) bodies still go through the Moshi round-trip (only it strips comments). The JSON-detection side effect (adding `Content-Type: application/json` when absent) is preserved — the gate remains the strict Moshi parse, so a non-JSON body still gets no content-type.

## Tests

- New characterization test per optimization; TDD RED→GREEN for B6.
- Unit `test`: clean. `build` (detekt + assembly): clean.
- `integrationTest`: passes on CI. (Locally, restful-api.dev returns HTTP 405 "daily request limit" env-quota flakes — not regressions; CI has fresh quota + the retry plugin.)

## Scope

Touches only the 6 owned source files + 6 new test files + 1 benchmark. Branched off master (WT-0 foundation already merged).