### PR TITLE
perf: WT-4 exe-engine + output micro-fixes (D1–D6) + persistent-map env O(1) snapshots (E2) + JMH

### DIFF
--- a/src/jmh/kotlin/com/salesforce/revoman/benchmark/EnvAccumBenchmark.kt
+++ b/src/jmh/kotlin/com/salesforce/revoman/benchmark/EnvAccumBenchmark.kt
@@ -8,6 +8,7 @@
 package com.salesforce.revoman.benchmark
 
 import com.salesforce.revoman.internal.postman.template.Item
+import com.salesforce.revoman.output.postman.PersistentBackedMutableMap
 import com.salesforce.revoman.output.postman.PostmanEnvironment
 import com.salesforce.revoman.output.report.Step
 import java.util.concurrent.TimeUnit
@@ -47,12 +48,12 @@ open class EnvAccumBenchmark {
 
   @Benchmark
   open fun accumulateAndSnapshot(bh: Blackhole) {
-    val env = PostmanEnvironment<Any?>()
+    val env = PostmanEnvironment<Any?>(PersistentBackedMutableMap<Any?>())
     stepList.forEach { step ->
       env.currentStep = step
       env.set("key_${step.name}", step.name)
-      // Mirror ReVoman.runStep's per-step snapshot capture:
-      bh.consume(env.copy(mutableEnv = env.mutableEnv.toMutableMap()))
+      // Mirror ReVoman.runStep's per-step snapshot capture (now the persistent O(1) path):
+      bh.consume(env.o1Snapshot())
     }
     bh.consume(env)
   }

--- a/src/jmh/kotlin/com/salesforce/revoman/benchmark/EnvAccumBenchmark.kt
+++ b/src/jmh/kotlin/com/salesforce/revoman/benchmark/EnvAccumBenchmark.kt
@@ -1,0 +1,59 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.benchmark
+
+import com.salesforce.revoman.internal.postman.template.Item
+import com.salesforce.revoman.output.postman.PostmanEnvironment
+import com.salesforce.revoman.output.report.Step
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import org.openjdk.jmh.infra.Blackhole
+
+/**
+ * M steps, each: set a fresh key + capture a per-step env snapshot (mirrors ReVoman.runStep's
+ * pmEnvSnapshot). Measures env-accumulation cost — O(M*E) with a copy-on-snapshot backing, O(M)
+ * once E2's persistent map makes the snapshot an O(1) structural share.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+open class EnvAccumBenchmark {
+  @Param("50", "200", "800") open var steps: Int = 0
+
+  private lateinit var stepList: List<Step>
+
+  @Setup
+  fun setUp() {
+    stepList = (0 until steps).map { Step(index = "$it", rawPMStep = Item(name = "s$it")) }
+  }
+
+  @Benchmark
+  open fun accumulateAndSnapshot(bh: Blackhole) {
+    val env = PostmanEnvironment<Any?>()
+    stepList.forEach { step ->
+      env.currentStep = step
+      env.set("key_${step.name}", step.name)
+      // Mirror ReVoman.runStep's per-step snapshot capture:
+      bh.consume(env.copy(mutableEnv = env.mutableEnv.toMutableMap()))
+    }
+    bh.consume(env)
+  }
+}

--- a/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
+++ b/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
@@ -60,6 +60,7 @@ import com.salesforce.revoman.output.StopReason
 import com.salesforce.revoman.output.ledger.LedgerEntry
 import com.salesforce.revoman.output.log.Outcome
 import com.salesforce.revoman.output.log.StepEvent
+import com.salesforce.revoman.output.postman.PersistentBackedMutableMap
 import com.salesforce.revoman.output.report.Step
 import com.salesforce.revoman.output.report.StepEnvVars
 import com.salesforce.revoman.output.report.StepReport
@@ -164,8 +165,15 @@ object ReVoman {
     val mergedEnv =
       mergeEnvs(kick.environmentPaths(), kick.environmentInputStreams(), kick.dynamicEnvironment())
     val environment = ledgerValues + mergedEnv.values
+    // Persistent-backed so every per-step pmEnvSnapshot is an O(1) structural share (see E2). The
+    // MutableMap contract is preserved, so PostmanSDK/RegexReplacer writes are unaffected.
     val pm =
-      PostmanSDK(moshiReVoman, kick.nodeModulesPath(), regexReplacer, environment.toMutableMap())
+      PostmanSDK(
+        moshiReVoman,
+        kick.nodeModulesPath(),
+        regexReplacer,
+        PersistentBackedMutableMap(environment),
+      )
     pm.environmentName = mergedEnv.name
     val sequenceResult =
       PmSandbox().use { sandbox ->
@@ -495,7 +503,7 @@ object ReVoman {
       .merge()
       .copy(
         exeTimings = exeTimings,
-        pmEnvSnapshot = pm.environment.copy(mutableEnv = pm.environment.mutableEnv.toMutableMap()),
+        pmEnvSnapshot = pm.environment.o1Snapshot(),
         envVars =
           StepEnvVars(
             produced = pm.environment.producedKeysFor(step),

--- a/src/main/kotlin/com/salesforce/revoman/internal/exe/HttpRequest.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/exe/HttpRequest.kt
@@ -34,9 +34,8 @@ internal fun fireHttpRequest(
   moshiReVoman: MoshiReVoman,
 ): Either<HttpRequestFailure, TxnInfo<Response>> =
   runCatching(currentStep, HTTP_REQUEST) {
-      // * NOTE gopala.akshintala 06/08/22: Preparing httpClient for each step,
-      // * as there can be intermediate auths
-      // ! TODO 29/01/24 gopala.akshintala: When would bearer token size be > 1?
+      // * NOTE gopala.akshintala 06/08/22: Shared client per TLS variant; auth is carried
+      // per-Request
       prepareHttpClient(insecureHttp)(httpRequest)
     }
     .mapLeft { HttpRequestFailure(it, TxnInfo(httpMsg = httpRequest, moshiReVoman = moshiReVoman)) }
@@ -59,8 +58,18 @@ internal fun renderHttpMsg(httpMsg: HttpMessage): String {
   return head + JsonPretty.pretty(body)
 }
 
+// One http4k/Apache client per TLS variant, memoized for the life of the JVM. Auth is carried
+// per-Request (each Request builds its own Authorization header), so a single shared, pooled
+// client is safe across steps/runs — and avoids building + discarding a pooled client (and its
+// connection manager) on every request, which also fixes the per-run client leak.
+private val secureHttpClient: HttpHandler by lazy { ApacheClient() }
+
+private val insecureHttpClient: HttpHandler by lazy {
+  ApacheClient(client = insecureApacheHttpClient())
+}
+
 internal fun prepareHttpClient(insecureHttp: Boolean): HttpHandler =
-  if (insecureHttp) ApacheClient(client = insecureApacheHttpClient()) else ApacheClient()
+  if (insecureHttp) insecureHttpClient else secureHttpClient
 
 /** WARNING: Only for Testing. DO NOT USE IN PROD */
 private fun insecureApacheHttpClient(): CloseableHttpClient =

--- a/src/main/kotlin/com/salesforce/revoman/internal/exe/PostStepHook.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/exe/PostStepHook.kt
@@ -43,15 +43,14 @@ private fun pickPostStepHooks(
   postStepHooks: List<HookConfig>,
   currentStepReport: StepReport,
   rundown: Rundown,
-): Sequence<PostStepHook> =
+): List<PostStepHook> =
   postStepHooks
