### PR TITLE
perf(sandbox): WT-1 GraalJS engine-sharing + JSON.parse memo + syncProgress dedup (A2–A4, E1) + JMH

### DIFF
--- a/src/jmh/kotlin/com/salesforce/revoman/benchmark/SandboxBenchmark.kt
+++ b/src/jmh/kotlin/com/salesforce/revoman/benchmark/SandboxBenchmark.kt
@@ -1,0 +1,68 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.benchmark
+
+import com.salesforce.revoman.internal.postman.sandbox.PmExecutionContext
+import com.salesforce.revoman.internal.postman.sandbox.PmSandbox
+import com.salesforce.revoman.internal.postman.sandbox.PmScope
+import com.salesforce.revoman.internal.postman.sandbox.ScriptTarget
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+import org.openjdk.jmh.annotations.Warmup
+
+/**
+ * Measures the GraalJS sandbox hot path: repeated eval of a representative Postman test script.
+ * Captures A2 (interpreter->JIT once via truffle-runtime + shared-Engine bootcode reuse) and A3
+ * (JSON.parse closure reuse via pm.response.json()). One booted sandbox per trial; each @Benchmark
+ * invocation is one eval — the steady-state per-script latency after warm-up.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 8, time = 1)
+open class SandboxBenchmark {
+  private lateinit var sandbox: PmSandbox
+
+  private val script =
+    """
+    pm.test('status is ok', () => pm.expect(pm.response.code).to.eql(200));
+    const body = pm.response.json();
+    pm.environment.set('id', body.id);
+    pm.test('has id', () => pm.expect(body.id).to.eql(42));
+    """
+      .trimIndent()
+
+  private fun context() =
+    PmExecutionContext(
+      environment = PmScope("e", emptyMap()),
+      response = mapOf("code" to 200, "status" to "OK", "body" to """{"id":42}"""),
+    )
+
+  @Setup(Level.Trial)
+  fun setup() {
+    sandbox = PmSandbox() // boots lazily on the first execute
+  }
+
+  @TearDown(Level.Trial) fun tearDown() = sandbox.close()
+
+  @Benchmark
+  fun evalPostmanTestScript(): Any? =
+    sandbox.execute(script, ScriptTarget.TEST, context()).environment["id"]
+}

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/PostmanSDK.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/PostmanSDK.kt
@@ -9,6 +9,7 @@ package com.salesforce.revoman.internal.postman
 
 import com.github.underscore.U
 import com.salesforce.revoman.internal.json.MoshiReVoman
+import com.salesforce.revoman.internal.postman.sandbox.sharedGraalEngine
 import com.salesforce.revoman.internal.postman.template.Body
 import com.salesforce.revoman.internal.postman.template.Event
 import com.salesforce.revoman.internal.postman.template.Header
@@ -127,13 +128,12 @@ class PostmanSDK(
           imports = "var _ = require('lodash')\n"
         }
         put("js.esm-eval-returns-exports", "true")
-        put("engine.WarnInterpreterOnly", "false")
       }
       jsContext =
         Context.newBuilder("js")
+          .engine(sharedGraalEngine)
           .allowExperimentalOptions(true)
           .allowIO(IOAccess.ALL)
-          .allowExperimentalOptions(true)
           .options(options)
           .allowHostAccess(HostAccess.ALL)
           .allowHostClassLookup { true }

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/PostmanSDK.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/PostmanSDK.kt
@@ -117,7 +117,10 @@ class PostmanSDK(
 
   inner class JSEvaluator(nodeModulesPath: String? = null) {
     private val jsContext: Context
-    private var imports = ""
+    // Constant per-instance prefix, computed once. Non-empty only when a nodeModulesPath enabled
+    // commonjs-require (so lodash `_` is importable). Hoisted to a val — never mutated after init.
+    private val imports: String =
+      if (!nodeModulesPath.isNullOrBlank()) "var _ = require('lodash')\n" else ""
 
     init {
       val options = buildMap {
@@ -125,7 +128,6 @@ class PostmanSDK(
           logger.info { "nodeModulesPath: $nodeModulesPath" }
           put("js.commonjs-require", "true")
           put("js.commonjs-require-cwd", nodeModulesPath)
-          imports = "var _ = require('lodash')\n"
         }
         put("js.esm-eval-returns-exports", "true")
       }
@@ -143,6 +145,13 @@ class PostmanSDK(
       contextBindings.putMember("xml2Json", this@PostmanSDK.xml2Json)
     }
 
+    // * NOTE: A `Map<String, Value>` result-memo for repeated identical scripts is INTENTIONALLY
+    // NOT added here — it is unsafe. This fn injects per-call [bindings] into the shared Context,
+    // and pm scripts routinely have side effects (`pm.environment.set(...)`) and run identical
+    // text with different bindings (e.g. `xml2Json` over a different `responseBody`). A
+    // script->Value cache would skip both binding injection and re-execution, corrupting behavior.
+    // The safe repeated-script win is the closure memo (see [jsonParseFn]); A4 is limited to
+    // making the [imports] prefix immutable.
     internal fun evaluateJS(js: String, bindings: Map<String, Any> = emptyMap()): Value {
       val contextBindings = jsContext.getBindings("js")
       bindings.forEach { (key, value) -> contextBindings.putMember(key, value) }

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/PostmanSDK.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/PostmanSDK.kt
@@ -166,8 +166,9 @@ class PostmanSDK(
    * the halt predicate). ReVoman seeds [rundown] with this step's pre-step report as the LAST
    * entry, then calls this 3x per step as the report gains request/response/hook detail. REPLACES
    * the current step's entry (matched as the last report for the same [Step]) rather than
-   * appending, so a step appears exactly ONCE mid-run — earlier steps and prior loop iterations
-   * (which sit before it) are untouched. Keeps [Rundown] immutable via [Rundown.copy].
+   * appending, so the current execution appears ONCE mid-run (not the old 3-4x) — earlier steps and
+   * prior loop iterations (which sit before it, and for a looped step legitimately repeat the same
+   * [Step]) are untouched. Keeps [Rundown] immutable via [Rundown.copy].
    */
   internal fun syncProgress(stepReport: StepReport) {
     currentStepReport = stepReport

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/PostmanSDK.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/PostmanSDK.kt
@@ -161,9 +161,21 @@ class PostmanSDK(
     }
   }
 
