### PR TITLE
perf: WT-3 regex/template/variable hot-path micro-optimizations (C1–C5) + JMH benchmark

### DIFF
--- a/src/jmh/kotlin/com/salesforce/revoman/benchmark/RegexVarBenchmark.kt
+++ b/src/jmh/kotlin/com/salesforce/revoman/benchmark/RegexVarBenchmark.kt
@@ -1,0 +1,66 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.benchmark
+
+import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
+import com.salesforce.revoman.internal.postman.PostmanSDK
+import com.salesforce.revoman.internal.postman.RegexReplacer
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import org.openjdk.jmh.infra.Blackhole
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+open class RegexVarBenchmark {
+
+  private lateinit var regexReplacer: RegexReplacer
+  private lateinit var pm: PostmanSDK
+
+  // ~90% of real strings carry no placeholder (headers, static URL segments, literal body fields)
+  // -> C1's fast-path guard should dominate the win here.
+  private val mixedStrings: List<String> =
+    (0 until 100).map { i ->
+      if (i % 10 == 0) """{ "id": "{{policyId}}", "when": "{{${'$'}isoTimestamp}}" }"""
+      else """{ "field$i": "static-value-$i", "note": "no placeholders in this line" }"""
+    }
+
+  @Setup
+  fun setup() {
+    regexReplacer = RegexReplacer()
+    pm = PostmanSDK(initMoshi(), null, regexReplacer)
+    pm.environment["policyId"] = "0Pol000000000001"
+    // Large env: mostly static entries + a few placeholder entries (exercises C2 static skip).
+    (0 until 500).forEach { i ->
+      if (i % 25 == 0) pm.environment["k$i"] = "prefix-{{policyId}}-suffix"
+      else pm.environment["k$i"] = "static-value-$i"
+    }
+  }
+
+  @Benchmark
+  fun replaceVariablesRecursivelyOverMixedStrings(bh: Blackhole) {
+    mixedStrings.forEach { bh.consume(regexReplacer.replaceVariablesRecursively(it, pm)) }
+  }
+
+  @Benchmark
+  fun replaceVariablesInEnvOverLargeEnv(bh: Blackhole) {
+    bh.consume(regexReplacer.replaceVariablesInEnv(pm))
+  }
+}

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/DynamicVariableGenerator.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/DynamicVariableGenerator.kt
@@ -62,12 +62,14 @@ private val dynamicVariableGenerators: Map<String, () -> String> =
       },
   )
 
-fun getRandomHex(): String = "%02X".format(nextInt(256))
+private val upperHexFormat = java.util.HexFormat.of().withUpperCase()
+
+fun getRandomHex(): String = upperHexFormat.toHexDigits(nextInt(256).toByte())
 
 private val charPool = ('a'..'z') + ('A'..'Z') + ('0'..'9')
 
-fun randomAlphanumeric(length: Int) =
-  (1..length).map { charPool[nextInt(0, charPool.size)] }.joinToString("")
+fun randomAlphanumeric(length: Int): String =
+  CharArray(length) { charPool[nextInt(0, charPool.size)] }.concatToString()
 
 private val dynamicVariableGeneratorsWithPM: Map<String, (PostmanSDK) -> String> =
   mapOf($$"$currentRequestName" to { it.info.requestName })

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/DynamicVariableGenerator.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/DynamicVariableGenerator.kt
@@ -62,7 +62,7 @@ private val dynamicVariableGenerators: Map<String, () -> String> =
       },
   )
 