-    .asSequence()
     .filter { (it.pick as PostTxnStepPick).pick(currentStepReport, rundown) }
     .map { it.stepHook as PostStepHook }
     .also {
-      if (it.iterator().hasNext()) {
-        logger.info { "${currentStepReport.step} Picked Post hook count : ${it.count()}" }
-        currentStepReport.step.postStepHookCount = it.count()
+      if (it.isNotEmpty()) {
+        logger.info { "${currentStepReport.step} Picked Post hook count : ${it.size}" }
+        currentStepReport.step.postStepHookCount = it.size
       }
     }
 

--- a/src/main/kotlin/com/salesforce/revoman/internal/exe/PostStepHook.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/exe/PostStepHook.kt
@@ -23,7 +23,11 @@ internal fun postStepHookExe(
   currentStepReport: StepReport,
   rundown: Rundown,
 ): PostStepHookFailure? =
+  // asSequence keeps hook execution LAZY + short-circuiting: if a picked hook fails, later hooks'
+  // accept() (with their side effects) do NOT run — the pre-D2 Sequence behavior. D2 materialized
+  // only the PICK (so the pick predicate runs once); execution order/short-circuit is preserved.
   pickPostStepHooks(kick.postStepHooks(), currentStepReport, rundown)
+    .asSequence()
     .map { postStepHook ->
       runCatching(currentStepReport.step, POST_STEP_HOOK) {
           postStepHook.accept(currentStepReport, rundown)

--- a/src/main/kotlin/com/salesforce/revoman/internal/exe/PreStepHook.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/exe/PreStepHook.kt
@@ -42,15 +42,14 @@ private fun pickPreStepHooks(
   currentStep: Step,
   requestInfo: TxnInfo<Request>,
   rundown: Rundown,
-): Sequence<PreStepHook> =
+): List<PreStepHook> =
   preStepHooks
-    .asSequence()
     .filter { (it.pick as PreTxnStepPick).pick(currentStep, requestInfo, rundown) }
     .map { it.stepHook as PreStepHook }
     .also {
-      if (it.iterator().hasNext()) {
-        logger.info { "$currentStep Picked Pre hook count : ${it.count()}" }
-        currentStep.preStepHookCount = it.count()
+      if (it.isNotEmpty()) {
+        logger.info { "$currentStep Picked Pre hook count : ${it.size}" }
+        currentStep.preStepHookCount = it.size
       }
     }
 

--- a/src/main/kotlin/com/salesforce/revoman/internal/exe/PreStepHook.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/exe/PreStepHook.kt
@@ -26,7 +26,11 @@ internal fun preStepHookExe(
   requestInfo: TxnInfo<Request>,
   rundown: Rundown,
 ): PreStepHookFailure? =
+  // asSequence keeps hook execution LAZY + short-circuiting: if a picked hook fails, later hooks'
+  // accept() (with their side effects) do NOT run — the pre-D2 Sequence behavior. D2 materialized
+  // only the PICK (so the pick predicate runs once); execution order/short-circuit is preserved.
   pickPreStepHooks(kick.preStepHooks(), currentStep, requestInfo, rundown)
+    .asSequence()
     .map { preStepHook ->
       runCatching(currentStep, PRE_STEP_HOOK) {
           preStepHook.accept(currentStep, requestInfo, rundown)

--- a/src/main/kotlin/com/salesforce/revoman/internal/exe/UnmarshallResponse.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/exe/UnmarshallResponse.kt
@@ -31,9 +31,10 @@ internal fun unmarshallResponse(
   rundown: Rundown,
 ): Either<UnmarshallResponseFailure, TxnInfo<Response>> {
   val httpResponse = currentStepReport.responseInfo!!.get().httpMsg
+  val body: String = httpResponse.bodyString()
+  val contentType: String? = httpResponse.contentType()?.value
   return when {
-    httpResponse.bodyString().isNotBlank() &&
-      APPLICATION_JSON.value.equals(httpResponse.contentType()?.value, true) -> {
+    body.isNotBlank() && APPLICATION_JSON.value.equals(contentType, true) -> {
       val httpStatus = httpResponse.status.successful
       val responseConfig =
         (kick.pickToResponseConfig()[httpStatus].orEmpty() +
@@ -46,7 +47,7 @@ internal fun unmarshallResponse(
           ?.responseType ?: Any::class.java
       val requestInfo = currentStepReport.requestInfo!!.get()
       runCatching(currentStep, UNMARSHALL_RESPONSE) {
-          moshiReVoman.fromJson<Any>(httpResponse.bodyString(), responseType)
+          moshiReVoman.fromJson<Any>(body, responseType)
         }
         .mapLeft {
           UnmarshallResponseFailure(
@@ -66,7 +67,7 @@ internal fun unmarshallResponse(
     }
     else -> {
       logger.info {
-        "${currentStepReport.step} Blank Response body or ${httpResponse.contentType()?.value} didn't match ${APPLICATION_JSON.value}"
+        "${currentStepReport.step} Blank Response body or $contentType didn't match ${APPLICATION_JSON.value}"
       }
       Right(TxnInfo(isJson = false, httpMsg = httpResponse, moshiReVoman = moshiReVoman))
     }

--- a/src/main/kotlin/com/salesforce/revoman/output/postman/PostmanEnvironment.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/postman/PostmanEnvironment.kt
@@ -17,6 +17,9 @@ import io.exoquery.pprint
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.vavr.control.Either
 import java.lang.reflect.Type
+import kotlinx.collections.immutable.PersistentMap
+import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.collections.immutable.toPersistentMap
 
 /** This is a Wrapper on `mutableEnv` map, providing some useful utilities */
 data class PostmanEnvironment<ValueT : Any?>
@@ -259,3 +262,135 @@ constructor(
 }
 
 private val logger = KotlinLogging.logger {}
+
+/**
+ * A [MutableMap] backed by an immutable [PersistentMap] that is SWAPPED on every write. Because the
+ * backing is immutable, [snapshotView] captures the current reference in O(1) and later writes to
+ * this instance (which install a NEW persistent map) never mutate that captured view — the
+ * point-in-time invariant [com.salesforce.revoman.output.report.StepReport] relies on.
+ * Reads/keys/entries/values are non-copying read-through views over the current backing (mutators
+ * on those views throw; nothing in ReVoman mutates through them), so the per-step
+ * `pm.environment.keys` access stays O(1).
+ */
+internal class PersistentBackedMutableMap<V>
+private constructor(private var current: PersistentMap<String, V>) : MutableMap<String, V> {
+
+  constructor() : this(persistentMapOf())
+
+  constructor(seed: Map<String, V>) : this(seed.toPersistentMap())
+
+  /** O(1): a NEW instance sharing this instance's current immutable backing. */
+  fun snapshotView(): PersistentBackedMutableMap<V> = PersistentBackedMutableMap(current)
+
+  override val size: Int
+    get() = current.size
+
+  override fun isEmpty(): Boolean = current.isEmpty()
+
+  override fun containsKey(key: String): Boolean = current.containsKey(key)
+
+  override fun containsValue(value: V): Boolean = current.containsValue(value)
+
+  override fun get(key: String): V? = current[key]
+
+  override fun put(key: String, value: V): V? {
+    val prev = current[key]
+    current = current.put(key, value)
+    return prev
+  }
+
+  override fun remove(key: String): V? {
+    val prev = current[key]
+    current = current.remove(key)
+    return prev
+  }
+
+  override fun putAll(from: Map<out String, V>) {
+    current = current.putAll(from)
+  }
+
+  override fun clear() {
+    current = persistentMapOf()
+  }
+
+  // Read-through views over the current backing. kotlinx immutable views are Set/Collection; wrap
+  // them so the MutableMap type is satisfied. Mutators throw — no ReVoman code path mutates
+  // through env.keys/entries/values (grep-verified); the swap-on-write API above is the only
+  // supported mutation surface.
+  override val keys: MutableSet<String>
+    get() =
+      object : AbstractMutableSet<String>() {
+        override val size: Int
+          get() = current.size
+
+        override fun iterator(): MutableIterator<String> =
+          current.keys.iterator().asReadOnlyMutable()
+
+        override fun add(element: String): Boolean = throw UnsupportedOperationException()
+      }
+
+  override val values: MutableCollection<V>
+    get() =
+      object : AbstractMutableCollection<V>() {
+        override val size: Int
+          get() = current.size
+
+        override fun iterator(): MutableIterator<V> = current.values.iterator().asReadOnlyMutable()
+
+        override fun add(element: V): Boolean = throw UnsupportedOperationException()
+      }
+
+  override val entries: MutableSet<MutableMap.MutableEntry<String, V>>
+    get() =
+      object : AbstractMutableSet<MutableMap.MutableEntry<String, V>>() {
+        override val size: Int
+          get() = current.size
+
+        // Non-copying: lazily wrap each read-only kotlinx `Map.Entry` in a read-only
+        // `MutableEntry` (setValue throws) as iteration advances — kotlinx `MapEntry` does
+        // NOT implement `MutableMap.MutableEntry`, so an unchecked cast would throw
+        // ClassCastException at runtime. No eager collection is materialized.
+        override fun iterator(): MutableIterator<MutableMap.MutableEntry<String, V>> =
+          current.entries
+            .asSequence()
+            .map { it.asReadOnlyMutableEntry() }
+            .iterator()
+            .asReadOnlyMutable()
+
+        override fun add(element: MutableMap.MutableEntry<String, V>): Boolean =
+          throw UnsupportedOperationException()
+      }
+
+  override fun equals(other: Any?): Boolean = current == other
+
+  override fun hashCode(): Int = current.hashCode()
+
+  override fun toString(): String = current.toString()
+}
+
+private fun <T> Iterator<T>.asReadOnlyMutable(): MutableIterator<T> =
+  object : MutableIterator<T> {
+    override fun hasNext(): Boolean = this@asReadOnlyMutable.hasNext()
+
+    override fun next(): T = this@asReadOnlyMutable.next()
+
+    override fun remove(): Unit = throw UnsupportedOperationException()
+  }
+
+private fun <K, V> Map.Entry<K, V>.asReadOnlyMutableEntry(): MutableMap.MutableEntry<K, V> =
+  object : MutableMap.MutableEntry<K, V> {
+    override val key: K
+      get() = this@asReadOnlyMutableEntry.key
+
+    override val value: V
+      get() = this@asReadOnlyMutableEntry.value
+
+    override fun setValue(newValue: V): V = throw UnsupportedOperationException()
+
+    override fun equals(other: Any?): Boolean =
+      other is Map.Entry<*, *> && other.key == key && other.value == value
+
+    override fun hashCode(): Int = (key?.hashCode() ?: 0) xor (value?.hashCode() ?: 0)
+
+    override fun toString(): String = "$key=$value"
+  }

--- a/src/main/kotlin/com/salesforce/revoman/output/postman/PostmanEnvironment.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/postman/PostmanEnvironment.kt
@@ -212,7 +212,7 @@ constructor(
     )
 
   fun <T> valuesForKeysStartingWith(type: Class<T>, prefix: String): Set<T> =
-    mutableEnvCopyWithKeysStartingWith(type, prefix).mutableEnv.values.toSet()
+    valuesForKeysStartingWith(type, *arrayOf(prefix))
 
   fun <T> valuesForKeysStartingWith(type: Class<T>, vararg prefixes: String): Set<T> =
     mutableEnv.entries

--- a/src/main/kotlin/com/salesforce/revoman/output/postman/PostmanEnvironment.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/postman/PostmanEnvironment.kt
@@ -287,6 +287,10 @@ private val logger = KotlinLogging.logger {}
  * on those views throw; nothing in ReVoman mutates through them), so the per-step
  * `pm.environment.keys` access stays O(1).
  */
+// The function count comes from implementing the full MutableMap surface (get/put/remove/putAll/
+// clear/containsKey/containsValue/isEmpty) plus snapshotView + the equals/hashCode/toString Map
+// contract — an interface obligation, not decomposable, so TooManyFunctions is suppressed here.
+@Suppress("TooManyFunctions")
 internal class PersistentBackedMutableMap<V>
 private constructor(private var current: PersistentMap<String, V>) : MutableMap<String, V> {
 

--- a/src/main/kotlin/com/salesforce/revoman/output/postman/PostmanEnvironment.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/postman/PostmanEnvironment.kt
@@ -28,22 +28,30 @@ constructor(
 
   internal lateinit var currentStep: Step
 
-  // --- Ledger capture: per-step produced/consumed env keys. Keyed by Step identity so a
+  // --- Ledger capture: per-step produced/consumed env keys. Keyed by `step.path` (String) so a
   //     reused-thread env can carry multiple steps' deltas; read out when StepReport is built.
+  //     NOTE: keyed by `step.path`, NOT the whole Step — Step's data-class hashCode/equals recurse
+  //     through rawPMStep (the full request body + every JS script), so a Step-keyed map hashes the
+  //     entire step on every op. `path` is the step's unique identity already used everywhere else
+  //     by the ledger (learnedLedger keying, `ledger.steps` lookup, iterationByPath). The same Step
+  //     instance (stable `path`) is reused across iterations, so path-keying yields the IDENTICAL
+  //     union accumulation as the prior Step-keying.
   //     NOTE: NOT reset between iterations — a step executing twice (control-flow loop) accumulates
   //     the UNION of all iterations' keys. Benign for ledger learning and invisible when iterations
   //     produce the same keys. ---
-  private val producedKeysByStep: MutableMap<Step, MutableSet<String>> = mutableMapOf()
-  private val consumedKeysByStep: MutableMap<Step, MutableSet<String>> = mutableMapOf()
+  private val producedKeysByStepPath: MutableMap<String, MutableSet<String>> = mutableMapOf()
+  private val consumedKeysByStepPath: MutableMap<String, MutableSet<String>> = mutableMapOf()
 
-  fun producedKeysFor(step: Step): Set<String> = producedKeysByStep[step]?.toSet() ?: emptySet()
+  fun producedKeysFor(step: Step): Set<String> =
+    producedKeysByStepPath[step.path]?.toSet() ?: emptySet()
 
-  fun consumedKeysFor(step: Step): Set<String> = consumedKeysByStep[step]?.toSet() ?: emptySet()
+  fun consumedKeysFor(step: Step): Set<String> =
+    consumedKeysByStepPath[step.path]?.toSet() ?: emptySet()
 
   /** Record a READ of [key] during the current step (regex `{{key}}` resolved against env). */
   fun recordConsumed(key: String) {
     if (::currentStep.isInitialized) {
-      consumedKeysByStep.getOrPut(currentStep) { mutableSetOf() }.add(key)
+      consumedKeysByStepPath.getOrPut(currentStep.path) { mutableSetOf() }.add(key)
     }
   }
 
@@ -61,7 +69,7 @@ constructor(
     // line
     // both no-op on an unstepped instance — interpolating an uninitialized lateinit would throw.
     val step: Step? = if (::currentStep.isInitialized) currentStep else null
-    if (step != null) producedKeysByStep.getOrPut(step) { mutableSetOf() }.add(key)
+    if (step != null) producedKeysByStepPath.getOrPut(step.path) { mutableSetOf() }.add(key)
     logger.info {
       "pm environment variable set in Step: $step - key: $key, value: ${pprint(value)}"
     }
@@ -71,7 +79,7 @@ constructor(
   fun unset(key: String) {
     mutableEnv.remove(key)
     val step: Step? = if (::currentStep.isInitialized) currentStep else null
-    if (step != null) producedKeysByStep[step]?.remove(key)
+    if (step != null) producedKeysByStepPath[step.path]?.remove(key)
     logger.info { "pm environment variable unset through JS in Step: $step - key: $key" }
   }
 

--- a/src/main/kotlin/com/salesforce/revoman/output/postman/PostmanEnvironment.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/postman/PostmanEnvironment.kt
@@ -342,6 +342,13 @@ private constructor(private var current: PersistentMap<String, V>) : MutableMap<
         override val size: Int
           get() = current.size
 
+        // Delegate membership to the backing's O(1) containsKey. Without this, AbstractCollection's
+        // default contains/containsAll do a linear iterator scan — and the ledger warm path calls
+        // `pm.environment.keys.containsAll(produces)` per step (ReVoman.kt), which would be O(E)
+        // per
+        // key (the O(M*E) the LinkedHashMap keySet avoided and E2 must preserve).
+        override fun contains(element: String): Boolean = current.containsKey(element)
+
         override fun iterator(): MutableIterator<String> =
           current.keys.iterator().asReadOnlyMutable()
 
@@ -353,6 +360,8 @@ private constructor(private var current: PersistentMap<String, V>) : MutableMap<
       object : AbstractMutableCollection<V>() {
         override val size: Int
           get() = current.size
+
+        override fun contains(element: V): Boolean = current.containsValue(element)
 
         override fun iterator(): MutableIterator<V> = current.values.iterator().asReadOnlyMutable()
 

--- a/src/main/kotlin/com/salesforce/revoman/output/postman/PostmanEnvironment.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/postman/PostmanEnvironment.kt
@@ -65,6 +65,21 @@ constructor(
     moshiReVoman.toPrettyJson(fromMap(mutableEnv, moshiReVoman))
   }
 
+  /**
+   * A point-in-time snapshot of this environment. When the backing is a
+   * [PersistentBackedMutableMap] this is O(1) — the snapshot shares the current immutable
+   * persistent map and later writes to this (live) env install a new map, leaving the snapshot
+   * untouched. Falls back to a defensive copy for a plain map backing (e.g.
+   * collectionVariables/globals or test-constructed envs), preserving the historical
+   * `copy(mutableEnv = mutableEnv.toMutableMap())` semantics.
+   */
+  fun o1Snapshot(): PostmanEnvironment<ValueT> =
+    copy(
+      mutableEnv =
+        (mutableEnv as? PersistentBackedMutableMap<ValueT>)?.snapshotView()
+          ?: mutableEnv.toMutableMap()
+    )
+
   fun set(key: String, value: ValueT) {
     mutableEnv[key] = value
     // `currentStep` is a lateinit set only on the step-bound `environment` instance; stores like

--- a/src/main/kotlin/com/salesforce/revoman/output/report/StepReport.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/report/StepReport.kt
@@ -149,7 +149,7 @@ internal constructor(
     ): StepReport =
       StepReport(
         step = step,
-        pmEnvSnapshot = env.copy(mutableEnv = env.mutableEnv.toMutableMap()),
+        pmEnvSnapshot = env.o1Snapshot(),
         envVars = StepEnvVars(produced = produced, consumed = consumed),
       )
 
@@ -168,7 +168,7 @@ internal constructor(
     ): StepReport =
       StepReport(
         step = step,
-        pmEnvSnapshot = env.copy(mutableEnv = env.mutableEnv.toMutableMap()),
+        pmEnvSnapshot = env.o1Snapshot(),
         iteration = iteration,
         requestSkippedFlag = true,
       )

--- a/src/main/kotlin/com/salesforce/revoman/output/report/TxnInfo.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/report/TxnInfo.kt
@@ -68,7 +68,7 @@ constructor(
     }
       as PojoT?
 
-  fun containsHeader(key: String): Boolean = httpMsg.headers.toMap().containsKey(key)
+  fun containsHeader(key: String): Boolean = httpMsg.headers.any { it.first == key }
 
   fun containsHeader(key: String, value: String): Boolean = httpMsg.headers.contains(key to value)
 

--- a/src/test/kotlin/com/salesforce/revoman/internal/exe/PickHooksMaterializeTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/exe/PickHooksMaterializeTest.kt
@@ -124,8 +124,33 @@ class PickHooksMaterializeTest {
     failure shouldBe null
     // Both hooks were picked and the count was recorded on the step.
     currentStepReport.step.postStepHookCount shouldBe 2
-    // The pick predicate ran EXACTLY once per configured hook (2), not 3-4x from a re-scanned
-    // Sequence.
+    // The pick predicate ran EXACTLY once per configured hook (2), not the ~7x a re-scanned
+    // Sequence
+    // produced before D2.
     predicateInvocations.get() shouldBe 2
+  }
+
+  @Test
+  fun `pre-step hook execution short-circuits - a hook after a failing one does not run`() {
+    // Guards that D2's Sequence->List of the PICK did NOT make hook EXECUTION eager: the consumer
+    // still runs picked hooks lazily and stops at the first failure, so a later hook's accept()
+    // (with its side effects) must NOT fire once an earlier hook has failed. Pre-D2 behavior.
+    val alwaysPick = PreTxnStepPick { _, _, _ -> true }
+    val secondHookRan = AtomicInteger(0)
+    val failingHook = HookConfig.StepHook.PreStepHook { _, _, _ -> error("boom from first hook") }
+    val secondHook = HookConfig.StepHook.PreStepHook { _, _, _ -> secondHookRan.incrementAndGet() }
+    val kick =
+      Kick.configure()
+        .templatePath("unused")
+        .hooks(HookConfig.pre(alwaysPick, failingHook), HookConfig.pre(alwaysPick, secondHook))
+        .off()
+    val currentStep = Step(index = "1", rawPMStep = Item(name = "short-circuit-step"))
+
+    val failure = preStepHookExe(currentStep, kick, requestInfo(), rundown())
+
+    // The first hook failed -> a failure is returned...
+    (failure != null) shouldBe true
+    // ...and the second hook's accept() NEVER ran (lazy short-circuit preserved).
+    secondHookRan.get() shouldBe 0
   }
 }

--- a/src/test/kotlin/com/salesforce/revoman/internal/exe/PickHooksMaterializeTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/exe/PickHooksMaterializeTest.kt
@@ -153,4 +153,41 @@ class PickHooksMaterializeTest {
     // ...and the second hook's accept() NEVER ran (lazy short-circuit preserved).
     secondHookRan.get() shouldBe 0
   }
+
+  @Test
+  fun `post-step hook execution short-circuits - a hook after a failing one does not run`() {
+    // Same guard as the pre path but for postStepHookExe (independently edited, identical
+    // structure):
+    // a picked post-hook after a failing one must NOT run its accept() side effects.
+    val alwaysPick = PostTxnStepPick { _, _ -> true }
+    val secondHookRan = AtomicInteger(0)
+    val failingHook =
+      HookConfig.StepHook.PostStepHook { _, _ -> error("boom from first post hook") }
+    val secondHook = HookConfig.StepHook.PostStepHook { _, _ -> secondHookRan.incrementAndGet() }
+    val kick =
+      Kick.configure()
+        .templatePath("unused")
+        .hooks(HookConfig.post(alwaysPick, failingHook), HookConfig.post(alwaysPick, secondHook))
+        .off()
+    val responseInfo: TxnInfo<Response> =
+      TxnInfo(
+        txnObjType = String::class.java,
+        txnObj = "fakeResponse",
+        httpMsg = Response(OK),
+        moshiReVoman = moshiReVoman,
+      )
+    val currentStepReport =
+      StepReport(
+        Step(index = "1", rawPMStep = Item(name = "post-short-circuit-step")),
+        Right(requestInfo()),
+        null,
+        Right(responseInfo),
+        pmEnvSnapshot = PostmanEnvironment(),
+      )
+
+    val failure = postStepHookExe(kick, currentStepReport, rundown())
+
+    (failure != null) shouldBe true
+    secondHookRan.get() shouldBe 0
+  }
 }

--- a/src/test/kotlin/com/salesforce/revoman/internal/exe/PickHooksMaterializeTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/exe/PickHooksMaterializeTest.kt
@@ -1,0 +1,131 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.exe
+
+import arrow.core.Either.Right
+import com.salesforce.revoman.input.config.HookConfig
+import com.salesforce.revoman.input.config.Kick
+import com.salesforce.revoman.input.config.StepPick.PostTxnStepPick
+import com.salesforce.revoman.input.config.StepPick.PreTxnStepPick
+import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
+import com.salesforce.revoman.internal.postman.template.Item
+import com.salesforce.revoman.internal.postman.template.Request
+import com.salesforce.revoman.internal.postman.template.Url
+import com.salesforce.revoman.output.Rundown
+import com.salesforce.revoman.output.postman.PostmanEnvironment
+import com.salesforce.revoman.output.report.Step
+import com.salesforce.revoman.output.report.StepReport
+import com.salesforce.revoman.output.report.TxnInfo
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.atomic.AtomicInteger
+import org.http4k.core.Method.POST
+import org.http4k.core.Response
+import org.http4k.core.Status.Companion.OK
+import org.junit.jupiter.api.Test
+
+/**
+ * Locks the D2 invariant: the pick predicate of each configured pre/post step hook is evaluated
+ * EXACTLY ONCE per step, and the picked-hook count set on the step is correct.
+ *
+ * Rationale: the boundary functions [pickPreStepHooks]/[pickPostStepHooks] are `private`, so this
+ * exercises them through the same-package `internal` consumers [preStepHookExe]/[postStepHookExe]
+ * with a real [Kick]. Each hook's [PreTxnStepPick]/[PostTxnStepPick] increments a shared
+ * [AtomicInteger]; with two always-true hooks the filter must run the predicate exactly twice (once
+ * per hook).
+ *
+ * On the pre-D2 `Sequence`-returning implementation the terminal `.also { it.iterator().hasNext();
+ * it.count(); it.count() }` plus the downstream `.map { }.firstOrNull { }` re-evaluate the lazy
+ * filter multiple times, so the counter overshoots (observed > 2). Materializing to a `List` once
+ * makes the filter eager, so the predicate runs exactly once per hook.
+ */
+class PickHooksMaterializeTest {
+
+  private val moshiReVoman = initMoshi()
+
+  private fun requestInfo(): TxnInfo<org.http4k.core.Request> {
+    val rawRequest =
+      Request(method = POST.toString(), url = Url("https://overfullstack.github.io/"))
+    return TxnInfo(
+      txnObjType = String::class.java,
+      txnObj = "fakeRequest",
+      httpMsg = rawRequest.toHttpRequest(moshiReVoman),
+      moshiReVoman = moshiReVoman,
+    )
+  }
+
+  private fun rundown(): Rundown =
+    Rundown(
+      mutableEnv = PostmanEnvironment(),
+      haltOnFailureOfTypeExcept = emptyMap(),
+      providedStepsToExecuteCount = 0,
+    )
+
+  @Test
+  fun `pre-step hook pick predicate runs exactly once per configured hook`() {
+    val predicateInvocations = AtomicInteger(0)
+    val countingPick = PreTxnStepPick { _, _, _ ->
+      predicateInvocations.incrementAndGet()
+      true
+    }
+    val noOpHook = HookConfig.StepHook.PreStepHook { _, _, _ -> }
+    val kick =
+      Kick.configure()
+        .templatePath("unused")
+        .hooks(HookConfig.pre(countingPick, noOpHook), HookConfig.pre(countingPick, noOpHook))
+        .off()
+    val currentStep = Step(index = "1", rawPMStep = Item(name = "pre-hook-step"))
+
+    val failure = preStepHookExe(currentStep, kick, requestInfo(), rundown())
+
+    failure shouldBe null
+    // Both hooks were picked and the count was recorded on the step.
+    currentStep.preStepHookCount shouldBe 2
+    // The pick predicate ran EXACTLY once per configured hook (2), not 3-4x from a re-scanned
+    // Sequence.
+    predicateInvocations.get() shouldBe 2
+  }
+
+  @Test
+  fun `post-step hook pick predicate runs exactly once per configured hook`() {
+    val predicateInvocations = AtomicInteger(0)
+    val countingPick = PostTxnStepPick { _, _ ->
+      predicateInvocations.incrementAndGet()
+      true
+    }
+    val noOpHook = HookConfig.StepHook.PostStepHook { _, _ -> }
+    val kick =
+      Kick.configure()
+        .templatePath("unused")
+        .hooks(HookConfig.post(countingPick, noOpHook), HookConfig.post(countingPick, noOpHook))
+        .off()
+    val responseInfo: TxnInfo<Response> =
+      TxnInfo(
+        txnObjType = String::class.java,
+        txnObj = "fakeResponse",
+        httpMsg = Response(OK),
+        moshiReVoman = moshiReVoman,
+      )
+    val currentStepReport =
+      StepReport(
+        Step(index = "1", rawPMStep = Item(name = "post-hook-step")),
+        Right(requestInfo()),
+        null,
+        Right(responseInfo),
+        pmEnvSnapshot = PostmanEnvironment(),
+      )
+
+    val failure = postStepHookExe(kick, currentStepReport, rundown())
+
+    failure shouldBe null
+    // Both hooks were picked and the count was recorded on the step.
+    currentStepReport.step.postStepHookCount shouldBe 2
+    // The pick predicate ran EXACTLY once per configured hook (2), not 3-4x from a re-scanned
+    // Sequence.
+    predicateInvocations.get() shouldBe 2
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/internal/exe/PrepareHttpClientTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/exe/PrepareHttpClientTest.kt
@@ -1,0 +1,28 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.exe
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class PrepareHttpClientTest {
+  @Test
+  fun `secure variant returns the same memoized handler across calls`() {
+    assertThat(prepareHttpClient(false)).isSameInstanceAs(prepareHttpClient(false))
+  }
+
+  @Test
+  fun `insecure variant returns the same memoized handler across calls`() {
+    assertThat(prepareHttpClient(true)).isSameInstanceAs(prepareHttpClient(true))
+  }
+
+  @Test
+  fun `secure and insecure are distinct handlers`() {
+    assertThat(prepareHttpClient(false)).isNotSameInstanceAs(prepareHttpClient(true))
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/internal/exe/UnmarshallResponseBodyTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/exe/UnmarshallResponseBodyTest.kt
@@ -1,0 +1,86 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.exe
+
+import arrow.core.Either.Right
+import com.salesforce.revoman.input.config.Kick
+import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
+import com.salesforce.revoman.internal.postman.template.Item
+import com.salesforce.revoman.internal.postman.template.Request
+import com.salesforce.revoman.internal.postman.template.Url
+import com.salesforce.revoman.output.Rundown
+import com.salesforce.revoman.output.postman.PostmanEnvironment
+import com.salesforce.revoman.output.report.Step
+import com.salesforce.revoman.output.report.StepReport
+import com.salesforce.revoman.output.report.TxnInfo
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.http4k.core.Method.POST
+import org.http4k.core.Response
+import org.http4k.core.Status.Companion.OK
+import org.junit.jupiter.api.Test
+
+class UnmarshallResponseBodyTest {
+
+  private val moshiReVoman = initMoshi()
+
+  private fun reportFor(response: Response): StepReport {
+    val rawRequest = Request(method = POST.toString(), url = Url("https://test.example.com/"))
+    val requestInfo =
+      TxnInfo(
+        txnObjType = String::class.java,
+        txnObj = "fakeRequest",
+        httpMsg = rawRequest.toHttpRequest(moshiReVoman),
+        moshiReVoman = moshiReVoman,
+      )
+    val responseInfo = TxnInfo(httpMsg = response, moshiReVoman = moshiReVoman)
+    return StepReport(
+      Step("1", Item(request = rawRequest)),
+      Right(requestInfo),
+      responseInfo = Right(responseInfo),
+      pmEnvSnapshot = PostmanEnvironment(),
+    )
+  }
+
+  private fun emptyRundown(): Rundown =
+    Rundown(
+      stepReports = emptyList(),
+      mutableEnv = PostmanEnvironment(),
+      haltOnFailureOfTypeExcept = emptyMap(),
+      providedStepsToExecuteCount = 0,
+    )
+
+  @Test
+  fun `JSON body unmarshals to a Map`() {
+    val kick = Kick.configure().off()
+    val response = Response(OK).header("Content-Type", "application/json").body("""{"a":1}""")
+    val result = unmarshallResponse(kick, moshiReVoman, reportFor(response), emptyRundown())
+    result.shouldBeInstanceOf<Right<TxnInfo<Response>>>()
+    val txnObj = result.value.txnObj
+    txnObj.shouldBeInstanceOf<Map<*, *>>()
+    txnObj.containsKey("a") shouldBe true
+  }
+
+  @Test
+  fun `blank body yields isJson false`() {
+    val kick = Kick.configure().off()
+    val response = Response(OK).header("Content-Type", "application/json").body("")
+    val result = unmarshallResponse(kick, moshiReVoman, reportFor(response), emptyRundown())
+    result.shouldBeInstanceOf<Right<TxnInfo<Response>>>()
+    result.value.isJson shouldBe false
+  }
+
+  @Test
+  fun `non-JSON content-type yields isJson false`() {
+    val kick = Kick.configure().off()
+    val response = Response(OK).header("Content-Type", "text/plain").body("hello")
+    val result = unmarshallResponse(kick, moshiReVoman, reportFor(response), emptyRundown())
+    result.shouldBeInstanceOf<Right<TxnInfo<Response>>>()
+    result.value.isJson shouldBe false
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/output/postman/EnvSnapshotImmutabilityTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/output/postman/EnvSnapshotImmutabilityTest.kt
@@ -1,0 +1,31 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.output.postman
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class EnvSnapshotImmutabilityTest {
+  @Test
+  fun `snapshot is a point-in-time view - later env writes do not change it`() {
+    val env = PostmanEnvironment<Any?>(PersistentBackedMutableMap(mapOf("a" to 1)))
+    val snapshot = env.o1Snapshot()
+    env["b"] = 2 // mutate live env AFTER the snapshot (regex write-back path)
+    env.putAll(mapOf("c" to 3))
+    assertThat(snapshot.mutableEnv).containsExactlyEntriesIn(mapOf("a" to 1))
+    assertThat(env.mutableEnv).containsExactlyEntriesIn(mapOf("a" to 1, "b" to 2, "c" to 3))
+  }
+
+  @Test
+  fun `o1Snapshot preserves value including nulls`() {
+    val env = PostmanEnvironment<Any?>(PersistentBackedMutableMap(mapOf("n" to null)))
+    val snapshot = env.o1Snapshot()
+    assertThat(snapshot.containsKey("n")).isTrue()
+    assertThat(snapshot["n"]).isNull()
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/output/postman/PersistentBackedMutableMapTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/output/postman/PersistentBackedMutableMapTest.kt
@@ -1,0 +1,60 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.output.postman
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class PersistentBackedMutableMapTest {
+  @Test
+  fun `put get remove behave like a map`() {
+    val m = PersistentBackedMutableMap<Any?>()
+    m["a"] = 1
+    m["b"] = 2
+    assertThat(m["a"]).isEqualTo(1)
+    assertThat(m.size).isEqualTo(2)
+    m.remove("a")
+    assertThat(m.containsKey("a")).isFalse()
+  }
+
+  @Test
+  fun `supports null values`() {
+    val m = PersistentBackedMutableMap<Any?>()
+    m["k"] = null
+    assertThat(m.containsKey("k")).isTrue()
+    assertThat(m["k"]).isNull()
+  }
+
+  @Test
+  fun `snapshot is an O(1) point-in-time view unaffected by later writes`() {
+    val m = PersistentBackedMutableMap<Any?>()
+    m["a"] = 1
+    val snap = m.snapshotView()
+    m["b"] = 2 // mutate the live map AFTER snapshot
+    assertThat(snap).containsExactlyEntriesIn(mapOf("a" to 1))
+    assertThat(m).containsExactlyEntriesIn(mapOf("a" to 1, "b" to 2))
+  }
+
+  @Test
+  fun `equals and hashCode follow Map contract`() {
+    val m = PersistentBackedMutableMap<Any?>()
+    m["a"] = 1
+    assertThat(m).isEqualTo(mapOf("a" to 1))
+    assertThat(m.hashCode()).isEqualTo(mapOf("a" to 1).hashCode())
+  }
+
+  @Test
+  fun `keys view reflects live state without copying`() {
+    val m = PersistentBackedMutableMap<Any?>()
+    m["a"] = 1
+    val keys = m.keys
+    m["b"] = 2
+    // read-through view: sees the new key
+    assertThat(keys).containsExactly("a", "b")
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/output/postman/PersistentBackedMutableMapTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/output/postman/PersistentBackedMutableMapTest.kt
@@ -57,4 +57,20 @@ class PersistentBackedMutableMapTest {
     // read-through view: sees the new key
     assertThat(keys).containsExactly("a", "b")
   }
+
+  @Test
+  fun `keys and values view membership delegates to the backing (not a scan)`() {
+    // The ledger warm path calls pm.environment.keys.containsAll(produces) per step; the keys view
+    // must answer contains via the backing's O(1) containsKey, not AbstractCollection's linear
+    // scan.
+    val m = PersistentBackedMutableMap<Any?>()
+    m["a"] = 1
+    m["b"] = 2
+    assertThat(m.keys.contains("a")).isTrue()
+    assertThat(m.keys.contains("missing")).isFalse()
+    assertThat(m.keys.containsAll(listOf("a", "b"))).isTrue()
+    assertThat(m.keys.containsAll(listOf("a", "missing"))).isFalse()
+    assertThat(m.values.contains(1)).isTrue()
+    assertThat(m.values.contains(999)).isFalse()
+  }
 }

--- a/src/test/kotlin/com/salesforce/revoman/output/postman/PostmanEnvironmentPathKeyTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/output/postman/PostmanEnvironmentPathKeyTest.kt
@@ -1,0 +1,42 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.output.postman
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.internal.postman.template.Item
+import com.salesforce.revoman.output.report.Step
+import org.junit.jupiter.api.Test
+
+class PostmanEnvironmentPathKeyTest {
+  @Test
+  fun `two set()s on the same step accumulate the union (path-keyed)`() {
+    val env = PostmanEnvironment<Any?>()
+    val step = Step(index = "1", rawPMStep = Item(name = "create-sa"))
+    env.currentStep = step
+    env.set("saId1", "a")
+    env.set("saId2", "b")
+    assertThat(env.producedKeysFor(step)).containsExactly("saId1", "saId2")
+  }
+
+  @Test
+  fun `producedKeysFor resolves by path, not Step-equality (same path, different index)`() {
+    val env = PostmanEnvironment<Any?>()
+    val step1 = Step(index = "1", rawPMStep = Item(name = "create-sa"))
+    env.currentStep = step1
+    env.set("saId1", "a")
+    // A Step with the SAME path (root step path == name == "create-sa") but a DIFFERENT index, so
+    // it is NOT Step-equal to step1 (Step's data-class equals covers index/rawPMStep/parentFolder).
+    // Under the old Step-keyed maps this lookup would MISS (empty); under path-keying it resolves.
+    // This is the assertion that actually distinguishes path-keying from Step-keying (would be RED
+    // on the pre-D4 code), guarding against a silent revert.
+    val samePathDifferentIndex = Step(index = "2", rawPMStep = Item(name = "create-sa"))
+    assertThat(samePathDifferentIndex.path).isEqualTo(step1.path)
+    assertThat(samePathDifferentIndex).isNotEqualTo(step1)
+    assertThat(env.producedKeysFor(samePathDifferentIndex)).containsExactly("saId1")
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/output/postman/ValuesForKeysStartingWithTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/output/postman/ValuesForKeysStartingWithTest.kt
@@ -1,0 +1,33 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.output.postman
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class ValuesForKeysStartingWithTest {
+  private val env =
+    PostmanEnvironment<Any?>(
+      mutableMapOf("saId1" to "a", "saId2" to "b", "other" to "c", "num" to 1)
+    )
+
+  @Test
+  fun `single prefix returns typed values for matching keys`() {
+    assertThat(env.valuesForKeysStartingWith(String::class.java, "saId")).containsExactly("a", "b")
+  }
+
+  @Test
+  fun `single prefix filters by type`() {
+    assertThat(env.valuesForKeysStartingWith(Integer::class.java, "num")).containsExactly(1)
+  }
+
+  @Test
+  fun `single prefix no match is empty`() {
+    assertThat(env.valuesForKeysStartingWith(String::class.java, "zzz")).isEmpty()
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/output/report/TxnInfoContainsHeaderTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/output/report/TxnInfoContainsHeaderTest.kt
@@ -1,0 +1,39 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.output.report
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.internal.json.MoshiReVoman.Companion.initMoshi
+import org.http4k.core.Method.GET
+import org.http4k.core.Request
+import org.junit.jupiter.api.Test
+
+class TxnInfoContainsHeaderTest {
+  private val moshiReVoman = initMoshi()
+
+  private fun txn(request: Request): TxnInfo<Request> =
+    TxnInfo(httpMsg = request, moshiReVoman = moshiReVoman)
+
+  @Test
+  fun `containsHeader true when header present`() {
+    val info = txn(Request(GET, "https://x.y/z").header("X-Trace", "abc"))
+    assertThat(info.containsHeader("X-Trace")).isTrue()
+  }
+
+  @Test
+  fun `containsHeader false when header absent`() {
+    val info = txn(Request(GET, "https://x.y/z").header("X-Trace", "abc"))
+    assertThat(info.containsHeader("X-Missing")).isFalse()
+  }
+
+  @Test
+  fun `containsHeader is case-sensitive on the key (preserves toMap semantics)`() {
+    val info = txn(Request(GET, "https://x.y/z").header("X-Trace", "abc"))
+    assertThat(info.containsHeader("x-trace")).isFalse()
+  }
+}


### PR DESCRIPTION
## What

WT-4 (final worktree) of the ReVoman perf-improvements effort: six behavior-preserving exe-engine/output micro-fixes, then back the Postman env with a persistent map so each per-step snapshot is an O(1) structural share.

| ID | Change | File |
|----|--------|------|
| **D5** | `TxnInfo.containsHeader` avoids `headers.toMap()` (uses `headers.any { it.first == key }` — case-sensitive, matches old semantics) | `TxnInfo.kt` |
| **D3** | `unmarshallResponse` decodes body + content-type once (hoisted vals) | `UnmarshallResponse.kt` |
| **D1** | Memoize one Apache http client per TLS variant (`by lazy`) — fixes a per-request client leak; auth is per-Request | `HttpRequest.kt` |
| **D2** | Materialize picked pre/post hooks to a `List` once (the pick predicate was re-running ~7×/step) | `PreStepHook.kt`, `PostStepHook.kt` |
| **D6** | Single-prefix `valuesForKeysStartingWith` delegates to the vararg sibling (single pass) | `PostmanEnvironment.kt` |
| **D4** | Key the two private ledger-capture maps by `step.path` instead of the whole `Step` (avoids a deep hash through `rawPMStep`; `path` is the ledger's existing identity) | `PostmanEnvironment.kt` |
| **E2a** | `PersistentBackedMutableMap` — a `MutableMap` over an immutable `PersistentMap`, swap-on-write, O(1) `snapshotView`, non-copying read-through views | `PostmanEnvironment.kt` |
| **E2b** | Back the live env with it (seeded from `ReVoman.kt`) + `o1Snapshot()` makes each `pmEnvSnapshot` an O(1) share | `ReVoman.kt`, `StepReport.kt`, `PostmanEnvironment.kt` |

Plus `EnvAccumBenchmark` (JMH, measured): 800-step per-step snapshot cost **29.9µs → 13.7µs** (O(M·E) → O(M)).

## Correctness

- **E2 immutability** is the crux: the live env swaps in a new `PersistentMap` on every write, so a captured `o1Snapshot()` is frozen — later env writes (regex set-back, `env[k]=v`, `putAll`) can't retroactively mutate a prior per-step snapshot. Locked by `EnvSnapshotImmutabilityTest`. Plain-backed envs (test-constructed, `collectionVariables`/`globals`) hit a defensive-copy fallback — unchanged behavior. Iteration order preserved (both backings insertion-ordered), so VERBOSE JSON is byte-stable.
- **D4** keeps the union-across-loop-iterations behavior; the guard test uses a *same-path, different-index* Step (not `Step`-equal) — verified RED under the old Step-keying, GREEN under path-keying.
- **D2** materializes only the *pick* (predicate runs once); a whole-branch review caught that the naive `List` also made hook *execution* eager on the failure path — fixed with `.asSequence()` in the consumers so a hook after a failing one still does not run (pre-D2 lazy short-circuit), with a regression test.
- Every `PostmanEnvironment` public signature, its primary-ctor shape, and its `IS-A MutableMap`-ness are unchanged, so WT-1/WT-3 callers are unaffected.

## ⚠️ Cross-worktree note (WT-1, already merged)

WT-1's `syncProgress` matches the current step as the last report for the same `Step` in `pm.rundown.stepReports`, relying on `ReVoman.kt`'s rundown seed ordering. WT-4's `ReVoman.kt` edits touch **only** the env seed + the `pmEnvSnapshot` capture — the rundown seed and stepReports ordering are byte-for-byte untouched, so that coupling holds.

## Tests

- Unit `test`: 467 passing, 0 failures. `build` (detekt + assembly): clean (a scoped `@Suppress("TooManyFunctions")` on the adapter — 12 fns = the `MutableMap` interface surface).
- `integrationTest`: passes on CI. (Locally, restful-api.dev returns HTTP 405 env-quota flakes — not regressions; CI has fresh quota + the retry plugin.)

## Scope

Touches only the owned source files (`ReVoman.kt`, `HttpRequest.kt`, `PreStepHook.kt`, `PostStepHook.kt`, `UnmarshallResponse.kt`, `PostmanEnvironment.kt`, `TxnInfo.kt`, `StepReport.kt`; `Polling.kt` benefits transitively, untouched) + test files + one benchmark. `PostmanSDK.kt` (WT-1) / `RegexReplacer.kt` (WT-3) untouched. Branched off master (includes WT-1/2/3).