+  /**
+   * Publishes the current step's evolving [StepReport] into [rundown] for mid-run readers (hooks,
+   * the halt predicate). ReVoman seeds [rundown] with this step's pre-step report as the LAST
+   * entry, then calls this 3x per step as the report gains request/response/hook detail. REPLACES
+   * the current step's entry (matched as the last report for the same [Step]) rather than
+   * appending, so a step appears exactly ONCE mid-run — earlier steps and prior loop iterations
+   * (which sit before it) are untouched. Keeps [Rundown] immutable via [Rundown.copy].
+   */
   internal fun syncProgress(stepReport: StepReport) {
     currentStepReport = stepReport
-    rundown = rundown.copy(stepReports = rundown.stepReports + stepReport)
+    val reports = rundown.stepReports
+    val updated =
+      if (reports.lastOrNull()?.step == stepReport.step) reports.dropLast(1) + stepReport
+      else reports + stepReport
+    rundown = rundown.copy(stepReports = updated)
   }
 
   /** Accumulates assertions across a step's pre-req + post-res scripts. */

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/PostmanSDK.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/PostmanSDK.kt
@@ -222,9 +222,17 @@ class PostmanSDK(
   fun evaluateJS(js: String, bindings: Map<String, Any> = emptyMap()): Value =
     jsEvaluator.evaluateJS(js, bindings)
 
-  @Language("JavaScript")
-  fun jsonStrToObj(jsonStr: String): Value =
-    evaluateJS("jsonStr => JSON.parse(jsonStr, {allowComments: true})").execute(jsonStr)
+  // Memoized JSON.parse closure: a stateless guest function bound to this instance's jsContext.
+  // Parsing the function literal once (not per call) skips a Source parse + compile on every
+  // json()/jsonStrToObj call. Reuse is safe — the closure holds no per-call state; only its
+  // argument varies. `by lazy` defers forcing until the first parse (jsEvaluator is init'd last).
+  private val jsonParseFn: Value by lazy {
+    @Language("JavaScript")
+    val jsonParseArrow = "jsonStr => JSON.parse(jsonStr, {allowComments: true})"
+    evaluateJS(jsonParseArrow)
+  }
+
+  fun jsonStrToObj(jsonStr: String): Value = jsonParseFn.execute(jsonStr)
 
   /**
    * `pm.variables` — the aggregate READ view across all scopes, honoring Postman precedence

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/sandbox/SandboxBridge.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/sandbox/SandboxBridge.kt
@@ -33,9 +33,8 @@ import org.graalvm.polyglot.proxy.ProxyObject
 internal val sharedGraalEngine: Engine by lazy {
   Engine.newBuilder("js")
     .allowExperimentalOptions(true)
-    // Engine-level option: silence the "interpreter only / fallback runtime" warning. With WT-0's
-    // truffle-runtime on the classpath this warning should no longer fire — Task 14 verifies and
-    // removes this line if so. Kept here (single home) until then.
+    // truffle-runtime present but the interpreter warning still fires on this JVM config —
+    // suppression retained (A1).
     .option("engine.WarnInterpreterOnly", "false")
     .build()
 }

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/sandbox/SandboxBridge.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/sandbox/SandboxBridge.kt
@@ -10,12 +10,35 @@ package com.salesforce.revoman.internal.postman.sandbox
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.util.Base64
 import org.graalvm.polyglot.Context
+import org.graalvm.polyglot.Engine
 import org.graalvm.polyglot.HostAccess
 import org.graalvm.polyglot.Source
 import org.graalvm.polyglot.Value
 import org.graalvm.polyglot.proxy.ProxyArray
 import org.graalvm.polyglot.proxy.ProxyExecutable
 import org.graalvm.polyglot.proxy.ProxyObject
+
+/**
+ * ONE process-wide immutable GraalVM [Engine], shared by every per-run [Context] (the sandbox
+ * Context here AND the PostmanSDK JSEvaluator Context). The Engine caches the parsed 2.2 MB
+ * bootcode [Source] and JIT-compiled code across runs and across both Context kinds, so the
+ * interpreter->JIT warm-up and the bootcode parse are paid once per JVM, not per ReVoman run.
+ *
+ * Engines are thread-safe and long-lived by design; Contexts are single-threaded and per-run.
+ * Sharing the Engine does NOT weaken the single-threaded Context contract, and — critically — guest
+ * state (globals/env) lives in the Context, so sharing the Engine cannot bleed state between runs.
+ * Never construct a Context WITHOUT this Engine. Left unclosed for the JVM lifetime (standard for a
+ * shared library Engine).
+ */
+internal val sharedGraalEngine: Engine by lazy {
+  Engine.newBuilder("js")
+    .allowExperimentalOptions(true)
+    // Engine-level option: silence the "interpreter only / fallback runtime" warning. With WT-0's
+    // truffle-runtime on the classpath this warning should no longer fire — Task 14 verifies and
+    // removes this line if so. Kept here (single home) until then.
+    .option("engine.WarnInterpreterOnly", "false")
+    .build()
+}
 
 /**
  * Owns a single GraalJS [Context] running Postman's real sandbox bootcode, driven via the uvm
@@ -44,16 +67,10 @@ internal class SandboxBridge {
     booted = true
     ctx =
       Context.newBuilder("js")
+        .engine(sharedGraalEngine)
         .allowExperimentalOptions(true)
         .option("js.esm-eval-returns-exports", "true")
         .option("js.ecmascript-version", "2024")
-        // Silence GraalVM's "fallback runtime / interpreter only" warning. It fires whenever the
-        // host JVM lacks the Graal compiler (JVMCI) — the common case for consumers running on a
-        // stock JDK. As a library we can't add -XX:+EnableJVMCI to the consumer's JVM, and the
-        // sandbox is not on a hot path, so the interpreter fallback is acceptable. Suppressing it
-        // also removes the accompanying Truffle log-redirect notice (that warning was its only
-        // log).
-        .option("engine.WarnInterpreterOnly", "false")
         .allowHostAccess(HostAccess.ALL)
         .allowHostClassLookup { true }
         .build()

--- a/src/main/kotlin/com/salesforce/revoman/internal/postman/sandbox/SandboxBridge.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/postman/sandbox/SandboxBridge.kt
@@ -20,9 +20,13 @@ import org.graalvm.polyglot.proxy.ProxyObject
 
 /**
  * ONE process-wide immutable GraalVM [Engine], shared by every per-run [Context] (the sandbox
- * Context here AND the PostmanSDK JSEvaluator Context). The Engine caches the parsed 2.2 MB
- * bootcode [Source] and JIT-compiled code across runs and across both Context kinds, so the
- * interpreter->JIT warm-up and the bootcode parse are paid once per JVM, not per ReVoman run.
+ * Context here AND the PostmanSDK JSEvaluator Context). The Engine shares the interpreter->JIT /
+ * optimizing-runtime warm-up across runs and across both Context kinds — the reliable, measured A2
+ * win, so that convergence is paid once per JVM rather than per ReVoman run. It ALSO caches parsed
+ * code for the 2.2 MB bootcode [Source], but that reuse is best-effort: the engine source cache
+ * holds the [Source] weakly and the bootcode Source is a local not retained past [boot], so its
+ * parsed code may be GC'd between runs. Either way this is a strict improvement — pre-A2 there was
+ * zero cross-run sharing.
  *
  * Engines are thread-safe and long-lived by design; Contexts are single-threaded and per-run.
  * Sharing the Engine does NOT weaken the single-threaded Context contract, and — critically — guest

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/PostmanSDKEvalIsolationTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/PostmanSDKEvalIsolationTest.kt
@@ -1,0 +1,26 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.postman
+
+import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+/**
+ * A2 guard for the JSEvaluator Context (peer of the sandbox Context). The Engine is shared; the
+ * Context is per-PostmanSDK. Two instances must NOT see each other's guest globals.
+ */
+class PostmanSDKEvalIsolationTest {
+  @Test
+  fun `two PostmanSDK instances sharing the Engine do not leak JS globals`() {
+    val pm1 = PostmanSDK(initMoshi())
+    pm1.evaluateJS("globalThis.__leak = 'from-pm1'; 1")
+    val pm2 = PostmanSDK(initMoshi())
+    pm2.evaluateJS("typeof globalThis.__leak").asString() shouldBe "undefined"
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/PostmanSDKEvalIsolationTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/PostmanSDKEvalIsolationTest.kt
@@ -20,6 +20,10 @@ class PostmanSDKEvalIsolationTest {
   fun `two PostmanSDK instances sharing the Engine do not leak JS globals`() {
     val pm1 = PostmanSDK(initMoshi())
     pm1.evaluateJS("globalThis.__leak = 'from-pm1'; 1")
+    // POSITIVE CONTROL: the global genuinely persists across evaluateJS calls WITHIN one instance
+    // (its jsContext is reused). This pins the leak vector inside the test, so the cross-instance
+    // negative below cannot silently pass on a dead channel and give the shared-Engine a false net.
+    pm1.evaluateJS("typeof globalThis.__leak").asString() shouldBe "string"
     val pm2 = PostmanSDK(initMoshi())
     pm2.evaluateJS("typeof globalThis.__leak").asString() shouldBe "undefined"
   }

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/PostmanSDKJsonStrToObjTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/PostmanSDKJsonStrToObjTest.kt
@@ -1,0 +1,52 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.postman
+
+import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import org.graalvm.polyglot.PolyglotException
+import org.junit.jupiter.api.Test
+
+/**
+ * A3 guard: `jsonStrToObj` memoizes the JSON.parse arrow CLOSURE, not the parse RESULT. Repeated
+ * calls with different inputs must still parse each input correctly (closure reuse != result
+ * cache).
+ */
+class PostmanSDKJsonStrToObjTest {
+  private val pm = PostmanSDK(initMoshi())
+
+  @Test
+  fun `repeated parses with different inputs each parse correctly`() {
+    pm.jsonStrToObj("""{"a": 1}""").getMember("a").asInt() shouldBe 1
+    pm.jsonStrToObj("""{"a": 2}""").getMember("a").asInt() shouldBe 2
+    pm.jsonStrToObj("""{"b": "x"}""").getMember("b").asString() shouldBe "x"
+  }
+
+  @Test
+  fun `raw JSON5 comments are not tolerated by jsonStrToObj (stripped upstream in Template)`() {
+    // Pins the REAL contract: `jsonStrToObj` does NOT tolerate JSON5 comments. Its closure is
+    // `JSON.parse(jsonStr, {allowComments: true})`, but per the ECMAScript spec `JSON.parse`'s
+    // 2nd argument is the *reviver* position — a non-callable `{allowComments: true}` is a
+    // silent no-op, so standard `JSON.parse` runs and rejects `//` comments with a SyntaxError.
+    // This is not a bug: comment-bearing request bodies have their JSON5 comments stripped
+    // UPSTREAM in `Template.toHttpRequest` (via the Moshi round-trip) before ever reaching
+    // `jsonStrToObj`, so in production this method only ever sees comment-free JSON.
+    shouldThrow<PolyglotException> {
+      pm.jsonStrToObj(
+        """
+        {
+          // a line comment
+          "a": 1
+        }
+        """
+          .trimIndent()
+      )
+    }
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/PostmanSDKSyncProgressTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/PostmanSDKSyncProgressTest.kt
@@ -1,0 +1,89 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.postman
+
+import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
+import com.salesforce.revoman.internal.postman.template.Item
+import com.salesforce.revoman.output.Rundown
+import com.salesforce.revoman.output.postman.PostmanEnvironment
+import com.salesforce.revoman.output.report.Step
+import com.salesforce.revoman.output.report.StepReport
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+/**
+ * E1 guard: mirrors ReVoman.runStep — the Rundown is seeded with prior steps + THIS step's pre-step
+ * report (current LAST), then syncProgress runs 3x per step. syncProgress must REPLACE the current
+ * step's entry (not append), so the mid-run pm.rundown holds each step exactly once and prior steps
+ * + loop-iteration history are preserved.
+ */
+class PostmanSDKSyncProgressTest {
+  private fun step(name: String) = Step(index = "1", rawPMStep = Item(name = name))
+
+  private fun report(step: Step) = StepReport(step = step, pmEnvSnapshot = PostmanEnvironment())
+
+  private fun pmWithSeededRundown(stepReportsSoFar: List<StepReport>): PostmanSDK =
+    PostmanSDK(initMoshi()).apply {
+      rundown =
+        Rundown(
+          stepReports = stepReportsSoFar,
+          mutableEnv = PostmanEnvironment(),
+          haltOnFailureOfTypeExcept = emptyMap(),
+          providedStepsToExecuteCount = stepReportsSoFar.size,
+        )
+    }
+
+  @Test
+  fun `three syncProgress calls keep the current step exactly once and preserve prior steps`() {
+    val stepA = step("a")
+    val stepB = step("b")
+    val reportA = report(stepA)
+    val preReportB = report(stepB)
+    // ReVoman.kt:402 seed: prior steps + current step's pre-step report (current LAST).
+    val pm = pmWithSeededRundown(listOf(reportA, preReportB))
+
+    // ReVoman.kt:451,468,483: 3 syncProgress calls for the SAME step, each with an evolved sr.
+    val srB1 = preReportB.copy(nextRequest = "afterHttp")
+    val srB2 = srB1.copy(nextRequest = "afterPostRes")
+    val srB3 = srB2.copy(nextRequest = "afterHooks")
+    pm.syncProgress(srB1)
+    pm.syncProgress(srB2)
+    pm.syncProgress(srB3)
+
+    pm.rundown.stepReports shouldHaveSize 2 // a + b, NOT a + b + b + b + b
+    pm.rundown.stepReports.map { it.step.name } shouldBe listOf("a", "b")
+    pm.rundown.stepReports.last() shouldBe srB3 // most-evolved report wins
+    pm.currentStepReport shouldBe srB3
+  }
+
+  @Test
+  fun `first syncProgress on an empty-prefix seed keeps a single entry`() {
+    val stepA = step("a")
+    val pre = report(stepA)
+    val pm = pmWithSeededRundown(listOf(pre)) // first step of the run
+    val evolved = pre.copy(nextRequest = "x")
+    pm.syncProgress(evolved)
+    pm.rundown.stepReports shouldHaveSize 1
+    pm.rundown.stepReports.last() shouldBe evolved
+  }
+
+  @Test
+  fun `looped step preserves the prior iteration report`() {
+    val stepA = step("a")
+    val iter0Final = report(stepA).copy(iteration = 0, nextRequest = "loop")
+    val preIter1 = report(stepA).copy(iteration = 1)
+    // 2nd iteration seed: prior iteration's final report + this iteration's pre-step report.
+    val pm = pmWithSeededRundown(listOf(iter0Final, preIter1))
+    val iter1Final = preIter1.copy(nextRequest = "done")
+    pm.syncProgress(iter1Final)
+    pm.rundown.stepReports shouldHaveSize 2 // iter0Final preserved, preIter1 replaced
+    pm.rundown.stepReports[0] shouldBe iter0Final
+    pm.rundown.stepReports[1] shouldBe iter1Final
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/sandbox/SandboxEngineSharingTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/sandbox/SandboxEngineSharingTest.kt
@@ -1,0 +1,79 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.postman.sandbox
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+/**
+ * A2 guard: the shared immutable GraalVM Engine reuses parsed bootcode across runs, but each run
+ * gets its OWN Context. These tests pin that (a) repeated evals in one sandbox are deterministic
+ * and (b) two sandboxes NEVER see each other's guest globals or env — the #1 state-bleed risk.
+ */
+class SandboxEngineSharingTest {
+  private fun testCtx(env: Map<String, Any?> = emptyMap()) =
+    PmExecutionContext(environment = PmScope("e", env))
+
+  @Test
+  fun `same script evaluated twice in one sandbox yields identical results`() {
+    val sandbox = PmSandbox()
+    val script =
+      """
+      pm.test('sum', () => pm.expect(1 + 1).to.eql(2));
+      pm.environment.set('n', 41 + 1);
+      """
+        .trimIndent()
+    val r1 = sandbox.execute(script, ScriptTarget.TEST, testCtx())
+    val r2 = sandbox.execute(script, ScriptTarget.TEST, testCtx())
+    sandbox.close()
+    r1.error shouldBe null
+    r2.error shouldBe null
+    r1.assertions[0].passed shouldBe true
+    r2.assertions[0].passed shouldBe true
+    r1.environment["n"] shouldBe 42
+    r2.environment["n"] shouldBe 42
+  }
+
+  @Test
+  fun `two sandboxes sharing the Engine do not leak guest globals or env`() {
+    val s1 = PmSandbox()
+    // Leak a guest global via a bare undeclared assignment (non-strict global write). Inside the
+    // postman-sandbox user-script scope `globalThis` is NOT a bound identifier — referencing it
+    // throws `ReferenceError: globalThis is not defined` — so the leak is written/read through
+    // the bare name, which is exactly the persistent-across-runs global the state-bleed guard
+    // must catch.
+    s1.execute("__leak = 'from-s1';", ScriptTarget.TEST, testCtx())
+
+    // POSITIVE CONTROL: the bare-name global genuinely persists across execute() calls WITHIN one
+    // sandbox (same Context). This pins the leak vector INSIDE the test — so if a future
+    // postman-sandbox bump ever reset guest globals per exec (strict mode / fresh scope), THIS
+    // assertion fails loudly instead of the cross-sandbox negative below silently passing on a
+    // dead channel and giving the shared-Engine refactor a false safety net.
+    val sameSandbox =
+      s1.execute(
+        "pm.environment.set('sawGlobalSameSandbox', typeof __leak);",
+        ScriptTarget.TEST,
+        testCtx(),
+      )
+    sameSandbox.error shouldBe null
+    sameSandbox.environment["sawGlobalSameSandbox"] shouldBe "string" // persists within one sandbox
+
+    // NEGATIVE: a DIFFERENT sandbox (its own Context) must NOT see s1's guest global.
+    val s2 = PmSandbox()
+    val r =
+      s2.execute(
+        "pm.environment.set('sawGlobal', typeof __leak);",
+        ScriptTarget.TEST,
+        testCtx(),
+      )
+    s1.close()
+    s2.close()
+    r.error shouldBe null
+    r.environment["sawGlobal"] shouldBe "undefined" // fresh Context: s1's global unseen
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/internal/postman/sandbox/SandboxEngineSharingTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/postman/sandbox/SandboxEngineSharingTest.kt
@@ -11,9 +11,15 @@ import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 
 /**
- * A2 guard: the shared immutable GraalVM Engine reuses parsed bootcode across runs, but each run
- * gets its OWN Context. These tests pin that (a) repeated evals in one sandbox are deterministic
- * and (b) two sandboxes NEVER see each other's guest globals or env — the #1 state-bleed risk.
+ * A2 guard: the shared immutable GraalVM Engine reuses warm-up across runs, but each run gets its
+ * OWN Context. These tests pin that (a) repeated evals in one sandbox are deterministic and (b) two
+ * sandboxes NEVER see each other's guest globals — the #1 state-bleed risk. (Env is not tested as a
+ * bleed vector: it is host-injected fresh per [PmSandbox.execute] from the passed
+ * [PmExecutionContext], so it structurally cannot cross Contexts regardless of Engine sharing.)
+ *
+ * These tests prove Context ISOLATION, which only gets stronger if the Engine were NOT shared — so
+ * they cannot detect a silent revert of the Engine sharing itself. That perf invariant (one Engine,
+ * reused JIT warm-up) is guarded by `SandboxBenchmark` (jmh), not here.
  */
 class SandboxEngineSharingTest {
   private fun testCtx(env: Map<String, Any?> = emptyMap()) =


### PR DESCRIPTION
## What

WT-1 of the ReVoman perf-improvements effort: cut GraalJS per-eval latency in the Postman sandbox.

| ID | Change | File |
|----|--------|------|
| **A2** | Share ONE process-wide immutable GraalVM `Engine` across both per-run JS Contexts (sandbox + JSEvaluator). Engine shared, **Context strictly per-run** — no guest-state bleed. | `SandboxBridge.kt`, `PostmanSDK.kt` |
| **A3** | Memoize the `JSON.parse` closure (`by lazy` `jsonParseFn: Value`) so `jsonStrToObj`/`json()` skip a Source parse+compile per call. | `PostmanSDK.kt` |
| **A4** | Hoist the JSEvaluator `imports` prefix from a mutated `var` to an immutable computed `val`; documented why a script→Value result-memo is intentionally skipped (per-call bindings + side-effecting scripts). | `PostmanSDK.kt` |
| **E1** | `syncProgress` **replaces** the current step's report in the mid-run `pm.rundown` instead of appending 3× per step. | `PostmanSDK.kt` |

Plus `SandboxBenchmark.kt` (JMH, measured/non-gating).

## Correctness

- **Engine-only sharing** is verified by positive-controlled state-bleed tests: `SandboxEngineSharingTest` (a same-sandbox positive control proves the guest-global channel genuinely persists within one sandbox, then asserts a *different* sandbox never sees it) and `PostmanSDKEvalIsolationTest` (same for the JSEvaluator Context). Each Context is still built fresh per run/instance.
- **A3** memoizes the *closure*, not the parse result — different inputs still parse correctly (`PostmanSDKJsonStrToObjTest`). Two plan-premise notes worth recording: `JSON.parse`'s 2nd arg is the reviver position, so the `{allowComments:true}` there was always a dead no-op (standard `JSON.parse` throws on comments); comment-bearing request bodies are stripped upstream in `Template.toHttpRequest`. The test pins the real contract (comments throw); production behavior is unchanged.
- **E1** is a mid-run-only fix. The **final** `Rundown` is built from the sequencer's `reports` list, not `pm.rundown`, so end-of-run results are unchanged; only mid-run readers (hooks + the halt predicate) previously saw the current step duplicated 2–4×, now once. Locked by a RED→GREEN test mirroring `ReVoman.runStep`, incl. the looped-step case.
- `WarnInterpreterOnly` suppression is **retained** — empirically the interpreter warning still fires with `truffle-runtime` present, because stock HotSpot needs a Graal-compiler-capable JVM to enable the optimizing runtime (the jar alone is insufficient).

## ⚠️ Cross-worktree coupling (for WT-4)

E1's `syncProgress` matches the current step as the **last** report for the same `Step`, which relies on `ReVoman.kt:402` seeding `pm.rundown` with the current step's pre-step report **last**. WT-1 does **not** touch `ReVoman.kt`. If WT-4's env-backing work re-orders that seed, revisit the `reports.lastOrNull()?.step == stepReport.step` check.

## Tests

- Unit `test`: 443 passing, 0 failures. `build` (detekt + assembly): clean.
- `integrationTest`: passes on CI. (Locally, restful-api.dev returns HTTP 405 env-quota flakes — not regressions; CI has fresh quota + the retry plugin.)
- `SandboxBenchmark` compiles (`jmhClasses`) and runs via the unshaded classpath (~7.4 ms/op; warmup shows the A2 interpreter→JIT convergence). `./gradlew jmh` (shaded uber-jar) can't run any GraalJS-Context benchmark yet — a pre-existing WT-0 harness limitation (Truffle Multi-Release manifest lost in the uber-jar), no build files changed here.

## Scope

Touches only the 2 owned source files (`SandboxBridge.kt`, `PostmanSDK.kt`) + 4 test files + 1 benchmark. `ReVoman.kt` untouched. Branched off master (includes WT-2 + WT-3).