-private val upperHexFormat = java.util.HexFormat.of().withUpperCase()
+private val upperHexFormat = HexFormat.of().withUpperCase()
 
 fun getRandomHex(): String = upperHexFormat.toHexDigits(nextInt(256).toByte())
 

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/RegexReplacer.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/RegexReplacer.kt
@@ -39,6 +39,7 @@ class RegexReplacer(
     pm: PostmanSDK,
     visitedKeys: Set<String>,
   ): String? = stringWithRegex?.let {
+    if (!it.contains("{{")) return@let it
     postManVariableRegex.replace(it) { variable ->
       val variableKey = variable.groups[VARIABLE_KEY]?.value!!
       if (variableKey in visitedKeys) {

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/RegexReplacer.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/RegexReplacer.kt
@@ -134,16 +134,15 @@ class RegexReplacer(
     )
 
   internal fun replaceVariablesInEnv(pm: PostmanSDK): Map<String, Any?> =
-    pm.environment
-      .toMap()
-      .entries
-      .associateBy(
-        { replaceVariablesRecursively(it.key, pm)!! },
-        {
-          if (it.value is String?) replaceVariablesRecursively(it.value as String?, pm)
-          else it.value
-        },
-      )
+    pm.environment.toMap().entries.associate { (key, value) ->
+      val valueHasPlaceholder = value is String && value.contains("{{")
+      if (!key.contains("{{") && !valueHasPlaceholder) {
+        key to value
+      } else {
+        replaceVariablesRecursively(key, pm)!! to
+          (if (value is String?) replaceVariablesRecursively(value, pm) else value)
+      }
+    }
 
   companion object {
     private fun setItBackInEnvironment(variableKey: String, value: String, pm: PostmanSDK) {

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3Loader.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3Loader.kt
@@ -106,8 +106,9 @@ internal object V3Loader {
 }
 
 internal fun sha256Hex(s: String): String =
-  java.security.MessageDigest.getInstance("SHA-256")
-    .digest(s.toByteArray(Charsets.UTF_8))
-    .joinToString("") { "%02x".format(it) }
+  java.util.HexFormat.of()
+    .formatHex(
+      java.security.MessageDigest.getInstance("SHA-256").digest(s.toByteArray(Charsets.UTF_8))
+    )
 
 private val logger = KotlinLogging.logger {}

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3Loader.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3Loader.kt
@@ -61,11 +61,13 @@ internal object V3Loader {
     val effectiveAuth =
       if (def != null && def.auth.isNotEmpty()) V3ToV2Converter.toAuth(def.auth) else parentAuth
 
-    val children = fs.list(dir)
+    val childrenWithMeta = fs.list(dir).map { it to fs.metadataOrNull(it) }
     val requestEntries: List<Pair<Item, Int>> =
-      children
-        .filter { fs.metadataOrNull(it)?.isRegularFile == true && it.name.endsWith(REQUEST_SUFFIX) }
-        .map { file ->
+      childrenWithMeta
+        .filter { (path, meta) ->
+          meta?.isRegularFile == true && path.name.endsWith(REQUEST_SUFFIX)
+        }
+        .map { (file, _) ->
           val rawYaml = fs.source(file).buffer().readUtf8()
           val v3req = V3YamlReader.readRequest(rawYaml)
           val fallbackName = file.name.removeSuffix(REQUEST_SUFFIX)
@@ -80,9 +82,9 @@ internal object V3Loader {
         }
 
     val folderEntries: List<Pair<Item, Int>> =
-      children
-        .filter { fs.metadataOrNull(it)?.isDirectory == true && hasDef(it, fs) }
-        .map { sub ->
+      childrenWithMeta
+        .filter { (path, meta) -> meta?.isDirectory == true && hasDef(path, fs) }
+        .map { (sub, _) ->
           val subDef = readDefOrThrow(sub, fs)
           val nestedItems = walk(sub, fs, parentAuth = effectiveAuth)
           val folderItem = Item(name = sub.name, item = nestedItems, request = Request())

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3YamlReader.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3YamlReader.kt
@@ -117,11 +117,13 @@ internal object V3YamlReader {
     return V3Settings(disabledSystemHeaders = disabled)
   }
 
-  // * NOTE: Yaml is NOT thread-safe; a ThreadLocal reuses one instance per thread (avoiding a fresh
-  //   Yaml() per parse) while staying safe if reads are ever parallelized — do NOT "simplify" to a
-  //   bare shared val. Zero cost for today's sequential walk; each load() is independent (no anchor
-  //   or state carryover across documents, pinned by
-  // sequentialReadsThroughSharedYamlAreIndependent).
+  // * NOTE 14 Jul 2026 gopala.akshintala: Yaml is NOT thread-safe; a ThreadLocal reuses one
+  // instance
+  //   per thread (avoiding a fresh Yaml() per parse) while staying safe if reads are ever
+  //   parallelized — do NOT "simplify" to a bare shared val. Zero cost for the sequential walk
+  // today;
+  //   each load() is independent, with no anchor/state carryover across documents (pinned by the
+  //   sequentialReadsThroughSharedYamlAreIndependent test).
   private val yamlReader: ThreadLocal<Yaml> = ThreadLocal.withInitial { Yaml() }
 
   private fun parseYaml(yaml: String): Map<String, Any?> {

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3YamlReader.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3YamlReader.kt
@@ -117,9 +117,16 @@ internal object V3YamlReader {
     return V3Settings(disabledSystemHeaders = disabled)
   }
 
+  // * NOTE: Yaml is NOT thread-safe; a ThreadLocal reuses one instance per thread (avoiding a fresh
+  //   Yaml() per parse) while staying safe if reads are ever parallelized — do NOT "simplify" to a
+  //   bare shared val. Zero cost for today's sequential walk; each load() is independent (no anchor
+  //   or state carryover across documents, pinned by
+  // sequentialReadsThroughSharedYamlAreIndependent).
+  private val yamlReader: ThreadLocal<Yaml> = ThreadLocal.withInitial { Yaml() }
+
   private fun parseYaml(yaml: String): Map<String, Any?> {
     @Suppress("UNCHECKED_CAST")
-    return (Yaml().load<Any?>(yaml) as? Map<String, Any?>) ?: emptyMap()
+    return (yamlReader.get().load<Any?>(yaml) as? Map<String, Any?>) ?: emptyMap()
   }
 
   private fun mapToCollectionDef(map: Map<String, Any?>): V3CollectionDef =

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/DynamicVariableGeneratorTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/DynamicVariableGeneratorTest.kt
@@ -41,4 +41,23 @@ class DynamicVariableGeneratorTest {
       assertThat(value).isAtMost(255)
     }
   }
+
+  @Test
+  fun `getRandomHex output equals the legacy percent-02X formatting for all byte values`() {
+    // Locks the exact rendering the old `"%02X".format(v)` produced across the full range.
+    (0..255).forEach { v ->
+      val legacy = "%02X".format(v)
+      val formatted = java.util.HexFormat.of().withUpperCase().toHexDigits(v.toByte())
+      assertThat(formatted).isEqualTo(legacy)
+    }
+  }
+
+  @Test
+  fun `randomAlphanumeric returns the requested length using only a-zA-Z0-9`() {
+    listOf(0, 1, 15, 64).forEach { len ->
+      val out = randomAlphanumeric(len)
+      assertThat(out).hasLength(len)
+      assertThat(out).matches("[a-zA-Z0-9]*")
+    }
+  }
 }

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/RegexReplacerTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/RegexReplacerTest.kt
@@ -170,4 +170,34 @@ class RegexReplacerTest {
     regexReplacer.replaceVariablesRecursively("prefix {{ } suffix", pm) shouldBe
       "prefix {{ } suffix"
   }
+
+  @Test
+  fun `replaceVariablesInEnv resolves placeholder entries and passes static + typed entries through`() {
+    val regexReplacer = RegexReplacer()
+    val pm = PostmanSDK(moshiReVoman, null, regexReplacer)
+    pm.environment["base"] = "example.com"
+    pm.environment["url"] = "https://{{base}}/api" // value placeholder
+    pm.environment["staticStr"] = "no placeholders" // static string -> unchanged
+    pm.environment["count"] = 42 // non-string -> passed through as-is
+    pm.environment["flag"] = true // non-string -> passed through as-is
+    val result = regexReplacer.replaceVariablesInEnv(pm)
+    result shouldContainAll
+      mapOf(
+        "base" to "example.com",
+        "url" to "https://example.com/api",
+        "staticStr" to "no placeholders",
+        "count" to 42,
+        "flag" to true,
+      )
+  }
+
+  @Test
+  fun `replaceVariablesInEnv resolves a placeholder in the key`() {
+    val regexReplacer = RegexReplacer()
+    val pm = PostmanSDK(moshiReVoman, null, regexReplacer)
+    pm.environment["name"] = "userName"
+    pm.environment["{{name}}"] = "value" // key placeholder -> remapped to resolved key
+    val result = regexReplacer.replaceVariablesInEnv(pm)
+    result shouldContain ("userName" to "value")
+  }
 }

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/RegexReplacerTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/RegexReplacerTest.kt
@@ -146,4 +146,28 @@ class RegexReplacerTest {
     val result = regexReplacer.replaceVariablesRecursively("{{a}}", pm)
     result shouldBe "value"
   }
+
+  @Test
+  fun `string without double-brace is returned unchanged`() {
+    val regexReplacer = RegexReplacer()
+    val pm = PostmanSDK(moshiReVoman, null, regexReplacer)
+    val plain = """{ "a": 1, "b": "no placeholders here", "c": "{ single brace }" }"""
+    regexReplacer.replaceVariablesRecursively(plain, pm) shouldBe plain
+  }
+
+  @Test
+  fun `null input stays null`() {
+    val regexReplacer = RegexReplacer()
+    val pm = PostmanSDK(moshiReVoman, null, regexReplacer)
+    regexReplacer.replaceVariablesRecursively(null, pm) shouldBe null
+  }
+
+  @Test
+  fun `single unmatched brace pair is not treated as a placeholder`() {
+    val regexReplacer = RegexReplacer()
+    val pm = PostmanSDK(moshiReVoman, null, regexReplacer)
+    // Contains "{{" so it enters the regex path, but "{{ }" has no closing "}}" -> left literal.
+    regexReplacer.replaceVariablesRecursively("prefix {{ } suffix", pm) shouldBe
+      "prefix {{ } suffix"
+  }
 }

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3LoaderTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3LoaderTest.kt
@@ -95,4 +95,13 @@ class V3LoaderTest {
     assertThat(items).hasSize(1)
     assertThat(items[0].request.auth!!.bearer.single().value).isEqualTo("GRANDPARENT")
   }
+
+  @Test
+  fun sha256HexMatchesKnownVectors() {
+    // FIPS-180-2 vectors; also locks lowercase, zero-padded, 64-char output.
+    assertThat(sha256Hex("abc"))
+      .isEqualTo("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
+    assertThat(sha256Hex(""))
+      .isEqualTo("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+  }
 }

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3YamlReaderTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/template/v3/V3YamlReaderTest.kt
@@ -145,4 +145,42 @@ class V3YamlReaderTest {
     assertThat(env.values[0].value).isEqualTo("https://pokeapi.co/api/v2")
     assertThat(env.values[1].value).isEqualTo("true")
   }
+
+  @Test
+  fun sequentialReadsThroughSharedYamlAreIndependent() {
+    val first =
+      V3YamlReader.readRequest(
+        """
+        ${'$'}kind: http-request
+        url: "{{baseUrl}}/one"
+        method: GET
+        """
+          .trimIndent()
+      )
+    val second =
+      V3YamlReader.readRequest(
+        """
+        ${'$'}kind: http-request
+        url: "{{baseUrl}}/two"
+        method: POST
+        """
+          .trimIndent()
+      )
+    // Re-read the first shape after the second to prove no cross-call carryover.
+    val firstAgain =
+      V3YamlReader.readRequest(
+        """
+        ${'$'}kind: http-request
+        url: "{{baseUrl}}/one"
+        method: GET
+        """
+          .trimIndent()
+      )
+    assertThat(first.url).isEqualTo("{{baseUrl}}/one")
+    assertThat(first.method).isEqualTo("GET")
+    assertThat(second.url).isEqualTo("{{baseUrl}}/two")
+    assertThat(second.method).isEqualTo("POST")
+    assertThat(firstAgain.url).isEqualTo("{{baseUrl}}/one")
+    assertThat(firstAgain.method).isEqualTo("GET")
+  }
 }


### PR DESCRIPTION
## What

WT-3 of the ReVoman perf-improvements effort: five FP-preserving, **behavior-identical** micro-optimizations on the regex/template/variable hot paths, each locked by a characterization test, plus a JMH benchmark.

| ID | Change | File |
|----|--------|------|
| **C1** | `{{` fast-path guard — skip the regex scan for strings without a literal `{{` (the pattern can't match without it) | `RegexReplacer.replaceVariablesRecursively` |
| **C2** | Pass static/typed env entries through without the per-entry regex remap; keep the `.toMap()` snapshot | `RegexReplacer.replaceVariablesInEnv` |
| **C5** | JDK 21 `HexFormat` for hex/sha encoding (`getRandomHex` uppercase, `sha256Hex` lowercase) + `CharArray` for `randomAlphanumeric` | `DynamicVariableGenerator`, `V3Loader` |
| **C3** | Reuse a per-thread SnakeYAML reader (`ThreadLocal<Yaml>`) instead of `new Yaml()` per parse | `V3YamlReader` |
| **C4** | Stat each `walk` child once and partition, instead of 2× `metadataOrNull` | `V3Loader.walk` |

Plus `RegexVarBenchmark.kt` (measured, non-gating).

## Behavior identity

All five are byte-for-byte behavior-identical (guards short-circuit only inputs that can't match / entries the regex would no-op; `HexFormat` output equals the old `%02X`/`%02x` across the full range, locked by tests incl. FIPS-180-2 SHA-256 vectors; `CharArray` preserves RNG draw count/order; `ThreadLocal<Yaml>` is state-bleed-free; the walk refactor preserves predicates, map bodies, and ordering).

## Tests

- New/extended characterization test per optimization; C4 relies on the existing `V3LoaderTest`/`V3LoaderJarTest` suite (a stat-count refactor is output-invisible).
- Unit `test`: 435 passing, clean. `build` (detekt + assembly): clean.
- `integrationTest`: passes on CI. (Locally, restful-api.dev returns HTTP 405 "daily request limit" env-quota flakes — not regressions; CI has fresh quota + the retry plugin.)

## Note

`RegexVarBenchmark` compiles + runs via the unshaded classpath (recursively-over-mixed ~14.7µs/op, env ~38µs/op). `./gradlew jmh` (the shaded uber-jar) currently can't run any `PostmanSDK`-constructing benchmark — the shaded jar drops GraalVM Truffle's Multi-Release manifest so the eager JS-Context build fails at `@Setup`. That's a pre-existing WT-0 harness/packaging limitation (no build files changed here); flagged for a future harness fix.

## Scope

Touches only the 4 owned source files + 4 new/extended test files + 1 benchmark. Branched off master (includes WT-0 + WT-2).