### PR TITLE
feat: Runbook layer — make the test's Postman-collection chain legible

### DIFF
--- a/docs/superpowers/plans/2026-07-13-runbook-legibility.md
+++ b/docs/superpowers/plans/2026-07-13-runbook-legibility.md
@@ -1,0 +1,1493 @@
+# Runbook Legibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a ReVoman test's Postman-collection chain legible from one declaration — surfaced in the test code (a `Runbook` DSL), an overhauled grouped log, and an on-demand mermaid/markdown view.
+
+**Architecture:** A thin `Runbook` layer wraps each `Kick` as a narrated `RunbookStep` (intent/phase/produces/consumes/assertAfter). A `revUp(Runbook)` overload drives a fold that mirrors the existing multi-kick `revUp(List<Kick>)` env threading exactly, interleaving per-step contract checks + `assertAfter` and emitting coarse log events that bracket the existing per-request events. `Kick` is untouched; the existing `revUp` overloads stay.
+
+**Tech Stack:** Kotlin (JVM 21), Java interop (`fun interface`, `Consumer`, `@JvmStatic`), Kotest/JUnit5 + Google Truth, `com.sun.net.httpserver.HttpServer` for network-free E2E.
+
+## Global Constraints
+
+- JDK 21+; Kotlin four-space indent; `when` over if-else chains (STYLE.md).
+- Functional style: state transformation over mutation; `fold`/`map`/`firstOrNull` over loops; monadic ops over `when` on `Either`/`Result` (STYLE.md).
+- Copyright header (Apache 2.0, `Copyright (c) 2023, Salesforce, Inc.`) at the top of every new `.kt` file — copy verbatim from `KickDef.kt:1-7`.
+- `Kick` (`KickDef.kt`) MUST NOT be modified. Existing `revUp(vararg Kick)` / `revUp(List<Kick>)` MUST remain behavior-identical.
+- New public APIs get KDoc (AGENTS.md). Add logging for new features (AGENTS.md).
+- Run `./gradlew spotlessApply` before every commit; verify with `./gradlew test` (unit). The 6 restful-api.dev integrationTest failures are a known env quota flake, NOT regressions.
+- Reuse the existing sink pipeline (`RunLogSink`/`StepEvent`/`RevomanLog.event`) — do NOT add a new sink type.
+
+## Existing symbols this plan builds on (verbatim signatures)
+
+- `com.salesforce.revoman.ReVoman` — `object`. `revUp(kick: Kick): Rundown`; `revUp(kicks: List<Kick>, postExeHook, dynamicEnvironment): List<Rundown>`; multi-kick fold at `ReVoman.kt:89-103`.
+- `com.salesforce.revoman.output.Rundown` — `data class`; `@JvmField val mutableEnv: PostmanEnvironment<Any?>`; `val immutableEnv: Map<String, Any?>`; `val firstUnIgnoredUnsuccessfulStepReport: StepReport?`; `@JvmField val stepReports: List<StepReport>`.
+- `com.salesforce.revoman.output.postman.PostmanEnvironment<ValueT>` — `data class ... : MutableMap<String, ValueT> by mutableEnv`; so `containsKey(k)`, `keys`, `get(k)` work directly; `fun getAsString(key: String?): String?`.
+- `com.salesforce.revoman.input.config.Kick` — Immutable; `Kick.configure().templatePath(..)...off()`; `fun dynamicEnvironment(): Map<String, Any?>`; `fun overrideDynamicEnvironment(Map): Kick` (Immutables `override*` from `@Value.Style`).
+- `com.salesforce.revoman.output.log.StepEvent` — `sealed interface`; `val path: String`; existing subtypes `StepStarted`, `StepFinished`, `LedgerSkipped`, `RequestSkipped`, `Jumped`, `RunStopped`, `LoopBudgetExceeded`; `enum class Outcome { SUCCESS, FAILED, SKIPPED }`.
+- `com.salesforce.revoman.output.log.RunLogSink` — `interface`; `fun event(event: StepEvent)`; `object NoOp`.
+- `com.salesforce.revoman.output.log.ConsoleRunLogSink` — `class ConsoleRunLogSink(out: PrintStream)`; `private fun render(event: StepEvent): String`; `companion object { @JvmField val DEFAULT }`.
+- `com.salesforce.revoman.internal.log.RevomanLog` — `internal object`; `fun event(event: StepEvent)` (safe, swallows sink errors).
+- Test harness pattern: loopback `HttpServer` + `pm-templates/v3/cf-ledger-jump`, see `MultiKickEnvTypesE2ETest.kt:58-76`.
+
+---
+
+### Task 1: Data model — `Phase`, `StepAssertion`, `StepSpec`, `RunbookStep`
+
+**Files:**
+- Create: `src/main/kotlin/com/salesforce/revoman/input/config/RunbookStep.kt`
+- Test: `src/test/kotlin/com/salesforce/revoman/input/config/StepSpecTest.kt`
+
+**Interfaces:**
+- Consumes: `Kick`, `Rundown`, `PostmanEnvironment` (existing).
+- Produces:
+  - `enum class Phase { SETUP, SEED, ACT, ASSERT, CLEANUP }`
+  - `fun interface StepAssertion { fun assertStep(rundown: Rundown, env: PostmanEnvironment<Any?>) }`
+  - `class StepSpec` — mutable spec serving BOTH the Kotlin `step { }` receiver and the Java `Consumer<StepSpec>`. Fields: `var intent: String`, `var phase: Phase`, `var kick: Kick?` (default null). Fluent methods (each returns `StepSpec`): `consumes(vararg keys: String)`, `produces(vararg keys: String)`, `produces(keyToValue: Map<String, String?>)`, `produces(pair: Pair<String, String?>)`, `underTest()`, `assertAfter(assertion: StepAssertion)`. `fun build(): RunbookStep`.
+  - `data class RunbookStep(val intent: String, val phase: Phase, val kick: Kick, val consumes: Set<String>, val produces: Map<String, String?>, val underTest: Boolean, val assertAfter: StepAssertion?)`
+
+**Design note:** This model uses Kotlin data class + a mutable `StepSpec` builder rather than the Immutables convention used by `Kick`, because (a) `assertAfter` is a lambda (awkward in Immutables) and (b) one `StepSpec` must serve both the Kotlin lambda-with-receiver and the Java `Consumer` fluent style. Note this deviation in the file's KDoc.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.input.config
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class StepSpecTest {
+    private fun anyKick(): Kick = Kick.configure().templatePath("pm-templates/v3/cf-stop").off()
+
+    @Test
+    fun `build snapshots spec into an immutable RunbookStep`() {
+        val step =
+            StepSpec()
+                .apply {
+                    intent = "seed fixture"
+                    phase = Phase.SEED
+                    kick = anyKick()
+                }
+                .consumes("authToken")
+                .produces("accountId", "shiftIds")
+                .build()
+        assertThat(step.intent).isEqualTo("seed fixture")
+        assertThat(step.phase).isEqualTo(Phase.SEED)
+        assertThat(step.consumes).containsExactly("authToken")
+        assertThat(step.produces.keys).containsExactly("accountId", "shiftIds")
+        assertThat(step.produces.values.all { it == null }).isTrue()
+        assertThat(step.underTest).isFalse()
+        assertThat(step.assertAfter).isNull()
+    }
+
+    @Test
+    fun `produces with values and underTest are captured`() {
+        val step =
+            StepSpec()
+                .apply {
+                    intent = "act"
+                    phase = Phase.ACT
+                    kick = anyKick()
+                }
+                .underTest()
+                .produces("schedulingStatus" to "Success")
+                .assertAfter { _, _ -> }
+                .build()
+        assertThat(step.underTest).isTrue()
+        assertThat(step.produces).containsEntry("schedulingStatus", "Success")
+        assertThat(step.assertAfter).isNotNull()
+    }
+
+    @Test
+    fun `build without a kick fails fast`() {
+        val ex = assertThrows<IllegalStateException> {
+            StepSpec().apply { intent = "no kick"; phase = Phase.SETUP }.build()
+        }
+        assertThat(ex).hasMessageThat().contains("kick")
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew test --tests "com.salesforce.revoman.input.config.StepSpecTest"`
+Expected: FAIL — unresolved references `StepSpec`, `Phase`, `RunbookStep`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `RunbookStep.kt` (with the copyright header). Implement:
+
+```kotlin
+package com.salesforce.revoman.input.config
+
+import com.salesforce.revoman.output.Rundown
+import com.salesforce.revoman.output.postman.PostmanEnvironment
+
+/** The story phase a [RunbookStep] belongs to; drives log grouping. Mirrors the comment blocks
+ *  that today separate setup/seed/act config constants. */
+enum class Phase {
+    SETUP,
+    SEED,
+    ACT,
+    ASSERT,
+    CLEANUP,
+}
+
+/** A per-step assertion run after a step's [Rundown] is produced; receives that step's rundown and
+ *  the accumulated env. A thrown [AssertionError] halts the runbook. Complementary to the contract
+ *  checks and to the whole-run `postExeHook`. */
+fun interface StepAssertion {
+    fun assertStep(rundown: Rundown, env: PostmanEnvironment<Any?>)
+}
+
+/** Mutable builder serving BOTH the Kotlin `step { }` receiver DSL and the Java
+ *  `Consumer<StepSpec>` configurator. Snapshot into an immutable [RunbookStep] via [build].
+ *  Deviates from the Immutables convention used by [Kick] because [assertAfter] is a lambda and one
+ *  spec must serve both language front doors. */
+class StepSpec {
+    var intent: String = ""
+    var phase: Phase = Phase.SETUP
+    var kick: Kick? = null
+
+    private val consumes: MutableSet<String> = linkedSetOf()
+    private val produces: MutableMap<String, String?> = linkedMapOf()
+    private var underTest: Boolean = false
+    private var assertAfter: StepAssertion? = null
+
+    fun consumes(vararg keys: String): StepSpec = apply { consumes += keys }
+
+    fun produces(vararg keys: String): StepSpec = apply { keys.forEach { produces[it] = null } }
+
+    fun produces(keyToValue: Map<String, String?>): StepSpec = apply { produces += keyToValue }
+
+    fun produces(pair: Pair<String, String?>): StepSpec = apply { produces[pair.first] = pair.second }
+
+    fun underTest(): StepSpec = apply { underTest = true }
+
+    fun assertAfter(assertion: StepAssertion): StepSpec = apply { assertAfter = assertion }
+
+    fun build(): RunbookStep =
+        RunbookStep(
+            intent = intent,
+            phase = phase,
+            kick = checkNotNull(kick) { "A runbook `step` requires a `kick` (was null for intent='$intent')" },
+            consumes = consumes.toSet(),
+            produces = produces.toMap(),
+            underTest = underTest,
+            assertAfter = assertAfter,
+        )
+}
+
+/** Immutable snapshot of one runbook step: a [Kick] wrapped with narration. */
+data class RunbookStep(
+    val intent: String,
+    val phase: Phase,
+    val kick: Kick,
+    val consumes: Set<String>,
+    val produces: Map<String, String?>,
+    val underTest: Boolean,
+    val assertAfter: StepAssertion?,
+)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew test --tests "com.salesforce.revoman.input.config.StepSpecTest"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+./gradlew spotlessApply
+git add src/main/kotlin/com/salesforce/revoman/input/config/RunbookStep.kt src/test/kotlin/com/salesforce/revoman/input/config/StepSpecTest.kt
+git commit -m "feat: runbook step data model (Phase, StepSpec, RunbookStep, StepAssertion)"
+```
+
+---
+
+### Task 2: `Runbook` + dual-language builders
+
+**Files:**
+- Create: `src/main/kotlin/com/salesforce/revoman/input/config/Runbook.kt`
+- Test: `src/test/kotlin/com/salesforce/revoman/input/config/RunbookDslTest.kt`
+- Test: `src/test/java/com/salesforce/revoman/input/config/RunbookJavaDslTest.java`
+
+**Interfaces:**
+- Consumes: `StepSpec`, `RunbookStep`, `Phase`, `Kick` (Task 1).
+- Produces:
+  - `class Runbook internal constructor(val name: String?, val steps: List<RunbookStep>)`
+  - Java builder: `Runbook.configure(): RunbookBuilder`; `RunbookBuilder.name(String): RunbookBuilder`; `RunbookBuilder.step(intent: String, phase: Phase, kick: Kick): RunbookBuilder`; `RunbookBuilder.step(intent: String, phase: Phase, kick: Kick, configurator: Consumer<StepSpec>): RunbookBuilder`; `RunbookBuilder.off(): Runbook`.
+  - Kotlin DSL: top-level `fun Runbook(name: String? = null, block: RunbookBuilder.() -> Unit): Runbook`; `fun RunbookBuilder.step(block: StepSpec.() -> Unit)`.
+  - `@DslMarker annotation class RunbookDsl` on `RunbookBuilder` and `StepSpec` receivers.
+
+- [ ] **Step 1: Write the failing Kotlin test**
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.input.config
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class RunbookDslTest {
+    private fun anyKick(name: String): Kick =
+        Kick.configure().templatePath("pm-templates/v3/$name").off()
+
+    @Test
+    fun `Kotlin receiver DSL builds ordered steps`() {
+        val runbook =
+            Runbook(name = "wfs double book") {
+                step {
+                    intent = "login as admin"
+                    phase = Phase.SETUP
+                    kick = anyKick("cf-stop")
+                    produces("authToken")
+                }
+                step {
+                    intent = "schedule"
+                    phase = Phase.ACT
+                    kick = anyKick("cf-loop")
+                    underTest()
+                    consumes("authToken")
+                    produces("schedulingStatus" to "Success")
+                }
+            }
+        assertThat(runbook.name).isEqualTo("wfs double book")
+        assertThat(runbook.steps.map { it.intent })
+            .containsExactly("login as admin", "schedule")
+            .inOrder()
+        assertThat(runbook.steps[1].underTest).isTrue()
+        assertThat(runbook.steps[1].consumes).containsExactly("authToken")
+        assertThat(runbook.steps[1].produces).containsEntry("schedulingStatus", "Success")
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew test --tests "com.salesforce.revoman.input.config.RunbookDslTest"`
+Expected: FAIL — unresolved `Runbook`, `step`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `Runbook.kt` (copyright header):
+
+```kotlin
+package com.salesforce.revoman.input.config
+
+import java.util.function.Consumer
+
+/** Marks the runbook builder receivers so an inner `step { }` cannot accidentally call
+ *  outer-[RunbookBuilder] methods. */
+@DslMarker annotation class RunbookDsl
+
+/** An ordered, named chain of [RunbookStep]s — the legible form of a multi-collection test.
+ *  Build via the Kotlin `Runbook { step { } }` DSL or the Java `Runbook.configure()...off()`
+ *  builder; drive with `ReVoman.revUp(runbook)`. */
+class Runbook internal constructor(val name: String?, val steps: List<RunbookStep>)
+
+/** Fluent builder backing both language front doors. */
+@RunbookDsl
+class RunbookBuilder internal constructor() {
+    private var name: String? = null
+    private val steps: MutableList<RunbookStep> = mutableListOf()
+
+    fun name(name: String): RunbookBuilder = apply { this.name = name }
+
+    /** Java: pure-narration step (no contract/assertion). */
+    fun step(intent: String, phase: Phase, kick: Kick): RunbookBuilder =
+        step(intent, phase, kick, Consumer {})
+
+    /** Java: configured step. */
+    fun step(intent: String, phase: Phase, kick: Kick, configurator: Consumer<StepSpec>): RunbookBuilder =
+        apply {
+            val spec = StepSpec().also { it.intent = intent; it.phase = phase; it.kick = kick }
+            configurator.accept(spec)
+            steps += spec.build()
+        }
+
+    internal fun addSpec(spec: StepSpec) = apply { steps += spec.build() }
+
+    internal fun build(): Runbook = Runbook(name, steps.toList())
+}
+
+/** Kotlin top-level receiver DSL entry point. */
+fun Runbook(name: String? = null, block: RunbookBuilder.() -> Unit): Runbook =
+    RunbookBuilder().apply { name?.let { name(it) } }.apply(block).build()
+
+/** Kotlin `step { }` receiver — accumulates a [StepSpec] into the builder. */
+@RunbookDsl
+fun RunbookBuilder.step(block: StepSpec.() -> Unit) {
+    addSpec(StepSpec().apply(block))
+}
+```
+
+Also add `@RunbookDsl` to the `StepSpec` class declaration in `RunbookStep.kt`:
+
+```kotlin
+@RunbookDsl
+class StepSpec {
+```
+
+- [ ] **Step 4: Run Kotlin test to verify it passes**
+
+Run: `./gradlew test --tests "com.salesforce.revoman.input.config.RunbookDslTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Write and run the Java DSL test**
+
+Create `src/test/java/com/salesforce/revoman/input/config/RunbookJavaDslTest.java`:
+
+```java
+/*
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.salesforce.revoman.input.config;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.salesforce.revoman.input.config.Phase.ACT;
+import static com.salesforce.revoman.input.config.Phase.SETUP;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class RunbookJavaDslTest {
+    private static Kick anyKick(final String name) {
+        return Kick.configure().templatePath("pm-templates/v3/" + name).off();
+    }
+
+    @Test
+    void javaBuilderBuildsOrderedSteps() {
+        final var runbook =
+            Runbook.configure()
+                .name("wfs double book")
+                .step("login as admin", SETUP, anyKick("cf-stop"), s -> s.produces("authToken"))
+                .step("schedule", ACT, anyKick("cf-loop"),
+                    s -> s.underTest()
+                          .consumes("authToken")
+                          .produces(Map.of("schedulingStatus", "Success")))
+                .off();
+        assertThat(runbook.getName()).isEqualTo("wfs double book");
+        assertThat(runbook.getSteps()).hasSize(2);
+        assertThat(runbook.getSteps().get(1).getUnderTest()).isTrue();
+        assertThat(runbook.getSteps().get(1).getProduces()).containsEntry("schedulingStatus", "Success");
+    }
+}
+```
+
+Add the Java-facing `configure()` factory to `Runbook.kt`'s `Runbook` class via a companion:
+
+```kotlin
+class Runbook internal constructor(val name: String?, val steps: List<RunbookStep>) {
+    companion object {
+        @JvmStatic fun configure(): RunbookBuilder = RunbookBuilder()
+    }
+}
+```
+
+Run: `./gradlew test --tests "com.salesforce.revoman.input.config.RunbookJavaDslTest"`
+Expected: PASS. (Kotlin `val name`/`val steps` expose `getName()`/`getSteps()`; `RunbookStep` data-class `val underTest` exposes `getUnderTest()`.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+./gradlew spotlessApply
+git add src/main/kotlin/com/salesforce/revoman/input/config/Runbook.kt src/main/kotlin/com/salesforce/revoman/input/config/RunbookStep.kt src/test/kotlin/com/salesforce/revoman/input/config/RunbookDslTest.kt src/test/java/com/salesforce/revoman/input/config/RunbookJavaDslTest.java
+git commit -m "feat: Runbook DSL (Kotlin receiver + Java configure/off builders)"
+```
+
+---
+
+### Task 3: Contract-check pure functions (subset / at-least semantics)
+
+**Files:**
+- Create: `src/main/kotlin/com/salesforce/revoman/internal/exe/RunbookContract.kt`
+- Test: `src/test/kotlin/com/salesforce/revoman/internal/exe/RunbookContractTest.kt`
+
+**Interfaces:**
+- Consumes: `RunbookStep` (Task 1), `PostmanEnvironment` (existing).
+- Produces (in `com.salesforce.revoman.internal.exe`, `internal`):
+  - `data class ContractViolation(val missingConsumed: Set<String>, val missingProduced: Set<String>, val valueMismatches: Map<String, Pair<String?, String?>>)` — `expected to actual`.
+  - `fun checkConsumes(step: RunbookStep, envKeys: Set<String>): Set<String>` — returns declared consume keys absent from `envKeys` (empty = OK).
+  - `fun checkProduces(step: RunbookStep, env: PostmanEnvironment<Any?>): ContractViolation` — computes missing produced keys AND, for declared key→value entries, value mismatches (compare via `env.getAsString(key)`). `missingConsumed` stays empty here.
+  - `fun ContractViolation.isEmpty(): Boolean`.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.exe
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.input.config.Kick
+import com.salesforce.revoman.input.config.Phase
+import com.salesforce.revoman.input.config.RunbookStep
+import com.salesforce.revoman.output.postman.PostmanEnvironment
+import org.junit.jupiter.api.Test
+
+class RunbookContractTest {
+    private fun step(consumes: Set<String> = emptySet(), produces: Map<String, String?> = emptyMap()) =
+        RunbookStep(
+            intent = "s",
+            phase = Phase.ACT,
+            kick = Kick.configure().templatePath("pm-templates/v3/cf-stop").off(),
+            consumes = consumes,
+            produces = produces,
+            underTest = false,
+            assertAfter = null,
+        )
+
+    private fun env(vararg entries: Pair<String, Any?>) =
+        PostmanEnvironment<Any?>(mutableMapOf(*entries))
+
+    @Test
+    fun `consumes passes when all declared keys present, ignoring extras`() {
+        val missing = checkConsumes(step(consumes = setOf("authToken")), setOf("authToken", "extra"))
+        assertThat(missing).isEmpty()
+    }
+
+    @Test
+    fun `consumes reports only the missing declared keys`() {
+        val missing = checkConsumes(step(consumes = setOf("authToken", "userId")), setOf("authToken"))
+        assertThat(missing).containsExactly("userId")
+    }
+
+    @Test
+    fun `produces key-only passes when present`() {
+        val v = checkProduces(step(produces = mapOf("accountId" to null)), env("accountId" to "001"))
+        assertThat(v.isEmpty()).isTrue()
+    }
+
+    @Test
+    fun `produces key-only reports missing key`() {
+        val v = checkProduces(step(produces = mapOf("accountId" to null)), env())
+        assertThat(v.missingProduced).containsExactly("accountId")
+    }
+
+    @Test
+    fun `produces key to value reports mismatch, passes on match`() {
+        val ok = checkProduces(step(produces = mapOf("status" to "Success")), env("status" to "Success"))
+        assertThat(ok.isEmpty()).isTrue()
+        val bad = checkProduces(step(produces = mapOf("status" to "Success")), env("status" to "Error"))
+        assertThat(bad.valueMismatches).containsKey("status")
+        assertThat(bad.valueMismatches["status"]).isEqualTo("Success" to "Error")
+    }
+
+    @Test
+    fun `empty declarations are always satisfied`() {
+        assertThat(checkConsumes(step(), setOf("x"))).isEmpty()
+        assertThat(checkProduces(step(), env("x" to 1)).isEmpty()).isTrue()
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew test --tests "com.salesforce.revoman.internal.exe.RunbookContractTest"`
+Expected: FAIL — unresolved `checkConsumes`, `checkProduces`, `ContractViolation`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `RunbookContract.kt` (copyright header):
+
+```kotlin
+package com.salesforce.revoman.internal.exe
+
+import com.salesforce.revoman.input.config.RunbookStep
+import com.salesforce.revoman.output.postman.PostmanEnvironment
+
+/** A step's data-flow contract breach. Empty sets/map = satisfied. `valueMismatches` maps a key to
+ *  `expected to actual`. */
+internal data class ContractViolation(
+    val missingConsumed: Set<String> = emptySet(),
+    val missingProduced: Set<String> = emptySet(),
+    val valueMismatches: Map<String, Pair<String?, String?>> = emptyMap(),
+)
+
+internal fun ContractViolation.isEmpty(): Boolean =
+    missingConsumed.isEmpty() && missingProduced.isEmpty() && valueMismatches.isEmpty()
+
+/** Subset/at-least: the declared consume keys absent from [envKeys]. Extras in the env are ignored. */
+internal fun checkConsumes(step: RunbookStep, envKeys: Set<String>): Set<String> =
+    step.consumes - envKeys
+
+/** Subset/at-least on produced keys, plus value equality for declared key→value entries. */
+internal fun checkProduces(step: RunbookStep, env: PostmanEnvironment<Any?>): ContractViolation {
+    val missing = step.produces.keys.filterNot { env.containsKey(it) }.toSet()
+    val mismatches =
+        step.produces
+            .filterValues { it != null }
+            .filterKeys { it !in missing }
+            .mapNotNull { (key, expected) ->
+                val actual = env.getAsString(key)
+                if (actual == expected) null else key to (expected to actual)
+            }
+            .toMap()
+    return ContractViolation(missingProduced = missing, valueMismatches = mismatches)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew test --tests "com.salesforce.revoman.internal.exe.RunbookContractTest"`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+./gradlew spotlessApply
+git add src/main/kotlin/com/salesforce/revoman/internal/exe/RunbookContract.kt src/test/kotlin/com/salesforce/revoman/internal/exe/RunbookContractTest.kt
+git commit -m "feat: runbook data-flow contract checks (subset semantics + value match)"
+```
+
+---
+
+### Task 4: New coarse `StepEvent`s
+
+**Files:**
+- Modify: `src/main/kotlin/com/salesforce/revoman/output/log/StepEvent.kt` (add subtypes after `LoopBudgetExceeded`, before the closing `}`)
+- Test: `src/test/kotlin/com/salesforce/revoman/output/log/RunbookStepEventTest.kt`
+
+**Interfaces:**
+- Consumes: `Phase` (Task 1), `Outcome` (existing).
+- Produces (new `StepEvent` subtypes):
+  - `data class PhaseEntered(val phase: Phase) : StepEvent { override val path = phase.name }`
+  - `data class RunbookStepStarted(override val path: String, val intent: String, val phase: Phase, val consumes: Set<String>, val underTest: Boolean) : StepEvent`
+  - `data class RunbookStepFinished(override val path: String, val intent: String, val outcome: Outcome, val produced: Map<String, String?>, val tookMs: Long) : StepEvent`
+  - `data class RunbookContractFailed(override val path: String, val intent: String, val missingConsumed: Set<String>, val missingProduced: Set<String>, val valueMismatches: Map<String, Pair<String?, String?>>) : StepEvent`
+- `path` for step events = the runbook step's `intent` (steps are identified by intent, not a URL path).
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.output.log
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.input.config.Phase
+import org.junit.jupiter.api.Test
+
+class RunbookStepEventTest {
+    @Test
+    fun `PhaseEntered path derives from phase name`() {
+        assertThat(StepEvent.PhaseEntered(Phase.SEED).path).isEqualTo("SEED")
+    }
+
+    @Test
+    fun `runbook step events carry narration`() {
+        val started = StepEvent.RunbookStepStarted("act", "schedule", Phase.ACT, setOf("id"), true)
+        assertThat(started.intent).isEqualTo("schedule")
+        assertThat(started.underTest).isTrue()
+        val finished =
+            StepEvent.RunbookStepFinished("act", "schedule", Outcome.SUCCESS, mapOf("s" to "Success"), 12L)
+        assertThat(finished.produced).containsEntry("s", "Success")
+        val failed = StepEvent.RunbookContractFailed("act", "schedule", emptySet(), setOf("s"), emptyMap())
+        assertThat(failed.missingProduced).containsExactly("s")
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew test --tests "com.salesforce.revoman.output.log.RunbookStepEventTest"`
+Expected: FAIL — unresolved subtypes.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `StepEvent.kt`, add `import com.salesforce.revoman.input.config.Phase` and, inside the `sealed interface StepEvent { … }` body after `LoopBudgetExceeded`:
+
+```kotlin
+  /** A runbook phase boundary opened. Coarse event bracketing the per-request events below it. */
+  data class PhaseEntered(val phase: Phase) : StepEvent {
+    override val path: String = phase.name
+  }
+
+  /** A runbook step (one whole collection/[com.salesforce.revoman.input.config.Kick]) opened. */
+  data class RunbookStepStarted(
+    override val path: String,
+    val intent: String,
+    val phase: Phase,
+    val consumes: Set<String>,
+    val underTest: Boolean,
+  ) : StepEvent
+
+  /** A runbook step finished with [outcome]; [produced] maps declared produced keys to values. */
+  data class RunbookStepFinished(
+    override val path: String,
+    val intent: String,
+    val outcome: Outcome,
+    val produced: Map<String, String?>,
+    val tookMs: Long,
+  ) : StepEvent
+
+  /** A runbook step breached its data-flow contract. */
+  data class RunbookContractFailed(
+    override val path: String,
+    val intent: String,
+    val missingConsumed: Set<String>,
+    val missingProduced: Set<String>,
+    val valueMismatches: Map<String, Pair<String?, String?>>,
+  ) : StepEvent
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew test --tests "com.salesforce.revoman.output.log.RunbookStepEventTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+./gradlew spotlessApply
+git add src/main/kotlin/com/salesforce/revoman/output/log/StepEvent.kt src/test/kotlin/com/salesforce/revoman/output/log/RunbookStepEventTest.kt
+git commit -m "feat: coarse runbook StepEvents (PhaseEntered, RunbookStep started/finished, ContractFailed)"
+```
+
+---
+
+### Task 5: `RunbookRundown` output type
+
+**Files:**
+- Create: `src/main/kotlin/com/salesforce/revoman/output/RunbookRundown.kt`
+- Test: `src/test/kotlin/com/salesforce/revoman/output/RunbookRundownTest.kt`
+
+**Interfaces:**
+- Consumes: `Rundown` (existing), `RunbookStep` (Task 1).
+- Produces:
+  - `class RunbookRundown(val name: String?, val stepRundowns: List<Pair<RunbookStep, Rundown>>) : List<Rundown> by stepRundowns.map { it.second }`
+  - `val rundowns: List<Rundown>` (the `List<Rundown>` view, for explicit access).
+  - `fun stepFor(intent: String): Pair<RunbookStep, Rundown>?`
+  - `toMermaid()` / `toMarkdown()` are added in Task 8 (declared there); this task delivers only the container + `List<Rundown>` delegation.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.output
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.input.config.Kick
+import com.salesforce.revoman.input.config.Phase
+import com.salesforce.revoman.input.config.RunbookStep
+import com.salesforce.revoman.output.postman.PostmanEnvironment
+import org.junit.jupiter.api.Test
+
+class RunbookRundownTest {
+    private fun step(intent: String) =
+        RunbookStep(intent, Phase.ACT, Kick.configure().templatePath("pm-templates/v3/cf-stop").off(),
+            emptySet(), emptyMap(), false, null)
+
+    private fun rundown() =
+        Rundown(mutableEnv = PostmanEnvironment(), haltOnFailureOfTypeExcept = emptyMap(),
+            providedStepsToExecuteCount = 0)
+
+    @Test
+    fun `behaves as a List of Rundown in order`() {
+        val a = rundown(); val b = rundown()
+        val rr = RunbookRundown("rb", listOf(step("login") to a, step("act") to b))
+        assertThat(rr).hasSize(2)
+        assertThat(rr[0]).isSameInstanceAs(a)
+        assertThat(rr[1]).isSameInstanceAs(b)
+        assertThat(rr.last()).isSameInstanceAs(b)
+    }
+
+    @Test
+    fun `stepFor finds by intent`() {
+        val a = rundown()
+        val rr = RunbookRundown(null, listOf(step("login") to a))
+        assertThat(rr.stepFor("login")?.second).isSameInstanceAs(a)
+        assertThat(rr.stepFor("missing")).isNull()
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew test --tests "com.salesforce.revoman.output.RunbookRundownTest"`
+Expected: FAIL — unresolved `RunbookRundown`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `RunbookRundown.kt` (copyright header):
+
+```kotlin
+package com.salesforce.revoman.output
+
+import com.salesforce.revoman.input.config.RunbookStep
+
+/** The executed runbook: each [RunbookStep] paired with its [Rundown], in order. Implements
+ *  `List<Rundown>` so it drops in wherever today's `revUp(List<Kick>)` return is consumed, while
+ *  adding step pairing and (Task 8) `toMermaid()`/`toMarkdown()` views. */
+class RunbookRundown(
+    val name: String?,
+    val stepRundowns: List<Pair<RunbookStep, Rundown>>,
+) : List<Rundown> by stepRundowns.map { it.second } {
+
+    val rundowns: List<Rundown>
+        get() = stepRundowns.map { it.second }
+
+    fun stepFor(intent: String): Pair<RunbookStep, Rundown>? =
+        stepRundowns.firstOrNull { it.first.intent == intent }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew test --tests "com.salesforce.revoman.output.RunbookRundownTest"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+./gradlew spotlessApply
+git add src/main/kotlin/com/salesforce/revoman/output/RunbookRundown.kt src/test/kotlin/com/salesforce/revoman/output/RunbookRundownTest.kt
+git commit -m "feat: RunbookRundown output (List<Rundown> + step pairing)"
+```
+
+---
+
+### Task 6: Runbook executor + `revUp(Runbook)` overload
+
+**Files:**
+- Create: `src/main/kotlin/com/salesforce/revoman/internal/exe/RunbookExe.kt`
+- Modify: `src/main/kotlin/com/salesforce/revoman/ReVoman.kt` (add overload + import)
+- Test: `src/test/kotlin/com/salesforce/revoman/RunbookExeE2ETest.kt`
+
+**Interfaces:**
+- Consumes: `Runbook`/`RunbookStep` (Tasks 1-2), contract fns (Task 3), coarse events (Task 4), `RunbookRundown` (Task 5), `ReVoman.revUp(kick)` + fold pattern (`ReVoman.kt:89-103`), `RevomanLog.event` (existing).
+- Produces:
+  - `internal fun executeRunbook(runbook: Runbook, dynamicEnvironment: Map<String, Any?>): RunbookRundown`
+  - `ReVoman.revUp(runbook: Runbook, dynamicEnvironment: Map<String, Any?> = emptyMap()): RunbookRundown` (`@JvmStatic @JvmOverloads`).
+- **Semantics:** mirror the existing multi-kick fold (`ReVoman.kt:89-103`) — each step's kick inherits `kick.dynamicEnvironment() + accumulatedMutableEnv`; thread `rundown.mutableEnv.immutableEnv` forward. Per step, in order: emit `PhaseEntered` (only on phase change), `RunbookStepStarted`; check `consumes` against accumulated env keys BEFORE running; run `revUp(kick)`; check `produces` against the step's `rundown.mutableEnv`; on any violation emit `RunbookContractFailed` + `RunbookStepFinished(FAILED)` then throw `AssertionError`; else run `assertAfter` (propagates on throw); emit `RunbookStepFinished(SUCCESS)`.
+
+- [ ] **Step 1: Write the failing E2E test** (loopback server, mirrors `MultiKickEnvTypesE2ETest`)
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.input.config.Kick
+import com.salesforce.revoman.input.config.Phase
+import com.salesforce.revoman.input.config.Runbook
+import com.salesforce.revoman.input.config.step
+import com.sun.net.httpserver.HttpServer
+import java.net.InetSocketAddress
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class RunbookExeE2ETest {
+    private val collection = "pm-templates/v3/cf-ledger-jump"
+
+    private fun kick(seed: Map<String, Any?> = emptyMap()) =
+        Kick.configure()
+            .templatePath(collection)
+            .dynamicEnvironment("baseUrl", baseUrl)
+            .let { seed.entries.fold(it) { k, (key, value) -> k.dynamicEnvironment(key, value) } }
+            .insecureHttp(true)
+            .off()
+
+    @Test
+    fun `runbook threads env across steps like the multi-kick fold`() {
+        val rr =
+            ReVoman.revUp(
+                Runbook("thread") {
+                    step { intent = "seed"; phase = Phase.SETUP; kick = kick(mapOf("count" to 42)) }
+                    step { intent = "use"; phase = Phase.ACT; kick = kick() }
+                })
+        assertThat(rr).hasSize(2)
+        assertThat(rr[1].mutableEnv["count"]).isEqualTo(42)
+        assertThat(rr.stepFor("use")).isNotNull()
+    }
+
+    @Test
+    fun `consumes breach halts at the step`() {
+        val ex = assertThrows<AssertionError> {
+            ReVoman.revUp(
+                Runbook {
+                    step { intent = "needs token"; phase = Phase.ACT; kick = kick(); consumes("authToken") }
+                })
+        }
+        assertThat(ex).hasMessageThat().contains("authToken")
+    }
+
+    @Test
+    fun `produces value mismatch halts at the step`() {
+        val ex = assertThrows<AssertionError> {
+            ReVoman.revUp(
+                Runbook {
+                    step {
+                        intent = "wrong value"; phase = Phase.ACT; kick = kick(mapOf("count" to 42))
+                        produces("count" to "999")
+                    }
+                })
+        }
+        assertThat(ex).hasMessageThat().contains("count")
+    }
+
+    @Test
+    fun `assertAfter runs and can pass`() {
+        val rr =
+            ReVoman.revUp(
+                Runbook {
+                    step {
+                        intent = "assert"; phase = Phase.ACT; kick = kick(mapOf("count" to 42))
+                        assertAfter { _, env -> assertThat(env["count"]).isEqualTo(42) }
+                    }
+                })
+        assertThat(rr).hasSize(1)
+    }
+
+    companion object {
+        private lateinit var server: HttpServer
+        private lateinit var baseUrl: String
+
+        @BeforeAll
+        @JvmStatic
+        fun startServer() {
+            server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+            server.createContext("/") { exchange ->
+                val body = "{}".toByteArray()
+                exchange.sendResponseHeaders(200, body.size.toLong())
+                exchange.responseBody.use { it.write(body) }
+            }
+            server.start()
+            baseUrl = "http://127.0.0.1:${server.address.port}"
+        }
+
+        @AfterAll @JvmStatic fun stopServer() = server.stop(0)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew test --tests "com.salesforce.revoman.RunbookExeE2ETest"`
+Expected: FAIL — `revUp(Runbook)` unresolved.
+
+- [ ] **Step 3: Write the executor**
+
+Create `RunbookExe.kt` (copyright header):
+
+```kotlin
+package com.salesforce.revoman.internal.exe
+
+import com.salesforce.revoman.ReVoman
+import com.salesforce.revoman.input.config.Phase
+import com.salesforce.revoman.input.config.Runbook
+import com.salesforce.revoman.input.config.RunbookStep
+import com.salesforce.revoman.internal.log.RevomanLog
+import com.salesforce.revoman.output.Rundown
+import com.salesforce.revoman.output.RunbookRundown
+import com.salesforce.revoman.output.log.Outcome
+import com.salesforce.revoman.output.log.StepEvent
+
+/** Drives a [Runbook] over the existing single-kick [ReVoman.revUp], threading env exactly as the
+ *  multi-kick fold (ReVoman.kt) does, and interleaving coarse log events + data-flow contract
+ *  checks + per-step assertions. First breach throws [AssertionError] (halt). */
+internal fun executeRunbook(runbook: Runbook, dynamicEnvironment: Map<String, Any?>): RunbookRundown {
+    var accumulatedEnv: Map<String, Any?> = dynamicEnvironment
+    var lastPhase: Phase? = null
+    val pairs =
+        runbook.steps.map { step ->
+            if (step.phase != lastPhase) {
+                RevomanLog.event(StepEvent.PhaseEntered(step.phase))
+                lastPhase = step.phase
+            }
+            RevomanLog.event(
+                StepEvent.RunbookStepStarted(step.intent, step.intent, step.phase, step.consumes, step.underTest))
+            checkConsumesOrHalt(step, accumulatedEnv.keys)
+            val startNs = System.nanoTime()
+            val rundown = ReVoman.revUp(step.kick.overrideDynamicEnvironment(step.kick.dynamicEnvironment() + accumulatedEnv))
+            val tookMs = (System.nanoTime() - startNs) / 1_000_000
+            checkProducesOrHalt(step, rundown, tookMs)
+            step.assertAfter?.assertStep(rundown, rundown.mutableEnv)
+            RevomanLog.event(
+                StepEvent.RunbookStepFinished(
+                    step.intent, step.intent, Outcome.SUCCESS, producedValues(step, rundown), tookMs))
+            accumulatedEnv = rundown.mutableEnv.immutableEnv
+            step to rundown
+        }
+    return RunbookRundown(runbook.name, pairs)
+}
+
+private fun producedValues(step: RunbookStep, rundown: Rundown): Map<String, String?> =
+    step.produces.keys.associateWith { rundown.mutableEnv.getAsString(it) }
+
+private fun checkConsumesOrHalt(step: RunbookStep, envKeys: Set<String>) {
+    val missing = checkConsumes(step, envKeys)
+    if (missing.isNotEmpty()) {
+        RevomanLog.event(StepEvent.RunbookContractFailed(step.intent, step.intent, missing, emptySet(), emptyMap()))
+        throw AssertionError("Runbook step '${step.intent}' missing consumed env keys: $missing")
+    }
+}
+
+private fun checkProducesOrHalt(step: RunbookStep, rundown: Rundown, tookMs: Long) {
+    val violation = checkProduces(step, rundown.mutableEnv)
+    if (!violation.isEmpty()) {
+        RevomanLog.event(
+            StepEvent.RunbookContractFailed(
+                step.intent, step.intent, emptySet(), violation.missingProduced, violation.valueMismatches))
+        RevomanLog.event(
+            StepEvent.RunbookStepFinished(step.intent, step.intent, Outcome.FAILED, emptyMap(), tookMs))
+        throw AssertionError(
+            "Runbook step '${step.intent}' contract breach — missing produced: ${violation.missingProduced}, " +
+                "value mismatches (expected→actual): ${violation.valueMismatches}")
+    }
+}
+```
+
+- [ ] **Step 4: Add the `revUp(Runbook)` overload to `ReVoman.kt`**
+
+Add imports near the other imports:
+
+```kotlin
+import com.salesforce.revoman.input.config.Runbook
+import com.salesforce.revoman.internal.exe.executeRunbook
+import com.salesforce.revoman.output.RunbookRundown
+```
+
+Add inside `object ReVoman` (after the existing `revUp(kicks: List<Kick>, ...)` overload):
+
+```kotlin
+  /** Execute a [Runbook] — the legible, narrated form of a multi-collection chain. Threads env
+   *  exactly like [revUp] over `List<Kick>`, adding per-step data-flow contract checks, per-step
+   *  assertions, and coarse grouped log events. Halts (throws [AssertionError]) at the first breach. */
+  @JvmStatic
+  @JvmOverloads
+  fun revUp(runbook: Runbook, dynamicEnvironment: Map<String, Any?> = emptyMap()): RunbookRundown =
+    executeRunbook(runbook, dynamicEnvironment)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `./gradlew test --tests "com.salesforce.revoman.RunbookExeE2ETest"`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Regression guard — existing multi-kick behavior unchanged**
+
+Run: `./gradlew test --tests "com.salesforce.revoman.MultiKickEnvTypesE2ETest"`
+Expected: PASS (2 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+./gradlew spotlessApply
+git add src/main/kotlin/com/salesforce/revoman/internal/exe/RunbookExe.kt src/main/kotlin/com/salesforce/revoman/ReVoman.kt src/test/kotlin/com/salesforce/revoman/RunbookExeE2ETest.kt
+git commit -m "feat: runbook executor + revUp(Runbook) overload (env-threading, contract halt, assertAfter)"
+```
+
+---
+
+### Task 7: `ConsoleRunLogSink` overhaul — glyphs, grouping, plain-`revUp` groups
+
+**Files:**
+- Modify: `src/main/kotlin/com/salesforce/revoman/output/log/ConsoleRunLogSink.kt`
+- Test: `src/test/kotlin/com/salesforce/revoman/output/log/ConsoleRunLogSinkTest.kt` (update existing snapshots + add coarse-event cases)
+
+**Interfaces:**
+- Consumes: all `StepEvent` subtypes incl. Task 4's coarse ones; `Outcome`, `Phase`.
+- Produces: new `render(event)` `when`-arms. Rendering rules (monospace, glyphs only — no color):
+  - `PhaseEntered` → `━━ <PHASE> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n` (pad the rule to a fixed 52-char line).
+  - `RunbookStepStarted` → `┌ <marker> <intent>` + right-aligned `⟵ <consumes joined by ", " or —>` (marker `◆` if `underTest` else `▶`); append `   ★ UNDER TEST` when `underTest`. Newline.
+  - existing `StepStarted` → `│ · <name>\n` (nested child request; `name` field carries the request label).
+  - existing `StepFinished` → `│   <httpStatus> <outcomeWord> <tookMs>ms\n` (+ existing req/resp block indented under `│`), where `outcomeWord` = `OK`/`FAIL`/`SKIP` from `outcome`.
+  - `RunbookStepFinished` → `└ <✔ or ✘> <intent>` + right-aligned `⟶ <produced as k or k=v joined>`; `✘` when `outcome==FAILED`. Newline.
+  - `RunbookContractFailed` → `│ ⚠ CONTRACT  <detail>\n` (detail lists missing consumed/produced + mismatches).
+  - existing `LedgerSkipped` → `│ ↺ reused ${reused}\n`; `RequestSkipped` → `│ ⊘ skipped ${path}\n`; `Jumped` → `│ ↪ ${path} → ${toPath}\n`; `RunStopped` → `■ STOP ${path}: ${reason}\n`; `LoopBudgetExceeded` → `✖ LOOP-BUDGET ${path} budget=${budget}\n`.
+- **Plain-`revUp` grouping:** no new event needed — when a run has no `RunbookStepStarted` bracketing (plain `revUp`), the child `StepStarted`/`StepFinished` still render with the `│` gutter, so a plain run reads as an ungrouped-but-consistent tree. (Phase/step brackets appear only when the runbook layer emits them.) Keep the change minimal: the gutter is unconditional.
+
+- [ ] **Step 1: Read the current test to see existing snapshot expectations**
+
+Run: `./gradlew test --tests "com.salesforce.revoman.output.log.ConsoleRunLogSinkTest"` and read `src/test/kotlin/com/salesforce/revoman/output/log/ConsoleRunLogSinkTest.kt` to capture the exact strings currently asserted (they encode the OLD glyphs and will be rewritten).
+
+- [ ] **Step 2: Write/adjust failing tests for the new rendering**
+
+Add cases (and update old ones) in `ConsoleRunLogSinkTest.kt`. Example new assertions:
+
+```kotlin
+@Test
+fun `renders phase rule`() {
+    val out = capture { it.event(StepEvent.PhaseEntered(Phase.SEED)) }
+    assertThat(out).startsWith("━━ SEED ━━")
+}
+
+@Test
+fun `renders runbook step open with under-test marker and consumes`() {
+    val out = capture {
+        it.event(StepEvent.RunbookStepStarted("schedule", "schedule", Phase.ACT, setOf("accountId"), true))
+    }
+    assertThat(out).contains("┌ ◆ schedule")
+    assertThat(out).contains("⟵ accountId")
+    assertThat(out).contains("★ UNDER TEST")
+}
+
+@Test
+fun `renders runbook step close with produced values`() {
+    val out = capture {
+        it.event(StepEvent.RunbookStepFinished("schedule", "schedule", Outcome.SUCCESS,
+            mapOf("schedulingStatus" to "Success"), 5))
+    }
+    assertThat(out).contains("└ ✔ schedule")
+    assertThat(out).contains("⟶ schedulingStatus=Success")
+}
+
+@Test
+fun `renders contract failure`() {
+    val out = capture {
+        it.event(StepEvent.RunbookContractFailed("schedule", "schedule", emptySet(), setOf("schedulingStatus"), emptyMap()))
+    }
+    assertThat(out).contains("⚠ CONTRACT")
+    assertThat(out).contains("schedulingStatus")
+}
+
+@Test
+fun `child request nests under a gutter`() {
+    val out = capture { it.event(StepEvent.StepStarted("auth/login", "login")) }
+    assertThat(out).startsWith("│ · ")
+}
+```
+
+Where `capture` is a helper that installs a `ConsoleRunLogSink(PrintStream)` over a `ByteArrayOutputStream` and returns the string (follow the existing test's setup pattern).
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `./gradlew test --tests "com.salesforce.revoman.output.log.ConsoleRunLogSinkTest"`
+Expected: FAIL — old glyphs vs new expectations; unresolved arms for coarse events.
+
+- [ ] **Step 4: Rewrite `render` in `ConsoleRunLogSink.kt`**
+
+```kotlin
+private const val RULE_WIDTH = 52
+
+private fun render(event: StepEvent): String =
+    when (event) {
+        is StepEvent.PhaseEntered -> phaseRule(event.phase.name)
+        is StepEvent.RunbookStepStarted -> renderStepOpen(event)
+        is StepEvent.RunbookStepFinished -> renderStepClose(event)
+        is StepEvent.RunbookContractFailed -> renderContractFailed(event)
+        is StepEvent.StepStarted -> "│ · ${event.name}\n"
+        is StepEvent.StepFinished -> renderFinished(event)
+        is StepEvent.LedgerSkipped -> "│ ↺ reused ${event.reused}\n"
+        is StepEvent.RequestSkipped -> "│ ⊘ skipped ${event.path}\n"
+        is StepEvent.Jumped -> "│ ↪ ${event.path} → ${event.toPath}\n"
+        is StepEvent.RunStopped -> "■ STOP ${event.path}: ${event.reason}\n"
+        is StepEvent.LoopBudgetExceeded -> "✖ LOOP-BUDGET ${event.path} budget=${event.budget}\n"
+    }
+
+private fun phaseRule(name: String): String {
+    val prefix = "━━ $name "
+    val fill = (RULE_WIDTH - prefix.length).coerceAtLeast(3)
+    return prefix + "━".repeat(fill) + "\n"
+}
+
+private fun renderStepOpen(e: StepEvent.RunbookStepStarted): String {
+    val marker = if (e.underTest) "◆" else "▶"
+    val consumes = if (e.consumes.isEmpty()) "—" else e.consumes.joinToString(", ")
+    val underTest = if (e.underTest) "   ★ UNDER TEST" else ""
+    return "┌ $marker ${e.intent}          ⟵ $consumes$underTest\n"
+}
+
+private fun renderStepClose(e: StepEvent.RunbookStepFinished): String {
+    val marker = if (e.outcome == Outcome.FAILED) "✘" else "✔"
+    val produced =
+        if (e.produced.isEmpty()) "—"
+        else e.produced.entries.joinToString(", ") { (k, v) -> if (v == null) k else "$k=$v" }
+    return "└ $marker ${e.intent}          ⟶ $produced\n"
+}
+
+private fun renderContractFailed(e: StepEvent.RunbookContractFailed): String {
+    val parts =
+        listOfNotNull(
+            e.missingConsumed.takeIf { it.isNotEmpty() }?.let { "missing consumed: $it" },
+            e.missingProduced.takeIf { it.isNotEmpty() }?.let { "missing produced: $it" },
+            e.valueMismatches.takeIf { it.isNotEmpty() }?.let { "value mismatch (expected→actual): $it" },
+        )
+    return "│ ⚠ CONTRACT  ${parts.joinToString("; ")}\n"
+}
+```
+
+Update `renderFinished` to the nested gutter form:
+
+```kotlin
+private fun renderFinished(event: StepEvent.StepFinished): String {
+    val word = when (event.outcome) {
+        Outcome.SUCCESS -> "OK"
+        Outcome.FAILED -> "FAIL"
+        Outcome.SKIPPED -> "SKIP"
+    }
+    val header = "│   ${event.httpStatus} $word ${event.tookMs}ms\n"
+    val keys =
+        if (event.produced.isEmpty() && event.consumed.isEmpty()) ""
+        else "│   ⟵ ${event.consumed}  ⟶ ${event.produced}\n"
+    val req = event.requestMsg?.let { "│ REQ:\n$it\n" } ?: ""
+    val resp = event.responseMsg?.let { "│ RESP:\n$it\n" } ?: ""
+    return header + keys + req + resp
+}
+```
+
+Add the imports `import com.salesforce.revoman.input.config.Phase` if needed (Phase referenced only via event; not required if not directly named — verify at compile).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `./gradlew test --tests "com.salesforce.revoman.output.log.ConsoleRunLogSinkTest"`
+Expected: PASS.
+
+- [ ] **Step 6: Full unit-test sweep** (catch any other snapshot depending on old glyphs)
+
+Run: `./gradlew test`
+Expected: PASS (ignore known restful-api.dev integrationTest quota flakes — this is `test`, unit only).
+
+- [ ] **Step 7: Commit**
+
+```bash
+./gradlew spotlessApply
+git add src/main/kotlin/com/salesforce/revoman/output/log/ConsoleRunLogSink.kt src/test/kotlin/com/salesforce/revoman/output/log/ConsoleRunLogSinkTest.kt
+git commit -m "feat: overhaul console log — phase rules, step grouping, data-flow arrows, under-test/contract markers"
+```
+
+---
+
+### Task 8: Generated view — `toMermaid()` / `toMarkdown()` + auto md summary
+
+**Files:**
+- Create: `src/main/kotlin/com/salesforce/revoman/output/RunbookView.kt`
+- Modify: `src/main/kotlin/com/salesforce/revoman/output/RunbookRundown.kt` (delegate `toMermaid()`/`toMarkdown()` to the view fns)
+- Modify: `src/main/kotlin/com/salesforce/revoman/internal/exe/RunbookExe.kt` (auto-emit md summary as a narration line at run end)
+- Test: `src/test/kotlin/com/salesforce/revoman/output/RunbookViewTest.kt`
+
+**Interfaces:**
+- Consumes: `RunbookRundown`, `RunbookStep`, `Rundown`, `Phase`, `RevomanLog.info` (existing `internal object RevomanLog` — `inline fun info(msg: () -> String)`).
+- Produces:
+  - `internal fun renderRunbookMarkdown(rr: RunbookRundown): String` — a table: `| Phase | Step | Consumes | Produces | Outcome |`.
+  - `internal fun renderRunbookMermaid(rr: RunbookRundown): String` — a `sequenceDiagram` with a participant per distinct phase and a message per step labeled with intent; produced keys annotated via `Note`.
+  - `RunbookRundown.toMarkdown(): String` and `RunbookRundown.toMermaid(): String` delegating to the above.
+  - Outcome per step derived from `rundown.firstUnIgnoredUnsuccessfulStepReport == null` → `OK` else `FAIL`.
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.output
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.input.config.Kick
+import com.salesforce.revoman.input.config.Phase
+import com.salesforce.revoman.input.config.RunbookStep
+import com.salesforce.revoman.output.postman.PostmanEnvironment
+import org.junit.jupiter.api.Test
+
+class RunbookViewTest {
+    private fun step(intent: String, phase: Phase, consumes: Set<String> = emptySet(),
+                     produces: Map<String, String?> = emptyMap()) =
+        RunbookStep(intent, phase, Kick.configure().templatePath("pm-templates/v3/cf-stop").off(),
+            consumes, produces, false, null)
+
+    private fun rundown() =
+        Rundown(mutableEnv = PostmanEnvironment(), haltOnFailureOfTypeExcept = emptyMap(),
+            providedStepsToExecuteCount = 0)
+
+    private fun rr() =
+        RunbookRundown("demo", listOf(
+            step("login", Phase.SETUP, produces = mapOf("authToken" to null)) to rundown(),
+            step("schedule", Phase.ACT, consumes = setOf("authToken"),
+                produces = mapOf("status" to "Success")) to rundown()))
+
+    @Test
+    fun `markdown lists steps with phase, consumes, produces`() {
+        val md = rr().toMarkdown()
+        assertThat(md).contains("| Phase | Step |")
+        assertThat(md).contains("SETUP")
+        assertThat(md).contains("login")
+        assertThat(md).contains("authToken")
+        assertThat(md).contains("status=Success")
+    }
+
+    @Test
+    fun `mermaid is a sequence diagram naming each step intent`() {
+        val mmd = rr().toMermaid()
+        assertThat(mmd).startsWith("sequenceDiagram")
+        assertThat(mmd).contains("login")
+        assertThat(mmd).contains("schedule")
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew test --tests "com.salesforce.revoman.output.RunbookViewTest"`
+Expected: FAIL — unresolved `toMarkdown`/`toMermaid`.
+
+- [ ] **Step 3: Write the view functions**
+
+Create `RunbookView.kt` (copyright header):
+
+```kotlin
+package com.salesforce.revoman.output
+
+import com.salesforce.revoman.input.config.RunbookStep
+
+private fun outcomeOf(rundown: Rundown): String =
+    if (rundown.firstUnIgnoredUnsuccessfulStepReport == null) "OK" else "FAIL"
+
+private fun producedText(step: RunbookStep): String =
+    if (step.produces.isEmpty()) "—"
+    else step.produces.entries.joinToString(", ") { (k, v) -> if (v == null) k else "$k=$v" }
+
+private fun consumedText(step: RunbookStep): String =
+    if (step.consumes.isEmpty()) "—" else step.consumes.joinToString(", ")
+
+/** A markdown table runbook: one row per step. Pure function of the declared+executed runbook. */
+internal fun renderRunbookMarkdown(rr: RunbookRundown): String {
+    val title = rr.name?.let { "### Runbook: $it\n\n" } ?: ""
+    val header = "| Phase | Step | Consumes | Produces | Outcome |\n|---|---|---|---|---|\n"
+    val rows =
+        rr.stepRundowns.joinToString("\n") { (step, rundown) ->
+            "| ${step.phase} | ${step.intent} | ${consumedText(step)} | ${producedText(step)} | ${outcomeOf(rundown)} |"
+        }
+    return title + header + rows + "\n"
+}
+
+/** A mermaid sequence diagram: a `Runbook` participant issuing one message per step, annotated with
+ *  produced keys. Theme is applied by whoever writes it into docs. */
+internal fun renderRunbookMermaid(rr: RunbookRundown): String {
+    val lines =
+        rr.stepRundowns.flatMap { (step, _) ->
+            listOf(
+                "    Runbook->>${step.phase}: ${step.intent}",
+                "    Note right of ${step.phase}: ⟶ ${producedText(step)}",
+            )
+        }
+    return (listOf("sequenceDiagram", "    participant Runbook") + lines).joinToString("\n") + "\n"
+}
+```
+
+Add to `RunbookRundown.kt`:
+
+```kotlin
+    fun toMarkdown(): String = renderRunbookMarkdown(this)
+
+    fun toMermaid(): String = renderRunbookMermaid(this)
+```
+
+- [ ] **Step 4: Auto-emit the md summary at run end**
+
+In `RunbookExe.kt`, before `return RunbookRundown(...)`, build the result then log its markdown:
+
+```kotlin
+    val result = RunbookRundown(runbook.name, pairs)
+    RevomanLog.info { "\n" + com.salesforce.revoman.output.renderRunbookMarkdown(result) }
+    return result
+```
+
+(Replace the bare `return RunbookRundown(runbook.name, pairs)` with the above. Add `import com.salesforce.revoman.internal.log.RevomanLog` — already imported for events.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `./gradlew test --tests "com.salesforce.revoman.output.RunbookViewTest"`
+Expected: PASS.
+
+- [ ] **Step 6: Re-run the executor E2E** (auto-summary must not break it)
+
+Run: `./gradlew test --tests "com.salesforce.revoman.RunbookExeE2ETest"`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+./gradlew spotlessApply
+git add src/main/kotlin/com/salesforce/revoman/output/RunbookView.kt src/main/kotlin/com/salesforce/revoman/output/RunbookRundown.kt src/main/kotlin/com/salesforce/revoman/internal/exe/RunbookExe.kt src/test/kotlin/com/salesforce/revoman/output/RunbookViewTest.kt
+git commit -m "feat: runbook generated views (toMarkdown/toMermaid) + auto md summary in log"
+```
+
+---
+
+### Task 9: End-to-end demonstration + full verification
+
+**Files:**
+- Create: `src/test/kotlin/com/salesforce/revoman/RunbookLegibilityE2ETest.kt`
+
+**Interfaces:**
+- Consumes: everything above; loopback server pattern.
+- Produces: a single test that reads like a runbook and asserts the three surfaces (executes, contract-guards, and renders a view), proving the feature end-to-end from a fresh reader's perspective.
+
+- [ ] **Step 1: Write the demonstration test**
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.input.config.Kick
+import com.salesforce.revoman.input.config.Phase
+import com.salesforce.revoman.input.config.Runbook
+import com.salesforce.revoman.input.config.step
+import com.salesforce.revoman.output.log.ConsoleRunLogSink
+import com.sun.net.httpserver.HttpServer
+import java.net.InetSocketAddress
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+
+class RunbookLegibilityE2ETest {
+    private fun kick(seed: Map<String, Any?> = emptyMap()) =
+        Kick.configure()
+            .templatePath("pm-templates/v3/cf-ledger-jump")
+            .dynamicEnvironment("baseUrl", baseUrl)
+            .let { seed.entries.fold(it) { k, (key, value) -> k.dynamicEnvironment(key, value) } }
+            .runLogSink(ConsoleRunLogSink.DEFAULT)
+            .insecureHttp(true)
+            .off()
+
+    @Test
+    fun `a runbook reads as a story, guards its handoffs, and renders a view`() {
+        val rundown =
+            ReVoman.revUp(
+                Runbook("legibility demo") {
+                    step {
+                        intent = "seed session token"
+                        phase = Phase.SETUP
+                        kick = kick(mapOf("authToken" to "tok-123"))
+                        produces("authToken")
+                    }
+                    step {
+                        intent = "act under test"
+                        phase = Phase.ACT
+                        kick = kick(mapOf("count" to 7))
+                        underTest()
+                        consumes("authToken")
+                        produces("count" to "7")
+                        assertAfter { _, env -> assertThat(env["count"]).isEqualTo(7) }
+                    }
+                })
+
+        // Executes and threads env across steps.
+        assertThat(rundown).hasSize(2)
+        assertThat(rundown[1].mutableEnv["authToken"]).isEqualTo("tok-123")
+        // Step pairing accessible by intent.
+        assertThat(rundown.stepFor("act under test")).isNotNull()
+        // Generated view surfaces the story.
+        val md = rundown.toMarkdown()
+        assertThat(md).contains("seed session token")
+        assertThat(md).contains("act under test")
+        assertThat(md).contains("count=7")
+        assertThat(rundown.toMermaid()).startsWith("sequenceDiagram")
+    }
+
+    companion object {
+        private lateinit var server: HttpServer
+        private lateinit var baseUrl: String
+
+        @BeforeAll
+        @JvmStatic
+        fun startServer() {
+            server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+            server.createContext("/") { exchange ->
+                val body = "{}".toByteArray()
+                exchange.sendResponseHeaders(200, body.size.toLong())
+                exchange.responseBody.use { it.write(body) }
+            }
+            server.start()
+            baseUrl = "http://127.0.0.1:${server.address.port}"
+        }
+
+        @AfterAll @JvmStatic fun stopServer() = server.stop(0)
+    }
+}
+```
+
+- [ ] **Step 2: Run the demonstration test**
+
+Run: `./gradlew test --tests "com.salesforce.revoman.RunbookLegibilityE2ETest"`
+Expected: PASS. Inspect the Gradle output to eyeball the grouped log (phase rules, `┌ ◆ … ★ UNDER TEST`, `└ ✔ … ⟶ count=7`, and the auto markdown summary).
+
+- [ ] **Step 3: Full build**
+
+Run: `./gradlew build`
+Expected: unit + spotless + kover pass. The only acceptable failures are the 6 known restful-api.dev integrationTest HTTP-405 quota flakes (RestfulAPIDev*Test x4, LedgerRoundTripKtTest, PokemonSandboxApiTest) — classify any integ failure as network-vs-regression before trusting it; unit `test` must be clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+./gradlew spotlessApply
+git add src/test/kotlin/com/salesforce/revoman/RunbookLegibilityE2ETest.kt
+git commit -m "test: end-to-end runbook legibility demonstration"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- New types (`Runbook`, `RunbookStep`, `Phase`, `RunbookRundown`) → Tasks 1, 2, 5. ✅
+- Kotlin `Runbook { step { } }` + Java `configure()/off()` → Task 2. ✅
+- Data-flow subset semantics + key→value + empty=narration → Task 3; enforcement/halt → Task 6. ✅
+- `assertAfter` complementary to Truth → Tasks 1 (type), 6 (invocation). ✅
+- First-breach halt → Task 6. ✅
+- Coarse events bracketing per-request → Task 4 (types), 6 (emit). ✅
+- Glyph/grouping overhaul + plain-`revUp` consistent gutter → Task 7. ✅
+- Generated view + auto md summary, files on-demand → Task 8. ✅
+- `RunbookRundown` as `List<Rundown>` (spec open-consideration, resolved yes) → Task 5. ✅
+- `Phase` fixed 5-value enum (spec open-consideration, resolved) → Task 1. ✅
+- Kick untouched, existing `revUp` overloads intact → Task 6 regression guard. ✅
+- Migration proof → Task 9 (fresh DSL E2E; real WFS port deferred — it's a core-IT excluded from CI, so a CI-runnable loopback demo is the better proof).
+
+**Placeholder scan:** No TBD/TODO; every code step shows compilable code. ✅
+
+**Type consistency:** `StepSpec`/`RunbookStep`/`Phase`/`StepAssertion` (Task 1) reused verbatim in Tasks 2-9. `checkConsumes`/`checkProduces`/`ContractViolation` (Task 3) match Task 6 call sites. `RunbookRundown(name, stepRundowns)` ctor (Task 5) matches Task 6/8 use. Coarse `StepEvent` field names (Task 4) match Task 6 emit + Task 7 render. `revUp(runbook, dynamicEnvironment)` (Task 6) matches Task 9 calls. ✅
+
+**Note on `Rundown` test construction:** `Rundown(mutableEnv=…, haltOnFailureOfTypeExcept=emptyMap(), providedStepsToExecuteCount=0)` uses the real constructor (see `Rundown.kt:16-33`; `stepReports` defaults empty). If a future compile error surfaces on a required param, add it from the data-class signature — do not stub.

--- a/docs/superpowers/specs/2026-07-13-runbook-legibility-design.md
+++ b/docs/superpowers/specs/2026-07-13-runbook-legibility-design.md
@@ -1,0 +1,346 @@
+# Runbook Legibility — making the test's collection-chain readable
+
+**Date:** 2026-07-13
+**Status:** Design approved, pending spec review
+**Author:** Gopal S Akshintala (with Claude)
+
+## Problem
+
+A ReVoman test acts as a *runbook*: it chains loosely-coupled Postman collections
+(separate files on disk) into an ordered story — *login → set policy → seed
+fixture → schedule (act) → control*. Today that runbook is **implicit**, spread
+across three places that the test reader must mentally reassemble:
+
+1. A separate config file (`ReVomanConfigForWfs.java`) declaring one `Kick`
+   constant per collection.
+2. The **order** those constants appear in a flat `revUp(...)` vararg call.
+3. The constant **names** plus hand-written comment blocks.
+
+Nothing in the test surfaces *what each step means*, *what data it hands to the
+next step*, or *which step is the act-step under test*. The coupling between
+collections (env keys produced by one, consumed by the next) is invisible.
+
+Concretely, today's WFS test reads:
+
+```java
+final var doubleBookRundown =
+    ReVoman.revUp(
+        (rundown, ignore) ->
+            assertThat(rundown.firstUnIgnoredUnsuccessfulStepReport()).isNull(),
+        AUTH_CONFIG,
+        AVAILABILITY_OP_HOURS_POLICY_CONFIG,
+        DOUBLE_BOOK_FIXTURE_CONFIG,
+        DOUBLE_BOOK_NON_REQUIRED_SCHEDULE_CONFIG,
+        DOUBLE_BOOK_REQUIRED_CONFLICT_SCHEDULE_CONFIG);
+```
+
+The story ("log in, apply the availability policy, seed the double-book fixture,
+run the two schedule act-steps") lives only in the constant names and the config
+file's comments.
+
+## Goal
+
+Make the runbook legible from **one declaration**, surfaced three ways from that
+single source of truth:
+
+1. **The test code** — a fluent DSL that reads like the runbook.
+2. **The log** — a grouped, narrated, glyph-rich run log.
+3. **A generated view** — a mermaid sequence diagram / markdown runbook, on demand.
+
+Non-goals: replacing `Kick`; forcing migration; replacing the test writer's
+Truth assertions.
+
+## Solution overview
+
+A thin **Runbook** layer wraps each `Kick` with narration and drives the existing
+multi-kick `revUp` fold. `Kick` stays the per-collection unit (*how a collection
+runs*); a `RunbookStep` adds the story layer (*what this step means*).
+
+```mermaid
+%%{init: {"theme":"base","themeVariables":{"fontFamily":"\"Inter\", -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, sans-serif","fontSize":"14px","background":"#e7e8ea","primaryColor":"#c9cace","primaryTextColor":"#333333","primaryBorderColor":"#c9cace","lineColor":"#8ba4c7","arrowheadColor":"#8ba4c7","textColor":"#333333","mainBkg":"#c9cace","nodeBorder":"#c9cace","clusterBkg":"#d7d8da","clusterBorder":"#d7d8da","titleColor":"#333333","edgeLabelBackground":"#e7e8ea"}}}%%
+flowchart TB
+  subgraph decl["Single declaration"]
+    RB["<code>Runbook</code><br/>ordered <code>RunbookStep</code>s"]
+    RS["<code>RunbookStep</code><br/>wraps one <code>Kick</code> +<br/>intent, phase, produces,<br/>consumes, assertAfter"]
+    RB --> RS
+  end
+  RB --> EXE["Runbook executor<br/>unwrap → existing <code>revUp</code> fold<br/>(env threading unchanged)"]
+  EXE --> CHK["per-step:<br/>consumes check → run Kick →<br/>produces check → assertAfter"]
+  CHK --> OUT["<code>RunbookRundown</code><br/>steps ↔ Rundowns"]
+  OUT --> V1["test code reads<br/>like the runbook"]
+  OUT --> V2["enhanced grouped log<br/>(auto md summary)"]
+  OUT --> V3["<code>toMermaid()</code> / <code>toMarkdown()</code><br/>on demand"]
+  classDef emphasized fill:#acafb4,stroke:#acafb4,color:#000;
+  class RB emphasized;
+```
+
+## New types
+
+All in `com.salesforce.revoman.input.config` (next to `Kick`), as Immutables
+(`@Value.Immutable`, same `configure()`/`off()` style annotation as `KickDef`),
+except the output type which lives under `com.salesforce.revoman.output`.
+
+| Type | Kind | Responsibility |
+|------|------|----------------|
+| `Runbook` | `@Value.Immutable`, `input.config` | Ordered list of `RunbookStep`s + optional runbook name. The whole story. |
+| `RunbookStep` | `@Value.Immutable`, `input.config` | Wraps ONE `Kick` + narration: `intent`, `phase`, `consumes`, `produces` (keys or key→value), `underTest`, `assertAfter`. |
+| `Phase` | `enum`, `input.config` | `SETUP, SEED, ACT, ASSERT, CLEANUP`. Mirrors today's comment blocks. |
+| `RunbookRundown` | output, `com.salesforce.revoman.output` | The executed runbook: steps paired with their `Rundown`s + `toMermaid()` / `toMarkdown()`. |
+
+**Boundary:** `RunbookStep` never duplicates `Kick` fields. `Kick` = *how a
+collection runs* (paths, hooks, adapters, halt rules). `RunbookStep` = *what this
+step means in the story*.
+
+## DSL
+
+### Kotlin — fluent receiver DSL (idiomatic type-safe builder)
+
+```kotlin
+val runbook = Runbook {
+    step {
+        intent = "login as admin"
+        phase = SETUP
+        kick = AUTH_CONFIG
+        produces("authToken", "userId")
+    }
+    step {
+        intent = "seed double-book fixture"
+        phase = SEED
+        kick = DOUBLE_BOOK_FIXTURE_CONFIG
+        consumes("authToken")
+        produces("accountId", "shiftIds")
+    }
+    step {
+        intent = "schedule double-book non-required"
+        phase = ACT
+        kick = DOUBLE_BOOK_SCHEDULE_CONFIG
+        underTest()                                          // → ◆ ★ UNDER TEST
+        consumes("accountId", "shiftIds")
+        produces("doubleBookNonRequiredSchedulingStatus" to "Success")   // key→value
+        assertAfter { rundown, env ->
+            assertThat(env).containsEntry("doubleBookNonRequiredSchedulingStatus", "Success")
+        }
+    }
+}
+
+val rundown: RunbookRundown = ReVoman.revUp(runbook)
+```
+
+- `Runbook { }` = top-level `fun Runbook(block: RunbookBuilder.() -> Unit): Runbook`.
+- `step { }` = `fun RunbookBuilder.step(block: StepSpec.() -> Unit)`.
+- `intent`/`phase`/`kick` are `var` properties; `produces`/`consumes`/`underTest`/
+  `assertAfter` are methods on the receiver.
+- `@DslMarker` scopes receivers so an inner `step { }` cannot call outer-builder
+  methods.
+- A `step { }` with no `kick` fails at build with a clear message.
+
+### Java — `configure()`/`off()` builder
+
+Java has no lambda-with-receiver, so a true `step { intent = ... }` block is
+impossible. The idiomatic Java ceiling is a `Consumer<StepSpec>` configurator —
+type-safe, no extra dependency. (Double-brace init is an anti-pattern; builder
+libraries like Immutables/Lombok only generate method chains, adding a dep
+without adding receiver blocks.)
+
+```java
+final var runbook = Runbook.configure()
+    .step("login as admin", SETUP, AUTH_CONFIG,
+        s -> s.produces("authToken", "userId"))
+    .step("seed double-book fixture", SEED, DOUBLE_BOOK_FIXTURE_CONFIG,
+        s -> s.consumes("authToken").produces("accountId", "shiftIds"))
+    .step("schedule double-book non-required", ACT, DOUBLE_BOOK_SCHEDULE_CONFIG,
+        s -> s.underTest()
+              .consumes("accountId", "shiftIds")
+              .produces(Map.of("doubleBookNonRequiredSchedulingStatus", "Success"))
+              .assertAfter((rundown, env) -> assertThat(env)
+                  .containsEntry("doubleBookNonRequiredSchedulingStatus", "Success")))
+    .off();
+
+final var rundown = ReVoman.revUp(runbook);
+```
+
+Both front doors build the **same** immutable model — the Kotlin layer only
+accumulates into what the Java builder produces, so there is nothing to keep in
+sync beyond the builder surface.
+
+### Entry point
+
+`revUp(Runbook)` is a **new opt-in overload**. Existing `revUp(vararg Kick)` and
+`revUp(List<Kick>)` are untouched — no test is forced to migrate.
+
+## Data-flow contract (subset / at-least semantics)
+
+Full env enumeration would be brittle (Postman scripts write many keys). Instead,
+declare **only the handoff keys that matter** to the story:
+
+- **`consumes(keys…)`** — before the step runs, assert the accumulated env
+  `containsAtLeast` these keys. Missing → `RunbookContractFailed` event + halt
+  with `missing consumed: [k]` naming the step.
+- **`produces(keys…)`** — after the step's `Rundown`, assert env `containsAtLeast`
+  these keys.
+- **`produces(key to value)`** — additionally assert the value equals (env
+  `getAsString`/equals). Key-only when the value is omitted. Mix freely.
+- **Empty declarations** → pure narration, no check. Enforcement is opt-in
+  *per key* by what you list.
+
+Extra env churn never fails a step. These checks are **complementary** to the
+test writer's Truth assertions, not a replacement.
+
+### `assertAfter`
+
+`assertAfter { rundown, env -> }` runs after that step, receiving the step's
+`Rundown` + the accumulated `MutableEnv` — the same objects the writer already
+asserts on, relocated next to the step. A thrown `AssertionError` (Truth) fails
+the run at that step. Complementary to the contract checks and to the whole-run
+`postExeHook`.
+
+### Per-step order & failure mode
+
+Per step: **`consumes` check → execute Kick (existing `revUp`) → `produces`
+check → `assertAfter`**. The **first** contract or `assertAfter` breach **halts**
+the runbook at that step — downstream steps depend on it, so continuing only adds
+noise. The log marks `✘` at the exact broken handoff.
+
+## Logging overhaul
+
+The runbook's narration data becomes log output, so a Gradle/JUnit log reads like
+the runbook rather than a flat wall of HTTP. This reuses the existing
+`RunLogSink` / `StepEvent` pipeline — no new sink type.
+
+### New coarse-grained events
+
+Added to the `StepEvent` sealed interface, bracketing the existing fine-grained
+per-request events (`StepStarted`/`StepFinished`):
+
+| Event | Carries |
+|-------|---------|
+| `PhaseEntered` | `phase` |
+| `RunbookStepStarted` | `name`, `intent`, `phase`, `consumes`, `underTest` |
+| `RunbookStepFinished` | `name`, `outcome`, `produced` (+ values), `tookMs` |
+| `RunbookContractFailed` | `name`, `missingProduced`, `missingConsumed` |
+
+Any existing custom sink already handles new events through its sealed `when`.
+
+### Symbol & grouping redesign (full overhaul)
+
+Design rules: (1) fixed-width left gutter so a reader scans one column; (2)
+tree/rule glyphs group related lines; (3) reserved markers highlight the
+important stuff (act-step-under-test, failures, contract breaks); (4) data-flow
+arrows at every handoff. Terminal/Gradle logs are monospace with no guaranteed
+color, so this rides on glyphs + indentation alone.
+
+| Meaning | Today | New |
+|---------|-------|-----|
+| Phase boundary | *(none)* | `━━ SEED ━━━━━━━━` |
+| Runbook step open | *(none)* | `┌ ▶ <intent>` |
+| Act-step open (under test) | *(none)* | `┌ ◆ <intent>  ★ UNDER TEST` |
+| child request start | `→ STEP` | `│ · <METHOD path>` |
+| child request done | `── STEP [200] SUCCESS` | `│   200 OK 243ms` |
+| runbook step OK | *(none)* | `└ ✔ <intent>` |
+| runbook step FAIL | *(none)* | `└ ✘ <intent>` |
+| ledger reuse | `↩ LEDGER-SKIP` | `│ ↺ reused {…}` |
+| request skip | `⤫ REQ-SKIP` | `│ ⊘ skipped` |
+| jump | `↪ JUMP a→b` | `│ ↪ a → b` |
+| stop | `■ STOP` | `■ STOP: <reason>` |
+| loop budget | `✖ LOOP-BUDGET` | `✖ LOOP-BUDGET budget=N` |
+| consumes (in) | `consumed=[…]` | `⟵ authToken` on step open |
+| produces (out) | `produced=[…]` | `⟶ schedulingStatus=Success` on step close |
+| contract breach | *(none)* | `│ ⚠ CONTRACT missing produced: …` |
+
+**After** (grouped, narrated, highlighted):
+
+```
+━━ SETUP ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+┌ ▶ login as admin                          ⟵ —
+│   POST auth/login              200 OK    243ms
+└ ✔ login as admin                          ⟶ authToken, userId
+━━ SEED ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+┌ ▶ seed double-book fixture                ⟵ authToken
+│   POST composite/graph         201 OK    512ms
+│ ↺ composite/query              reused {accountId}
+└ ✔ seed double-book fixture                ⟶ accountId, shiftIds
+━━ ACT ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+┌ ◆ schedule double-book non-required       ⟵ accountId, shiftIds   ★ UNDER TEST
+│   POST actions/schedule        200 OK    876ms
+└ ✔ schedule double-book non-required       ⟶ schedulingStatus=Success
+```
+
+Failure case makes the broken handoff jump out:
+
+```
+┌ ◆ schedule required control               ⟵ accountId, shiftIds   ★ UNDER TEST
+│   POST actions/schedule        200 OK    654ms
+│ ⚠ CONTRACT  missing produced: schedulingStatus
+└ ✘ schedule required control               FAILED
+```
+
+### Plain `revUp` reimagined too
+
+Even a plain `revUp(vararg Kick)` / `revUp(List<Kick>)` call (no `Runbook`, no
+narration) gets the reimagined rendering: one group per `Kick`/collection, step
+name derived from the template path, no phase/intent lines, but the **same** tree
+layout + status column. One rendering engine, two levels of richness depending on
+whether narration is present.
+
+### Scope
+
+New glyphs and the per-request rewrites live in `ConsoleRunLogSink.render()`
+(new `when`-arms for the coarse events + rewritten arms for existing events). The
+event *data* for existing events is unchanged; existing `ConsoleRunLogSink` tests
+are updated to the new rendering. `◆`/`★` fire when a step's phase is `ACT` or
+its explicit `underTest` flag is set.
+
+## Generated view
+
+`RunbookRundown` exposes:
+
+- **`toMermaid()`** — a sequence diagram: participants are phases; each step is an
+  arrow labeled with its intent; produces/consumes annotated; `◆` act-steps
+  flagged. Themed per the repo's mermaid convention when written to docs.
+- **`toMarkdown()`** — a table/checklist runbook: phase → step → intent →
+  consumes → produces → outcome.
+
+Both are pure functions of the declared `Runbook` (renderable even before running)
+with executed outcomes overlaid when present.
+
+**Emission:** after a run, the enhanced log **auto-prints** the compact markdown
+runbook summary (the log is already narrating). Mermaid and file output stay
+**on-demand** — the methods return strings; the caller (or a future Gradle task)
+decides where to write. No forced file I/O.
+
+## Migration
+
+Mechanical and optional:
+
+1. Wrap each existing `revUp` vararg entry in a `step { }` (Kotlin) or
+   `.step(...)` (Java), adding `intent`/`phase` and, for the handoff keys that
+   matter, `consumes`/`produces`.
+2. The `Kick` constants (e.g. `ReVomanConfigForWfs`) stay exactly as-is; order is
+   preserved.
+3. The whole-run `postExeHook` either stays a `revUp` arg or moves into the last
+   step's `assertAfter` — writer's choice.
+
+No test is forced to migrate: `revUp(vararg Kick)` / `revUp(List<Kick>)` remain.
+
+## Testing
+
+- **DSL build** — Kotlin `Runbook { step { } }` and Java `configure().step().off()`
+  produce equivalent immutables; missing-`kick` fails at build.
+- **Contract semantics** — `consumes`/`produces` subset checks (present, missing,
+  extra-ignored); `produces(key to value)` pass/fail; empty = no check.
+- **Failure mode** — first breach halts at the right step; downstream steps do not
+  run; `RunbookContractFailed` emitted.
+- **Executor equivalence** — a `Runbook` of N steps threads env identically to
+  today's `revUp(vararg Kick)` of the same N kicks (regression guard).
+- **Logging** — new `StepEvent` arms render the expected glyphs/grouping;
+  `ConsoleRunLogSink` snapshot updated; plain-`revUp` grouping renders.
+- **Generated view** — `toMermaid()`/`toMarkdown()` output for a known runbook;
+  auto-md-summary appears in the log.
+- **Migration proof** — port one real test (e.g. `WfsDoubleBookHelperE2ETest`)
+  to the DSL and assert identical behavior.
+
+## Open considerations (for spec review)
+
+- Exact `Phase` set — are 5 enough, or should `Phase` be an open label?
+- Whether `RunbookRundown` should also implement/extend `List<Rundown>` for
+  drop-in compatibility with code that reads today's `revUp` return.

--- a/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
+++ b/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
@@ -119,15 +119,15 @@ object ReVoman {
   @JvmStatic
   @OptIn(ExperimentalStdlibApi::class)
   fun revUp(kick: Kick): Rundown {
-    // BORROW the sink for this run only: install on the ThreadLocal, remove in finally. Do NOT
+    // BORROW the sink for this run only: install on the ThreadLocal, restore in finally. Do NOT
     // close() it — the caller OWNS the sink's lifecycle. A single caller-supplied sink commonly
     // spans MANY revUp calls (persona-creation, general-setup, the test body, cleanup); closing it
     // here would shut the writer after the first revUp and silently drop every later run's output.
-    RunLogContext.install(kick.runLogSink())
+    val previousSink = RunLogContext.install(kick.runLogSink())
     try {
       return revUpInternal(kick)
     } finally {
-      RunLogContext.remove()
+      RunLogContext.restore(previousSink)
     }
   }
 

--- a/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
+++ b/src/main/kotlin/com/salesforce/revoman/ReVoman.kt
@@ -15,6 +15,7 @@ import com.salesforce.revoman.input.PostExeHook
 import com.salesforce.revoman.input.bufferFile
 import com.salesforce.revoman.input.bufferInputStream
 import com.salesforce.revoman.input.config.Kick
+import com.salesforce.revoman.input.config.Runbook
 import com.salesforce.revoman.input.isV3Collection
 import com.salesforce.revoman.internal.exe.StepDirective
 import com.salesforce.revoman.internal.exe.deepFlattenItems
@@ -22,6 +23,7 @@ import com.salesforce.revoman.internal.exe.directiveOf
 import com.salesforce.revoman.internal.exe.executePolling
 import com.salesforce.revoman.internal.exe.executePostResJS
 import com.salesforce.revoman.internal.exe.executePreReqJS
+import com.salesforce.revoman.internal.exe.executeRunbook
 import com.salesforce.revoman.internal.exe.fireHttpRequest
 import com.salesforce.revoman.internal.exe.ledgerSkipDecision
 import com.salesforce.revoman.internal.exe.postStepHookExe
@@ -55,6 +57,7 @@ import com.salesforce.revoman.output.ExeType.PRE_REQ_JS
 import com.salesforce.revoman.output.ExeType.PRE_STEP_HOOK
 import com.salesforce.revoman.output.ExeType.UNMARSHALL_REQUEST
 import com.salesforce.revoman.output.ExeType.UNMARSHALL_RESPONSE
+import com.salesforce.revoman.output.RunbookRundown
 import com.salesforce.revoman.output.Rundown
 import com.salesforce.revoman.output.StopReason
 import com.salesforce.revoman.output.ledger.LedgerEntry
@@ -102,6 +105,16 @@ object ReVoman {
         rundown.mutableEnv.immutableEnv to accumulatedRundowns
       }
       .second
+
+  /**
+   * Execute a [Runbook] — the legible, narrated form of a multi-collection chain. Threads env
+   * exactly like [revUp] over `List<Kick>`, adding per-step data-flow contract checks, per-step
+   * assertions, and coarse grouped log events. Halts (throws [AssertionError]) at the first breach.
+   */
+  @JvmStatic
+  @JvmOverloads
+  fun revUp(runbook: Runbook, dynamicEnvironment: Map<String, Any?> = emptyMap()): RunbookRundown =
+    executeRunbook(runbook, dynamicEnvironment)
 
   @JvmStatic
   @OptIn(ExperimentalStdlibApi::class)

--- a/src/main/kotlin/com/salesforce/revoman/input/config/Runbook.kt
+++ b/src/main/kotlin/com/salesforce/revoman/input/config/Runbook.kt
@@ -105,6 +105,9 @@ class RunbookBuilder internal constructor() {
     return Runbook(name, steps.toList(), runLogSinkValue, haltOnStepFailureValue)
   }
 
+  /**
+   * Java terminal builder call: validates and snapshots this builder into an immutable [Runbook].
+   */
   fun off(): Runbook = build()
 }
 

--- a/src/main/kotlin/com/salesforce/revoman/input/config/Runbook.kt
+++ b/src/main/kotlin/com/salesforce/revoman/input/config/Runbook.kt
@@ -93,8 +93,17 @@ class RunbookBuilder internal constructor() {
 
   internal fun addSpec(spec: StepSpec) = apply { steps += spec.build() }
 
-  internal fun build(): Runbook =
-    Runbook(name, steps.toList(), runLogSinkValue, haltOnStepFailureValue)
+  internal fun build(): Runbook {
+    // `intent` is the event `path` and the `stepFor(intent)` lookup key, so duplicates would
+    // mis-pair start/finish events and silently shadow in `stepFor` (firstOrNull). Enforce distinct
+    // intents at build so the ambiguity fails loud instead of corrupting the log/views.
+    require(steps.map { it.intent }.toSet().size == steps.size) {
+      val duplicates =
+        steps.map { it.intent }.groupingBy { it }.eachCount().filterValues { it > 1 }.keys
+      "Runbook step intents must be distinct; duplicates: $duplicates"
+    }
+    return Runbook(name, steps.toList(), runLogSinkValue, haltOnStepFailureValue)
+  }
 
   fun off(): Runbook = build()
 }

--- a/src/main/kotlin/com/salesforce/revoman/input/config/Runbook.kt
+++ b/src/main/kotlin/com/salesforce/revoman/input/config/Runbook.kt
@@ -1,0 +1,73 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.input.config
+
+import java.util.function.Consumer
+
+/**
+ * Marks the runbook builder receivers so an inner `step { }` cannot accidentally call
+ * outer-[RunbookBuilder] methods.
+ */
+@DslMarker annotation class RunbookDsl
+
+/**
+ * An ordered, named chain of [RunbookStep]s — the legible form of a multi-collection test. Build
+ * via the Kotlin `Runbook { step { } }` DSL or the Java `Runbook.configure()...off()` builder;
+ * drive with `ReVoman.revUp(runbook)`.
+ */
+class Runbook internal constructor(val name: String?, val steps: List<RunbookStep>) {
+  companion object {
+    @JvmStatic fun configure(): RunbookBuilder = RunbookBuilder()
+  }
+}
+
+/** Fluent builder backing both language front doors. */
+@RunbookDsl
+class RunbookBuilder internal constructor() {
+  private var name: String? = null
+  private val steps: MutableList<RunbookStep> = mutableListOf()
+
+  fun name(name: String): RunbookBuilder = apply { this.name = name }
+
+  /** Java: pure-narration step (no contract/assertion). */
+  fun step(intent: String, phase: Phase, kick: Kick): RunbookBuilder =
+    step(intent, phase, kick, Consumer {})
+
+  /** Java: configured step. */
+  fun step(
+    intent: String,
+    phase: Phase,
+    kick: Kick,
+    configurator: Consumer<StepSpec>,
+  ): RunbookBuilder = apply {
+    val spec =
+      StepSpec().also {
+        it.intent = intent
+        it.phase = phase
+        it.kick = kick
+      }
+    configurator.accept(spec)
+    steps += spec.build()
+  }
+
+  internal fun addSpec(spec: StepSpec) = apply { steps += spec.build() }
+
+  internal fun build(): Runbook = Runbook(name, steps.toList())
+
+  fun off(): Runbook = build()
+}
+
+/** Kotlin top-level receiver DSL entry point. */
+fun Runbook(name: String? = null, block: RunbookBuilder.() -> Unit): Runbook =
+  RunbookBuilder().apply { name?.let { name(it) } }.apply(block).build()
+
+/** Kotlin `step { }` receiver — accumulates a [StepSpec] into the builder. */
+@RunbookDsl
+fun RunbookBuilder.step(block: StepSpec.() -> Unit) {
+  addSpec(StepSpec().apply(block))
+}

--- a/src/main/kotlin/com/salesforce/revoman/input/config/Runbook.kt
+++ b/src/main/kotlin/com/salesforce/revoman/input/config/Runbook.kt
@@ -7,6 +7,7 @@
  */
 package com.salesforce.revoman.input.config
 
+import com.salesforce.revoman.output.log.RunLogSink
 import java.util.function.Consumer
 
 /**
@@ -20,7 +21,12 @@ import java.util.function.Consumer
  * via the Kotlin `Runbook { step { } }` DSL or the Java `Runbook.configure()...off()` builder;
  * drive with `ReVoman.revUp(runbook)`.
  */
-class Runbook internal constructor(val name: String?, val steps: List<RunbookStep>) {
+class Runbook
+internal constructor(
+  val name: String?,
+  val steps: List<RunbookStep>,
+  val runLogSink: RunLogSink,
+) {
   companion object {
     @JvmStatic fun configure(): RunbookBuilder = RunbookBuilder()
   }
@@ -31,8 +37,11 @@ class Runbook internal constructor(val name: String?, val steps: List<RunbookSte
 class RunbookBuilder internal constructor() {
   private var name: String? = null
   private val steps: MutableList<RunbookStep> = mutableListOf()
+  var runLogSink: RunLogSink = RunLogSink.NoOp
 
   fun name(name: String): RunbookBuilder = apply { this.name = name }
+
+  fun runLogSink(sink: RunLogSink): RunbookBuilder = apply { this.runLogSink = sink }
 
   /** Java: pure-narration step (no contract/assertion). */
   fun step(intent: String, phase: Phase, kick: Kick): RunbookBuilder =
@@ -57,7 +66,7 @@ class RunbookBuilder internal constructor() {
 
   internal fun addSpec(spec: StepSpec) = apply { steps += spec.build() }
 
-  internal fun build(): Runbook = Runbook(name, steps.toList())
+  internal fun build(): Runbook = Runbook(name, steps.toList(), runLogSink)
 
   fun off(): Runbook = build()
 }

--- a/src/main/kotlin/com/salesforce/revoman/input/config/Runbook.kt
+++ b/src/main/kotlin/com/salesforce/revoman/input/config/Runbook.kt
@@ -67,7 +67,6 @@ fun Runbook(name: String? = null, block: RunbookBuilder.() -> Unit): Runbook =
   RunbookBuilder().apply { name?.let { name(it) } }.apply(block).build()
 
 /** Kotlin `step { }` receiver — accumulates a [StepSpec] into the builder. */
-@RunbookDsl
 fun RunbookBuilder.step(block: StepSpec.() -> Unit) {
   addSpec(StepSpec().apply(block))
 }

--- a/src/main/kotlin/com/salesforce/revoman/input/config/Runbook.kt
+++ b/src/main/kotlin/com/salesforce/revoman/input/config/Runbook.kt
@@ -26,22 +26,49 @@ internal constructor(
   val name: String?,
   val steps: List<RunbookStep>,
   val runLogSink: RunLogSink,
+  /**
+   * When true (default), a step whose underlying collection has an un-ignored failure halts the
+   * runbook (throws [AssertionError]) like a contract breach. When false, the step is marked FAILED
+   * in the log/views and the runbook continues — the caller inspects the returned
+   * [com.salesforce.revoman.output.RunbookRundown] (mirrors base `revUp(List<Kick>)`).
+   */
+  val haltOnStepFailure: Boolean,
 ) {
   companion object {
     @JvmStatic fun configure(): RunbookBuilder = RunbookBuilder()
   }
 }
 
-/** Fluent builder backing both language front doors. */
+/**
+ * Fluent builder backing both language front doors. Each configurable field has exactly ONE storage
+ * slot funneled through a fluent method (Java) and a receiver `var` extension (the Kotlin DSL, e.g.
+ * [RunbookBuilder.runLogSink]/[RunbookBuilder.haltOnStepFailure] below) — never a public raw field.
+ */
 @RunbookDsl
 class RunbookBuilder internal constructor() {
   private var name: String? = null
   private val steps: MutableList<RunbookStep> = mutableListOf()
-  var runLogSink: RunLogSink = RunLogSink.NoOp
+  internal var runLogSinkValue: RunLogSink = RunLogSink.NoOp
+  internal var haltOnStepFailureValue: Boolean = true
 
+  /** Sets the runbook's human-readable [Runbook.name]. */
   fun name(name: String): RunbookBuilder = apply { this.name = name }
 
-  fun runLogSink(sink: RunLogSink): RunbookBuilder = apply { this.runLogSink = sink }
+  /**
+   * Sets the runbook-scope [RunLogSink]. Its child per-request events nest under this runbook's
+   * brackets so the whole run renders as one coherent tree.
+   */
+  fun runLogSink(sink: RunLogSink): RunbookBuilder = apply { this.runLogSinkValue = sink }
+
+  /**
+   * When true (default), a step whose underlying collection has an un-ignored failure halts the
+   * runbook (throws [AssertionError]) like a contract breach. When false, the step is marked FAILED
+   * in the log/views and the runbook continues — the caller inspects the returned
+   * [com.salesforce.revoman.output.RunbookRundown] (mirrors base `revUp(List<Kick>)`).
+   */
+  fun haltOnStepFailure(halt: Boolean): RunbookBuilder = apply {
+    this.haltOnStepFailureValue = halt
+  }
 
   /** Java: pure-narration step (no contract/assertion). */
   fun step(intent: String, phase: Phase, kick: Kick): RunbookBuilder =
@@ -66,10 +93,31 @@ class RunbookBuilder internal constructor() {
 
   internal fun addSpec(spec: StepSpec) = apply { steps += spec.build() }
 
-  internal fun build(): Runbook = Runbook(name, steps.toList(), runLogSink)
+  internal fun build(): Runbook =
+    Runbook(name, steps.toList(), runLogSinkValue, haltOnStepFailureValue)
 
   fun off(): Runbook = build()
 }
+
+/**
+ * Kotlin DSL alias for [RunbookBuilder.runLogSink]: `Runbook { runLogSink = mySink }`. Funnels to
+ * the same single storage the fluent method writes.
+ */
+var RunbookBuilder.runLogSink: RunLogSink
+  get() = runLogSinkValue
+  set(value) {
+    runLogSinkValue = value
+  }
+
+/**
+ * Kotlin DSL alias for [RunbookBuilder.haltOnStepFailure]: `Runbook { haltOnStepFailure = false }`.
+ * Funnels to the same single storage the fluent method writes. Defaults to true (halt).
+ */
+var RunbookBuilder.haltOnStepFailure: Boolean
+  get() = haltOnStepFailureValue
+  set(value) {
+    haltOnStepFailureValue = value
+  }
 
 /** Kotlin top-level receiver DSL entry point. */
 fun Runbook(name: String? = null, block: RunbookBuilder.() -> Unit): Runbook =

--- a/src/main/kotlin/com/salesforce/revoman/input/config/RunbookStep.kt
+++ b/src/main/kotlin/com/salesforce/revoman/input/config/RunbookStep.kt
@@ -1,0 +1,84 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.input.config
+
+import com.salesforce.revoman.output.Rundown
+import com.salesforce.revoman.output.postman.PostmanEnvironment
+
+/**
+ * The story phase a [RunbookStep] belongs to; drives log grouping. Mirrors the comment blocks that
+ * today separate setup/seed/act config constants.
+ */
+enum class Phase {
+  SETUP,
+  SEED,
+  ACT,
+  ASSERT,
+  CLEANUP,
+}
+
+/**
+ * A per-step assertion run after a step's [Rundown] is produced; receives that step's rundown and
+ * the accumulated env. A thrown [AssertionError] halts the runbook. Complementary to the contract
+ * checks and to the whole-run `postExeHook`.
+ */
+fun interface StepAssertion {
+  fun assertStep(rundown: Rundown, env: PostmanEnvironment<Any?>)
+}
+
+/**
+ * Mutable builder serving BOTH the Kotlin `step { }` receiver DSL and the Java `Consumer<StepSpec>`
+ * configurator. Snapshot into an immutable [RunbookStep] via [build]. Deviates from the Immutables
+ * convention used by [Kick] because [assertAfter] is a lambda and one spec must serve both language
+ * front doors.
+ */
+class StepSpec {
+  var intent: String = ""
+  var phase: Phase = Phase.SETUP
+  var kick: Kick? = null
+
+  private val consumes: MutableSet<String> = linkedSetOf()
+  private val produces: MutableMap<String, String?> = linkedMapOf()
+  private var underTest: Boolean = false
+  private var assertAfter: StepAssertion? = null
+
+  fun consumes(vararg keys: String): StepSpec = apply { consumes += keys }
+
+  fun produces(vararg keys: String): StepSpec = apply { keys.forEach { produces[it] = null } }
+
+  fun produces(keyToValue: Map<String, String?>): StepSpec = apply { produces += keyToValue }
+
+  fun produces(pair: Pair<String, String?>): StepSpec = apply { produces[pair.first] = pair.second }
+
+  fun underTest(): StepSpec = apply { underTest = true }
+
+  fun assertAfter(assertion: StepAssertion): StepSpec = apply { assertAfter = assertion }
+
+  fun build(): RunbookStep =
+    RunbookStep(
+      intent = intent,
+      phase = phase,
+      kick =
+        checkNotNull(kick) { "A runbook `step` requires a `kick` (was null for intent='$intent')" },
+      consumes = consumes.toSet(),
+      produces = produces.toMap(),
+      underTest = underTest,
+      assertAfter = assertAfter,
+    )
+}
+
+/** Immutable snapshot of one runbook step: a [Kick] wrapped with narration. */
+data class RunbookStep(
+  val intent: String,
+  val phase: Phase,
+  val kick: Kick,
+  val consumes: Set<String>,
+  val produces: Map<String, String?>,
+  val underTest: Boolean,
+  val assertAfter: StepAssertion?,
+)

--- a/src/main/kotlin/com/salesforce/revoman/input/config/RunbookStep.kt
+++ b/src/main/kotlin/com/salesforce/revoman/input/config/RunbookStep.kt
@@ -37,6 +37,7 @@ fun interface StepAssertion {
  * convention used by [Kick] because [assertAfter] is a lambda and one spec must serve both language
  * front doors.
  */
+@RunbookDsl
 class StepSpec {
   var intent: String = ""
   var phase: Phase = Phase.SETUP

--- a/src/main/kotlin/com/salesforce/revoman/input/config/RunbookStep.kt
+++ b/src/main/kotlin/com/salesforce/revoman/input/config/RunbookStep.kt
@@ -40,7 +40,7 @@ fun interface StepAssertion {
 @RunbookDsl
 class StepSpec {
   var intent: String = ""
-  var phase: Phase = Phase.SETUP
+  var phase: Phase? = null
   var kick: Kick? = null
 
   private val consumes: MutableSet<String> = linkedSetOf()
@@ -64,7 +64,7 @@ class StepSpec {
     require(intent.isNotBlank()) { "A runbook step requires a non-blank intent" }
     return RunbookStep(
       intent = intent,
-      phase = phase,
+      phase = checkNotNull(phase) { "A runbook step requires a `phase`" },
       kick =
         checkNotNull(kick) { "A runbook `step` requires a `kick` (was null for intent='$intent')" },
       consumes = consumes.toSet(),
@@ -75,8 +75,14 @@ class StepSpec {
   }
 }
 
-/** Immutable snapshot of one runbook step: a [Kick] wrapped with narration. */
-data class RunbookStep(
+/**
+ * Immutable snapshot of one runbook step: a [Kick] wrapped with narration. Its constructor is
+ * `internal` so all construction routes through [StepSpec.build], which enforces the invariants
+ * (non-blank [intent], non-null [phase]/[kick]); the public `data class` `copy()` stays visible to
+ * the same Gradle module (tests) but not to library consumers.
+ */
+data class RunbookStep
+internal constructor(
   val intent: String,
   val phase: Phase,
   val kick: Kick,

--- a/src/main/kotlin/com/salesforce/revoman/input/config/RunbookStep.kt
+++ b/src/main/kotlin/com/salesforce/revoman/input/config/RunbookStep.kt
@@ -60,8 +60,9 @@ class StepSpec {
 
   fun assertAfter(assertion: StepAssertion): StepSpec = apply { assertAfter = assertion }
 
-  fun build(): RunbookStep =
-    RunbookStep(
+  fun build(): RunbookStep {
+    require(intent.isNotBlank()) { "A runbook step requires a non-blank intent" }
+    return RunbookStep(
       intent = intent,
       phase = phase,
       kick =
@@ -71,6 +72,7 @@ class StepSpec {
       underTest = underTest,
       assertAfter = assertAfter,
     )
+  }
 }
 
 /** Immutable snapshot of one runbook step: a [Kick] wrapped with narration. */

--- a/src/main/kotlin/com/salesforce/revoman/internal/exe/RunbookContract.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/exe/RunbookContract.kt
@@ -1,0 +1,45 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.exe
+
+import com.salesforce.revoman.input.config.RunbookStep
+import com.salesforce.revoman.output.postman.PostmanEnvironment
+
+/**
+ * A step's data-flow contract breach. Empty sets/map = satisfied. `valueMismatches` maps a key to
+ * `expected to actual`.
+ */
+internal data class ContractViolation(
+  val missingConsumed: Set<String> = emptySet(),
+  val missingProduced: Set<String> = emptySet(),
+  val valueMismatches: Map<String, Pair<String?, String?>> = emptyMap(),
+)
+
+internal fun ContractViolation.isEmpty(): Boolean =
+  missingConsumed.isEmpty() && missingProduced.isEmpty() && valueMismatches.isEmpty()
+
+/**
+ * Subset/at-least: the declared consume keys absent from [envKeys]. Extras in the env are ignored.
+ */
+internal fun checkConsumes(step: RunbookStep, envKeys: Set<String>): Set<String> =
+  step.consumes - envKeys
+
+/** Subset/at-least on produced keys, plus value equality for declared key→value entries. */
+internal fun checkProduces(step: RunbookStep, env: PostmanEnvironment<Any?>): ContractViolation {
+  val missing = step.produces.keys.filterNot { env.containsKey(it) }.toSet()
+  val mismatches =
+    step.produces
+      .filterValues { it != null }
+      .filterKeys { it !in missing }
+      .mapNotNull { (key, expected) ->
+        val actual = env.getAsString(key)
+        if (actual == expected) null else key to (expected to actual)
+      }
+      .toMap()
+  return ContractViolation(missingProduced = missing, valueMismatches = mismatches)
+}

--- a/src/main/kotlin/com/salesforce/revoman/internal/exe/RunbookContract.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/exe/RunbookContract.kt
@@ -5,6 +5,8 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  * ************************************************************************************************
  */
+// detekt MatchingDeclarationName: this file intentionally groups ContractViolation + its check
+// functions (checkConsumes/checkProduces/isEmpty); the file name describes the group, not one decl.
 @file:Suppress("MatchingDeclarationName")
 
 package com.salesforce.revoman.internal.exe

--- a/src/main/kotlin/com/salesforce/revoman/internal/exe/RunbookContract.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/exe/RunbookContract.kt
@@ -29,6 +29,10 @@ internal fun ContractViolation.isEmpty(): Boolean =
 
 /**
  * Subset/at-least: the declared consume keys absent from [envKeys]. Extras in the env are ignored.
+ *
+ * Presence-only semantics: a declared key that is PRESENT in [envKeys] satisfies the consume even
+ * if its env value is null — this checks key presence, not value non-nullness, so authors are not
+ * lulled into thinking a null-valued key would be reported missing.
  */
 internal fun checkConsumes(step: RunbookStep, envKeys: Set<String>): Set<String> =
   step.consumes - envKeys

--- a/src/main/kotlin/com/salesforce/revoman/internal/exe/RunbookContract.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/exe/RunbookContract.kt
@@ -5,6 +5,8 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  * ************************************************************************************************
  */
+@file:Suppress("MatchingDeclarationName")
+
 package com.salesforce.revoman.internal.exe
 
 import com.salesforce.revoman.input.config.RunbookStep

--- a/src/main/kotlin/com/salesforce/revoman/internal/exe/RunbookExe.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/exe/RunbookExe.kt
@@ -30,7 +30,11 @@ internal fun executeRunbook(
   dynamicEnvironment: Map<String, Any?>,
 ): RunbookRundown {
   val runbookSink = runbook.runLogSink
-  val previousSink = RunLogContext.install(runbookSink)
+  // Install the runbook-scope sink ONLY when it is a real sink. For the NoOp default there is
+  // nothing to route to, and skipping the install keeps `current()` null so the zero-config path
+  // stays bit-identical to before this layer existed (e.g. the summary line below renders lazily).
+  val installed = runbookSink !== RunLogSink.NoOp
+  val previousSink = if (installed) RunLogContext.install(runbookSink) else null
   try {
     var accumulatedEnv: Map<String, Any?> = dynamicEnvironment
     var lastPhase: Phase? = null
@@ -78,7 +82,7 @@ internal fun executeRunbook(
     RevomanLog.info { "\n" + renderRunbookMarkdown(result) }
     return result
   } finally {
-    RunLogContext.restore(previousSink)
+    if (installed) RunLogContext.restore(previousSink)
   }
 }
 

--- a/src/main/kotlin/com/salesforce/revoman/internal/exe/RunbookExe.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/exe/RunbookExe.kt
@@ -64,7 +64,9 @@ internal fun executeRunbook(
       accumulatedEnv = rundown.mutableEnv.immutableEnv
       step to rundown
     }
-  return RunbookRundown(runbook.name, pairs)
+  val result = RunbookRundown(runbook.name, pairs)
+  RevomanLog.info { "\n" + com.salesforce.revoman.output.renderRunbookMarkdown(result) }
+  return result
 }
 
 private fun producedValues(step: RunbookStep, rundown: Rundown): Map<String, String?> =

--- a/src/main/kotlin/com/salesforce/revoman/internal/exe/RunbookExe.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/exe/RunbookExe.kt
@@ -12,10 +12,13 @@ import com.salesforce.revoman.input.config.Phase
 import com.salesforce.revoman.input.config.Runbook
 import com.salesforce.revoman.input.config.RunbookStep
 import com.salesforce.revoman.internal.log.RevomanLog
+import com.salesforce.revoman.internal.log.RunLogContext
 import com.salesforce.revoman.output.RunbookRundown
 import com.salesforce.revoman.output.Rundown
 import com.salesforce.revoman.output.log.Outcome
+import com.salesforce.revoman.output.log.RunLogSink
 import com.salesforce.revoman.output.log.StepEvent
+import com.salesforce.revoman.output.renderRunbookMarkdown
 
 /**
  * Drives a [Runbook] over the existing single-kick [ReVoman.revUp], threading env exactly as the
@@ -26,47 +29,57 @@ internal fun executeRunbook(
   runbook: Runbook,
   dynamicEnvironment: Map<String, Any?>,
 ): RunbookRundown {
-  var accumulatedEnv: Map<String, Any?> = dynamicEnvironment
-  var lastPhase: Phase? = null
-  val pairs =
-    runbook.steps.map { step ->
-      if (step.phase != lastPhase) {
-        RevomanLog.event(StepEvent.PhaseEntered(step.phase))
-        lastPhase = step.phase
+  val runbookSink = runbook.runLogSink
+  val previousSink = RunLogContext.install(runbookSink)
+  try {
+    var accumulatedEnv: Map<String, Any?> = dynamicEnvironment
+    var lastPhase: Phase? = null
+    val pairs =
+      runbook.steps.map { step ->
+        if (step.phase != lastPhase) {
+          RevomanLog.event(StepEvent.PhaseEntered(step.phase))
+          lastPhase = step.phase
+        }
+        RevomanLog.event(
+          StepEvent.RunbookStepStarted(
+            step.intent,
+            step.intent,
+            step.phase,
+            step.consumes,
+            step.underTest,
+          )
+        )
+        checkConsumesOrHalt(step, accumulatedEnv.keys)
+        val startNs = System.nanoTime()
+        // Thread the runbook sink into the kick so its child per-request events nest under
+        // this runbook's brackets (same sink instance = coherent tree). Only when the runbook
+        // has a real sink — otherwise leave the kick's own sink untouched (backward compat).
+        val kickToRun =
+          step.kick
+            .overrideDynamicEnvironment(step.kick.dynamicEnvironment() + accumulatedEnv)
+            .let { if (runbookSink !== RunLogSink.NoOp) it.overrideRunLogSink(runbookSink) else it }
+        val rundown = ReVoman.revUp(kickToRun)
+        val tookMs = (System.nanoTime() - startNs) / 1_000_000
+        checkProducesOrHalt(step, rundown, tookMs)
+        step.assertAfter?.assertStep(rundown, rundown.mutableEnv)
+        RevomanLog.event(
+          StepEvent.RunbookStepFinished(
+            step.intent,
+            step.intent,
+            Outcome.SUCCESS,
+            producedValues(step, rundown),
+            tookMs,
+          )
+        )
+        accumulatedEnv = rundown.mutableEnv.immutableEnv
+        step to rundown
       }
-      RevomanLog.event(
-        StepEvent.RunbookStepStarted(
-          step.intent,
-          step.intent,
-          step.phase,
-          step.consumes,
-          step.underTest,
-        )
-      )
-      checkConsumesOrHalt(step, accumulatedEnv.keys)
-      val startNs = System.nanoTime()
-      val rundown =
-        ReVoman.revUp(
-          step.kick.overrideDynamicEnvironment(step.kick.dynamicEnvironment() + accumulatedEnv)
-        )
-      val tookMs = (System.nanoTime() - startNs) / 1_000_000
-      checkProducesOrHalt(step, rundown, tookMs)
-      step.assertAfter?.assertStep(rundown, rundown.mutableEnv)
-      RevomanLog.event(
-        StepEvent.RunbookStepFinished(
-          step.intent,
-          step.intent,
-          Outcome.SUCCESS,
-          producedValues(step, rundown),
-          tookMs,
-        )
-      )
-      accumulatedEnv = rundown.mutableEnv.immutableEnv
-      step to rundown
-    }
-  val result = RunbookRundown(runbook.name, pairs)
-  RevomanLog.info { "\n" + com.salesforce.revoman.output.renderRunbookMarkdown(result) }
-  return result
+    val result = RunbookRundown(runbook.name, pairs)
+    RevomanLog.info { "\n" + renderRunbookMarkdown(result) }
+    return result
+  } finally {
+    RunLogContext.restore(previousSink)
+  }
 }
 
 private fun producedValues(step: RunbookStep, rundown: Rundown): Map<String, String?> =

--- a/src/main/kotlin/com/salesforce/revoman/internal/exe/RunbookExe.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/exe/RunbookExe.kt
@@ -74,13 +74,30 @@ private data class RunbookAcc(
  * produces/assertAfter — because a failed collection makes those downstream checks meaningless and
  * their messages misleading.
  */
+@Suppress("TooGenericExceptionCaught")
 private fun executeStep(
   runbook: Runbook,
   runbookSink: RunLogSink,
   step: RunbookStep,
   acc: RunbookAcc,
 ): RunbookAcc {
-  if (step.phase != acc.lastPhase) {
+  emitStepOpen(step, acc.lastPhase)
+  val startNs = System.nanoTime()
+  val close = StepCloseGuard(step, startNs)
+  // A catch-all is intentional here: the bracket MUST be closed on EVERY throw between the open
+  // and the normal close — an AssertionError from a contract/assertAfter breach, a step-failure
+  // halt, or any error out of `revUp` — after which we rethrow verbatim (see [StepCloseGuard]).
+  try {
+    return runStepBody(runbook, runbookSink, step, acc, startNs, close)
+  } catch (t: Throwable) {
+    close.emitFailedIfOpen()
+    throw t
+  }
+}
+
+/** Emits the phase rule (only on a phase change) and the step-open bracket for [step]. */
+private fun emitStepOpen(step: RunbookStep, lastPhase: Phase?) {
+  if (step.phase != lastPhase) {
     RevomanLog.event(StepEvent.PhaseEntered(step.phase))
   }
   RevomanLog.event(
@@ -92,71 +109,78 @@ private fun executeStep(
       step.underTest,
     )
   )
-  val startNs = System.nanoTime()
-  var closeEmitted = false
-  try {
-    checkConsumesOrHalt(step, acc.env.keys)
-    // Thread the runbook sink into the kick so its child per-request events nest under this
-    // runbook's brackets (same sink instance = coherent tree). Only when the runbook has a real
-    // sink — otherwise leave the kick's own sink untouched (backward compat).
-    val kickToRun =
-      step.kick.overrideDynamicEnvironment(step.kick.dynamicEnvironment() + acc.env).let {
-        if (runbookSink !== RunLogSink.NoOp) it.overrideRunLogSink(runbookSink) else it
-      }
-    val rundown = ReVoman.revUp(kickToRun)
-    val tookMs = (System.nanoTime() - startNs) / 1_000_000
-    val nextAcc =
-      RunbookAcc(rundown.mutableEnv.immutableEnv, step.phase, acc.pairs + (step to rundown))
-    val failedReport = rundown.firstUnIgnoredUnsuccessfulStepReport
-    return when {
-      failedReport != null -> {
-        RevomanLog.event(
-          StepEvent.RunbookStepFinished(
-            step.intent,
-            step.intent,
-            Outcome.FAILED,
-            producedValues(step, rundown),
-            tookMs,
-          )
-        )
-        closeEmitted = true
-        if (runbook.haltOnStepFailure) {
-          throw AssertionError(
-            "Runbook step '${step.intent}' failed: underlying collection step " +
-              "'${failedReport.step.path}' was unsuccessful (stopReason=${rundown.stopReason})"
-          )
-        }
-        // Continue: keep the (step, rundown) pair and thread env forward; do NOT emit a SUCCESS
-        // close. The caller inspects the returned RunbookRundown (mirrors base revUp(List<Kick>)).
-        nextAcc
-      }
-      else -> {
-        checkProducesOrHalt(step, rundown)
-        step.assertAfter?.assertStep(rundown, rundown.mutableEnv)
-        RevomanLog.event(
-          StepEvent.RunbookStepFinished(
-            step.intent,
-            step.intent,
-            Outcome.SUCCESS,
-            producedValues(step, rundown),
-            tookMs,
-          )
-        )
-        closeEmitted = true
-        nextAcc
-      }
+}
+
+/**
+ * Runs [step]'s kick and resolves its outcome into the next [RunbookAcc]. Underlying-collection
+ * failure is checked FIRST — before produces/assertAfter — because a failed collection makes those
+ * downstream checks meaningless and their messages misleading. Outcome is derived, never hardcoded.
+ */
+private fun runStepBody(
+  runbook: Runbook,
+  runbookSink: RunLogSink,
+  step: RunbookStep,
+  acc: RunbookAcc,
+  startNs: Long,
+  close: StepCloseGuard,
+): RunbookAcc {
+  checkConsumesOrHalt(step, acc.env.keys)
+  // Thread the runbook sink into the kick so its child per-request events nest under this runbook's
+  // brackets (same sink instance = coherent tree). Only when the runbook has a real sink —
+  // otherwise leave the kick's own sink untouched (backward compat).
+  val kickToRun =
+    step.kick.overrideDynamicEnvironment(step.kick.dynamicEnvironment() + acc.env).let {
+      if (runbookSink !== RunLogSink.NoOp) it.overrideRunLogSink(runbookSink) else it
     }
-  } catch (t: Throwable) {
-    // FIX 2: close the bracket on EVERY halt path (consumes breach, produces breach, assertAfter
-    // throw, or a step-failure halt whose close was not already emitted above). Exactly one close
-    // per step. The RunbookContractFailed detail line is emitted separately by the check helpers.
-    if (!closeEmitted) {
+  val rundown = ReVoman.revUp(kickToRun)
+  val tookMs = (System.nanoTime() - startNs) / 1_000_000
+  val nextAcc =
+    RunbookAcc(rundown.mutableEnv.immutableEnv, step.phase, acc.pairs + (step to rundown))
+  val failedReport = rundown.firstUnIgnoredUnsuccessfulStepReport
+  return when {
+    failedReport != null -> {
+      close.emit(Outcome.FAILED, producedValues(step, rundown), tookMs)
+      if (runbook.haltOnStepFailure) {
+        throw AssertionError(
+          "Runbook step '${step.intent}' failed: underlying collection step " +
+            "'${failedReport.step.path}' was unsuccessful (stopReason=${rundown.stopReason})"
+        )
+      }
+      // Continue: keep the (step, rundown) pair and thread env forward; do NOT emit a SUCCESS
+      // close. The caller inspects the returned RunbookRundown (mirrors base revUp(List<Kick>)).
+      nextAcc
+    }
+    else -> {
+      checkProducesOrHalt(step, rundown)
+      step.assertAfter?.assertStep(rundown, rundown.mutableEnv)
+      close.emit(Outcome.SUCCESS, producedValues(step, rundown), tookMs)
+      nextAcc
+    }
+  }
+}
+
+/**
+ * Guarantees EXACTLY ONE [StepEvent.RunbookStepFinished] close per step. The normal paths call
+ * [emit] with the derived outcome; any throw before that routes through [emitStepOpen]'s caller
+ * catch, which calls [emitFailedIfOpen] to close a still-open bracket with [Outcome.FAILED] (so no
+ * halt path leaves a dangling `┌` with no `└`). The [StepEvent.RunbookContractFailed] detail line
+ * is emitted separately by the check helpers.
+ */
+private class StepCloseGuard(private val step: RunbookStep, private val startNs: Long) {
+  private var emitted = false
+
+  fun emit(outcome: Outcome, produced: Map<String, String?>, tookMs: Long) {
+    RevomanLog.event(
+      StepEvent.RunbookStepFinished(step.intent, step.intent, outcome, produced, tookMs)
+    )
+    emitted = true
+  }
+
+  fun emitFailedIfOpen() {
+    if (!emitted) {
       val tookMs = (System.nanoTime() - startNs) / 1_000_000
-      RevomanLog.event(
-        StepEvent.RunbookStepFinished(step.intent, step.intent, Outcome.FAILED, emptyMap(), tookMs)
-      )
+      emit(Outcome.FAILED, emptyMap(), tookMs)
     }
-    throw t
   }
 }
 

--- a/src/main/kotlin/com/salesforce/revoman/internal/exe/RunbookExe.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/exe/RunbookExe.kt
@@ -23,7 +23,9 @@ import com.salesforce.revoman.output.renderRunbookMarkdown
 /**
  * Drives a [Runbook] over the existing single-kick [ReVoman.revUp], threading env exactly as the
  * multi-kick fold (ReVoman.kt) does, and interleaving coarse log events + data-flow contract
- * checks + per-step assertions. First breach throws [AssertionError] (halt).
+ * checks + per-step assertions. A contract/assert breach always throws [AssertionError] (halt); an
+ * underlying-collection step failure halts or is recorded-and-continued per
+ * [Runbook.haltOnStepFailure].
  */
 internal fun executeRunbook(
   runbook: Runbook,
@@ -36,35 +38,100 @@ internal fun executeRunbook(
   val installed = runbookSink !== RunLogSink.NoOp
   val previousSink = if (installed) RunLogContext.install(runbookSink) else null
   try {
-    var accumulatedEnv: Map<String, Any?> = dynamicEnvironment
-    var lastPhase: Phase? = null
-    val pairs =
-      runbook.steps.map { step ->
-        if (step.phase != lastPhase) {
-          RevomanLog.event(StepEvent.PhaseEntered(step.phase))
-          lastPhase = step.phase
-        }
+    // Immutable state transformation via fold (mirrors the multi-kick fold in ReVoman.kt): each
+    // step yields a NEW accumulator (threaded env, last phase, accumulated (step, rundown) pairs).
+    // A halt propagates as a thrown exception, aborting the fold just like the former `.map`.
+    val finalAcc =
+      runbook.steps.fold(RunbookAcc(dynamicEnvironment, null, emptyList())) { acc, step ->
+        executeStep(runbook, runbookSink, step, acc)
+      }
+    val result = RunbookRundown(runbook.name, finalAcc.pairs)
+    RevomanLog.info { "\n" + renderRunbookMarkdown(result) }
+    return result
+  } finally {
+    if (installed) RunLogContext.restore(previousSink)
+  }
+}
+
+/**
+ * The fold accumulator threaded across runbook steps: the env carried forward (all value types),
+ * the [Phase] of the previous step (to emit a [StepEvent.PhaseEntered] only on change), and the
+ * ordered (step, rundown) pairs produced so far.
+ */
+private data class RunbookAcc(
+  val env: Map<String, Any?>,
+  val lastPhase: Phase?,
+  val pairs: List<Pair<RunbookStep, Rundown>>,
+)
+
+/**
+ * Executes ONE runbook step and returns the next [RunbookAcc]. Emits exactly one
+ * [StepEvent.RunbookStepFinished] per step, always, carrying the correct [Outcome]: any throw
+ * between the open bracket and the normal close routes through the `catch` which emits a FAILED
+ * close before rethrowing (so no halt path leaves a dangling `┌` open with no `└` close).
+ *
+ * Outcome is derived, never hardcoded. The underlying-collection failure is checked FIRST — before
+ * produces/assertAfter — because a failed collection makes those downstream checks meaningless and
+ * their messages misleading.
+ */
+private fun executeStep(
+  runbook: Runbook,
+  runbookSink: RunLogSink,
+  step: RunbookStep,
+  acc: RunbookAcc,
+): RunbookAcc {
+  if (step.phase != acc.lastPhase) {
+    RevomanLog.event(StepEvent.PhaseEntered(step.phase))
+  }
+  RevomanLog.event(
+    StepEvent.RunbookStepStarted(
+      step.intent,
+      step.intent,
+      step.phase,
+      step.consumes,
+      step.underTest,
+    )
+  )
+  val startNs = System.nanoTime()
+  var closeEmitted = false
+  try {
+    checkConsumesOrHalt(step, acc.env.keys)
+    // Thread the runbook sink into the kick so its child per-request events nest under this
+    // runbook's brackets (same sink instance = coherent tree). Only when the runbook has a real
+    // sink — otherwise leave the kick's own sink untouched (backward compat).
+    val kickToRun =
+      step.kick.overrideDynamicEnvironment(step.kick.dynamicEnvironment() + acc.env).let {
+        if (runbookSink !== RunLogSink.NoOp) it.overrideRunLogSink(runbookSink) else it
+      }
+    val rundown = ReVoman.revUp(kickToRun)
+    val tookMs = (System.nanoTime() - startNs) / 1_000_000
+    val nextAcc =
+      RunbookAcc(rundown.mutableEnv.immutableEnv, step.phase, acc.pairs + (step to rundown))
+    val failedReport = rundown.firstUnIgnoredUnsuccessfulStepReport
+    return when {
+      failedReport != null -> {
         RevomanLog.event(
-          StepEvent.RunbookStepStarted(
+          StepEvent.RunbookStepFinished(
             step.intent,
             step.intent,
-            step.phase,
-            step.consumes,
-            step.underTest,
+            Outcome.FAILED,
+            producedValues(step, rundown),
+            tookMs,
           )
         )
-        checkConsumesOrHalt(step, accumulatedEnv.keys)
-        val startNs = System.nanoTime()
-        // Thread the runbook sink into the kick so its child per-request events nest under
-        // this runbook's brackets (same sink instance = coherent tree). Only when the runbook
-        // has a real sink — otherwise leave the kick's own sink untouched (backward compat).
-        val kickToRun =
-          step.kick
-            .overrideDynamicEnvironment(step.kick.dynamicEnvironment() + accumulatedEnv)
-            .let { if (runbookSink !== RunLogSink.NoOp) it.overrideRunLogSink(runbookSink) else it }
-        val rundown = ReVoman.revUp(kickToRun)
-        val tookMs = (System.nanoTime() - startNs) / 1_000_000
-        checkProducesOrHalt(step, rundown, tookMs)
+        closeEmitted = true
+        if (runbook.haltOnStepFailure) {
+          throw AssertionError(
+            "Runbook step '${step.intent}' failed: underlying collection step " +
+              "'${failedReport.step.path}' was unsuccessful (stopReason=${rundown.stopReason})"
+          )
+        }
+        // Continue: keep the (step, rundown) pair and thread env forward; do NOT emit a SUCCESS
+        // close. The caller inspects the returned RunbookRundown (mirrors base revUp(List<Kick>)).
+        nextAcc
+      }
+      else -> {
+        checkProducesOrHalt(step, rundown)
         step.assertAfter?.assertStep(rundown, rundown.mutableEnv)
         RevomanLog.event(
           StepEvent.RunbookStepFinished(
@@ -75,14 +142,21 @@ internal fun executeRunbook(
             tookMs,
           )
         )
-        accumulatedEnv = rundown.mutableEnv.immutableEnv
-        step to rundown
+        closeEmitted = true
+        nextAcc
       }
-    val result = RunbookRundown(runbook.name, pairs)
-    RevomanLog.info { "\n" + renderRunbookMarkdown(result) }
-    return result
-  } finally {
-    if (installed) RunLogContext.restore(previousSink)
+    }
+  } catch (t: Throwable) {
+    // FIX 2: close the bracket on EVERY halt path (consumes breach, produces breach, assertAfter
+    // throw, or a step-failure halt whose close was not already emitted above). Exactly one close
+    // per step. The RunbookContractFailed detail line is emitted separately by the check helpers.
+    if (!closeEmitted) {
+      val tookMs = (System.nanoTime() - startNs) / 1_000_000
+      RevomanLog.event(
+        StepEvent.RunbookStepFinished(step.intent, step.intent, Outcome.FAILED, emptyMap(), tookMs)
+      )
+    }
+    throw t
   }
 }
 
@@ -99,9 +173,11 @@ private fun checkConsumesOrHalt(step: RunbookStep, envKeys: Set<String>) {
   }
 }
 
-private fun checkProducesOrHalt(step: RunbookStep, rundown: Rundown, tookMs: Long) {
+private fun checkProducesOrHalt(step: RunbookStep, rundown: Rundown) {
   val violation = checkProduces(step, rundown.mutableEnv)
   if (!violation.isEmpty()) {
+    // Emit the CONTRACT detail line only; the FAILED close bracket is emitted by executeStep's
+    // catch, so there is exactly one RunbookStepFinished per step.
     RevomanLog.event(
       StepEvent.RunbookContractFailed(
         step.intent,
@@ -110,9 +186,6 @@ private fun checkProducesOrHalt(step: RunbookStep, rundown: Rundown, tookMs: Lon
         violation.missingProduced,
         violation.valueMismatches,
       )
-    )
-    RevomanLog.event(
-      StepEvent.RunbookStepFinished(step.intent, step.intent, Outcome.FAILED, emptyMap(), tookMs)
     )
     throw AssertionError(
       "Runbook step '${step.intent}' contract breach — missing produced: ${violation.missingProduced}, " +

--- a/src/main/kotlin/com/salesforce/revoman/internal/exe/RunbookExe.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/exe/RunbookExe.kt
@@ -1,0 +1,103 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.exe
+
+import com.salesforce.revoman.ReVoman
+import com.salesforce.revoman.input.config.Phase
+import com.salesforce.revoman.input.config.Runbook
+import com.salesforce.revoman.input.config.RunbookStep
+import com.salesforce.revoman.internal.log.RevomanLog
+import com.salesforce.revoman.output.RunbookRundown
+import com.salesforce.revoman.output.Rundown
+import com.salesforce.revoman.output.log.Outcome
+import com.salesforce.revoman.output.log.StepEvent
+
+/**
+ * Drives a [Runbook] over the existing single-kick [ReVoman.revUp], threading env exactly as the
+ * multi-kick fold (ReVoman.kt) does, and interleaving coarse log events + data-flow contract
+ * checks + per-step assertions. First breach throws [AssertionError] (halt).
+ */
+internal fun executeRunbook(
+  runbook: Runbook,
+  dynamicEnvironment: Map<String, Any?>,
+): RunbookRundown {
+  var accumulatedEnv: Map<String, Any?> = dynamicEnvironment
+  var lastPhase: Phase? = null
+  val pairs =
+    runbook.steps.map { step ->
+      if (step.phase != lastPhase) {
+        RevomanLog.event(StepEvent.PhaseEntered(step.phase))
+        lastPhase = step.phase
+      }
+      RevomanLog.event(
+        StepEvent.RunbookStepStarted(
+          step.intent,
+          step.intent,
+          step.phase,
+          step.consumes,
+          step.underTest,
+        )
+      )
+      checkConsumesOrHalt(step, accumulatedEnv.keys)
+      val startNs = System.nanoTime()
+      val rundown =
+        ReVoman.revUp(
+          step.kick.overrideDynamicEnvironment(step.kick.dynamicEnvironment() + accumulatedEnv)
+        )
+      val tookMs = (System.nanoTime() - startNs) / 1_000_000
+      checkProducesOrHalt(step, rundown, tookMs)
+      step.assertAfter?.assertStep(rundown, rundown.mutableEnv)
+      RevomanLog.event(
+        StepEvent.RunbookStepFinished(
+          step.intent,
+          step.intent,
+          Outcome.SUCCESS,
+          producedValues(step, rundown),
+          tookMs,
+        )
+      )
+      accumulatedEnv = rundown.mutableEnv.immutableEnv
+      step to rundown
+    }
+  return RunbookRundown(runbook.name, pairs)
+}
+
+private fun producedValues(step: RunbookStep, rundown: Rundown): Map<String, String?> =
+  step.produces.keys.associateWith { rundown.mutableEnv.getAsString(it) }
+
+private fun checkConsumesOrHalt(step: RunbookStep, envKeys: Set<String>) {
+  val missing = checkConsumes(step, envKeys)
+  if (missing.isNotEmpty()) {
+    RevomanLog.event(
+      StepEvent.RunbookContractFailed(step.intent, step.intent, missing, emptySet(), emptyMap())
+    )
+    throw AssertionError("Runbook step '${step.intent}' missing consumed env keys: $missing")
+  }
+}
+
+private fun checkProducesOrHalt(step: RunbookStep, rundown: Rundown, tookMs: Long) {
+  val violation = checkProduces(step, rundown.mutableEnv)
+  if (!violation.isEmpty()) {
+    RevomanLog.event(
+      StepEvent.RunbookContractFailed(
+        step.intent,
+        step.intent,
+        emptySet(),
+        violation.missingProduced,
+        violation.valueMismatches,
+      )
+    )
+    RevomanLog.event(
+      StepEvent.RunbookStepFinished(step.intent, step.intent, Outcome.FAILED, emptyMap(), tookMs)
+    )
+    throw AssertionError(
+      "Runbook step '${step.intent}' contract breach — missing produced: ${violation.missingProduced}, " +
+        "value mismatches (expected→actual): ${violation.valueMismatches}"
+    )
+  }
+}

--- a/src/main/kotlin/com/salesforce/revoman/internal/log/RunLogContext.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/log/RunLogContext.kt
@@ -24,7 +24,15 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 internal object RunLogContext {
   private val holder = ThreadLocal<RunLogSink?>()
 
-  fun install(sink: RunLogSink) = holder.set(sink)
+  /**
+   * Installs [sink] as current, returning the previously-installed sink (or null) so a nested
+   * caller can restore it — makes install/restore stack correctly across nested revUp calls.
+   */
+  fun install(sink: RunLogSink): RunLogSink? {
+    val previous = holder.get()
+    holder.set(sink)
+    return previous
+  }
 
   fun current(): RunLogSink? = holder.get()
 
@@ -37,6 +45,11 @@ internal object RunLogContext {
   fun hasActiveSink(): Boolean {
     val sink = holder.get()
     return sink != null && sink !== RunLogSink.NoOp
+  }
+
+  /** Restores a sink captured from [install]; null means "no sink was active", i.e. remove. */
+  fun restore(previous: RunLogSink?) {
+    if (previous == null) holder.remove() else holder.set(previous)
   }
 
   fun remove() = holder.remove()

--- a/src/main/kotlin/com/salesforce/revoman/internal/log/RunLogContext.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/log/RunLogContext.kt
@@ -75,7 +75,12 @@ internal object RevomanLog {
   inline fun error(crossinline msg: () -> String) = tee(LogLevel.ERROR, msg)
 
   fun event(event: StepEvent) {
-    RunLogContext.current()?.let { runCatching { it.event(event) } }
+    RunLogContext.current()?.let {
+      // Keep the no-throw contract (a sink MUST NOT fail the hot execution path), but leave a
+      // breadcrumb so a rendering bug in the sink isn't completely invisible.
+      runCatching { it.event(event) }
+        .onFailure { t -> logger.debug { "run-log sink event failed (ignored): $t" } }
+    }
   }
 
   inline fun tee(level: LogLevel, crossinline msg: () -> String) {
@@ -99,6 +104,8 @@ internal object RevomanLog {
       LogLevel.WARN -> logger.warn { rendered }
       LogLevel.ERROR -> logger.error { rendered }
     }
+    // No-throw contract with a breadcrumb (see [event]).
     runCatching { sink.line(level, rendered) }
+      .onFailure { t -> logger.debug { "run-log sink line failed (ignored): $t" } }
   }
 }

--- a/src/main/kotlin/com/salesforce/revoman/internal/log/RunLogContext.kt
+++ b/src/main/kotlin/com/salesforce/revoman/internal/log/RunLogContext.kt
@@ -14,12 +14,15 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 
 /**
  * Holds the [RunLogSink] active for the current [com.salesforce.revoman.ReVoman.revUp] run. A
- * ThreadLocal because a run executes its steps serially on one thread; [install] at the start of a
- * run, [remove] in its `finally`. [current] is `null` outside a run (the default, NoOp-equivalent
- * path), so non-instrumented callers pay nothing.
+ * ThreadLocal because a run executes its steps serially on one thread. [install] the sink at the
+ * start of a run and [restore] the returned previous sink in its `finally`; this install/restore
+ * pair STACKS, so a nested `revUp` (e.g. a runbook driving per-step kicks) does not wipe the outer
+ * run's sink. [current] is `null` outside any run (the default, NoOp-equivalent path), so
+ * non-instrumented callers pay nothing. [remove] remains for callers that unconditionally clear.
  *
- * **Callers MUST guarantee [remove] runs (e.g. in a `finally`)** — a skipped remove leaks the sink
- * across thread-pool reuse, mis-routing a later unrelated run's logs into a stale sink.
+ * **Callers MUST guarantee [restore] (or [remove]) runs (e.g. in a `finally`)** — a skipped restore
+ * leaks the sink across thread-pool reuse, mis-routing a later unrelated run's logs into a stale
+ * sink.
  */
 internal object RunLogContext {
   private val holder = ThreadLocal<RunLogSink?>()

--- a/src/main/kotlin/com/salesforce/revoman/output/RunbookRundown.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/RunbookRundown.kt
@@ -14,22 +14,47 @@ import com.salesforce.revoman.input.config.RunbookStep
  * `List<Rundown>` so it drops in wherever today's `revUp(List<Kick>)` return is consumed, while
  * adding step pairing and (Task 8) `toMermaid()`/`toMarkdown()` views.
  */
-class RunbookRundown(
+class RunbookRundown
+private constructor(
   val name: String?,
   val stepRundowns: List<Pair<RunbookStep, Rundown>>,
-) : List<Rundown> by (stepRundowns.map { it.second }) {
+  // The backing `List<Rundown>` view delegation forwards to. Held as a NAMED field (not
+  // `stepRundowns.map { }` inlined into the `by` clause) so `equals`/`hashCode`/`toString` below
+  // can
+  // delegate to it directly — delegating them to `this` would recurse infinitely.
+  private val rundownsView: List<Rundown>,
+) : List<Rundown> by rundownsView {
+
+  constructor(
+    name: String?,
+    stepRundowns: List<Pair<RunbookStep, Rundown>>,
+  ) : this(name, stepRundowns, stepRundowns.map { it.second })
 
   /**
    * Explicit accessor for the per-step [Rundown]s (this object also IS that list via delegation).
    */
   val rundowns: List<Rundown>
-    get() = this
+    get() = rundownsView
 
+  /** The (step, rundown) pair for [intent], or null if no step declared it. */
   fun stepFor(intent: String): Pair<RunbookStep, Rundown>? = stepRundowns.firstOrNull {
     it.first.intent == intent
   }
 
+  /** A markdown table view of this runbook — one row per step. */
   fun toMarkdown(): String = renderRunbookMarkdown(this)
 
+  /** A mermaid sequence-diagram view of this runbook — one message per step. */
   fun toMermaid(): String = renderRunbookMermaid(this)
+
+  // Kotlin `by`-delegation forwards only the `List` interface members, NOT `equals`/`hashCode`/
+  // `toString` (they are `Any` members). Without these overrides the type would keep identity
+  // equals while `List` mandates structural equals, breaking the `List` contract (asymmetric with
+  // a plain `List<Rundown>`). Equality is by the per-step [Rundown] list ONLY — [name] and the
+  // step pairing in [stepRundowns] are deliberately excluded, matching `List` semantics.
+  override fun equals(other: Any?): Boolean = rundownsView == other
+
+  override fun hashCode(): Int = rundownsView.hashCode()
+
+  override fun toString(): String = rundownsView.toString()
 }

--- a/src/main/kotlin/com/salesforce/revoman/output/RunbookRundown.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/RunbookRundown.kt
@@ -17,33 +17,13 @@ import com.salesforce.revoman.input.config.RunbookStep
 class RunbookRundown(
   val name: String?,
   val stepRundowns: List<Pair<RunbookStep, Rundown>>,
-) : List<Rundown> {
+) : List<Rundown> by (stepRundowns.map { it.second }) {
 
-  val rundowns: List<Rundown> = stepRundowns.map { it.second }
-
-  override val size: Int
-    get() = rundowns.size
-
-  override fun contains(element: Rundown): Boolean = rundowns.contains(element)
-
-  override fun containsAll(elements: Collection<Rundown>): Boolean = rundowns.containsAll(elements)
-
-  override fun get(index: Int): Rundown = rundowns[index]
-
-  override fun indexOf(element: Rundown): Int = rundowns.indexOf(element)
-
-  override fun isEmpty(): Boolean = rundowns.isEmpty()
-
-  override fun iterator(): Iterator<Rundown> = rundowns.iterator()
-
-  override fun lastIndexOf(element: Rundown): Int = rundowns.lastIndexOf(element)
-
-  override fun listIterator(): ListIterator<Rundown> = rundowns.listIterator()
-
-  override fun listIterator(index: Int): ListIterator<Rundown> = rundowns.listIterator(index)
-
-  override fun subList(fromIndex: Int, toIndex: Int): List<Rundown> =
-    rundowns.subList(fromIndex, toIndex)
+  /**
+   * Explicit accessor for the per-step [Rundown]s (this object also IS that list via delegation).
+   */
+  val rundowns: List<Rundown>
+    get() = this
 
   fun stepFor(intent: String): Pair<RunbookStep, Rundown>? = stepRundowns.firstOrNull {
     it.first.intent == intent

--- a/src/main/kotlin/com/salesforce/revoman/output/RunbookRundown.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/RunbookRundown.kt
@@ -12,7 +12,7 @@ import com.salesforce.revoman.input.config.RunbookStep
 /**
  * The executed runbook: each [RunbookStep] paired with its [Rundown], in order. Implements
  * `List<Rundown>` so it drops in wherever today's `revUp(List<Kick>)` return is consumed, while
- * adding step pairing and (Task 8) `toMermaid()`/`toMarkdown()` views.
+ * adding step pairing and the [toMermaid]/[toMarkdown] views.
  */
 class RunbookRundown
 private constructor(

--- a/src/main/kotlin/com/salesforce/revoman/output/RunbookRundown.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/RunbookRundown.kt
@@ -28,4 +28,8 @@ class RunbookRundown(
   fun stepFor(intent: String): Pair<RunbookStep, Rundown>? = stepRundowns.firstOrNull {
     it.first.intent == intent
   }
+
+  fun toMarkdown(): String = renderRunbookMarkdown(this)
+
+  fun toMermaid(): String = renderRunbookMermaid(this)
 }

--- a/src/main/kotlin/com/salesforce/revoman/output/RunbookRundown.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/RunbookRundown.kt
@@ -1,0 +1,51 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.output
+
+import com.salesforce.revoman.input.config.RunbookStep
+
+/**
+ * The executed runbook: each [RunbookStep] paired with its [Rundown], in order. Implements
+ * `List<Rundown>` so it drops in wherever today's `revUp(List<Kick>)` return is consumed, while
+ * adding step pairing and (Task 8) `toMermaid()`/`toMarkdown()` views.
+ */
+class RunbookRundown(
+  val name: String?,
+  val stepRundowns: List<Pair<RunbookStep, Rundown>>,
+) : List<Rundown> {
+
+  val rundowns: List<Rundown> = stepRundowns.map { it.second }
+
+  override val size: Int
+    get() = rundowns.size
+
+  override fun contains(element: Rundown): Boolean = rundowns.contains(element)
+
+  override fun containsAll(elements: Collection<Rundown>): Boolean = rundowns.containsAll(elements)
+
+  override fun get(index: Int): Rundown = rundowns[index]
+
+  override fun indexOf(element: Rundown): Int = rundowns.indexOf(element)
+
+  override fun isEmpty(): Boolean = rundowns.isEmpty()
+
+  override fun iterator(): Iterator<Rundown> = rundowns.iterator()
+
+  override fun lastIndexOf(element: Rundown): Int = rundowns.lastIndexOf(element)
+
+  override fun listIterator(): ListIterator<Rundown> = rundowns.listIterator()
+
+  override fun listIterator(index: Int): ListIterator<Rundown> = rundowns.listIterator(index)
+
+  override fun subList(fromIndex: Int, toIndex: Int): List<Rundown> =
+    rundowns.subList(fromIndex, toIndex)
+
+  fun stepFor(intent: String): Pair<RunbookStep, Rundown>? = stepRundowns.firstOrNull {
+    it.first.intent == intent
+  }
+}

--- a/src/main/kotlin/com/salesforce/revoman/output/RunbookView.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/RunbookView.kt
@@ -1,0 +1,46 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.output
+
+import com.salesforce.revoman.input.config.RunbookStep
+
+private fun outcomeOf(rundown: Rundown): String =
+  if (rundown.firstUnIgnoredUnsuccessfulStepReport == null) "OK" else "FAIL"
+
+private fun producedText(step: RunbookStep): String =
+  if (step.produces.isEmpty()) "—"
+  else step.produces.entries.joinToString(", ") { (k, v) -> if (v == null) k else "$k=$v" }
+
+private fun consumedText(step: RunbookStep): String =
+  if (step.consumes.isEmpty()) "—" else step.consumes.joinToString(", ")
+
+/** A markdown table runbook: one row per step. Pure function of the declared+executed runbook. */
+internal fun renderRunbookMarkdown(rr: RunbookRundown): String {
+  val title = rr.name?.let { "### Runbook: $it\n\n" } ?: ""
+  val header = "| Phase | Step | Consumes | Produces | Outcome |\n|---|---|---|---|---|\n"
+  val rows =
+    rr.stepRundowns.joinToString("\n") { (step, rundown) ->
+      "| ${step.phase} | ${step.intent} | ${consumedText(step)} | ${producedText(step)} | ${outcomeOf(rundown)} |"
+    }
+  return title + header + rows + "\n"
+}
+
+/**
+ * A mermaid sequence diagram: a `Runbook` participant issuing one message per step, annotated with
+ * produced keys. Theme is applied by whoever writes it into docs.
+ */
+internal fun renderRunbookMermaid(rr: RunbookRundown): String {
+  val lines =
+    rr.stepRundowns.flatMap { (step, _) ->
+      listOf(
+        "    Runbook->>${step.phase}: ${step.intent}",
+        "    Note right of ${step.phase}: ⟶ ${producedText(step)}",
+      )
+    }
+  return (listOf("sequenceDiagram", "    participant Runbook") + lines).joinToString("\n") + "\n"
+}

--- a/src/main/kotlin/com/salesforce/revoman/output/RunbookView.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/RunbookView.kt
@@ -32,14 +32,18 @@ internal fun renderRunbookMarkdown(rr: RunbookRundown): String {
 
 /**
  * A mermaid sequence diagram: a `Runbook` participant issuing one message per step, annotated with
- * produced keys. Theme is applied by whoever writes it into docs.
+ * consumed and produced keys, and under-test marker. Theme is applied by whoever writes it into
+ * docs.
  */
 internal fun renderRunbookMermaid(rr: RunbookRundown): String {
   val lines =
     rr.stepRundowns.flatMap { (step, _) ->
+      val marker = if (step.underTest) "◆ " else ""
+      val consumes = "⟵ ${consumedText(step)}"
+      val produces = "⟶ ${producedText(step)}"
       listOf(
         "    Runbook->>${step.phase}: ${step.intent}",
-        "    Note right of ${step.phase}: ⟶ ${producedText(step)}",
+        "    Note right of ${step.phase}: $marker$consumes  $produces",
       )
     }
   return (listOf("sequenceDiagram", "    participant Runbook") + lines).joinToString("\n") + "\n"

--- a/src/main/kotlin/com/salesforce/revoman/output/log/ConsoleRunLogSink.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/log/ConsoleRunLogSink.kt
@@ -53,29 +53,90 @@ class ConsoleRunLogSink(private val out: PrintStream = System.out) : RunLogSink 
 
   private fun render(event: StepEvent): String =
     when (event) {
-      is StepEvent.StepStarted -> "→  STEP ${event.path} (${event.name})\n"
+      is StepEvent.PhaseEntered -> phaseRule(event.phase.name)
+      is StepEvent.RunbookStepStarted -> renderStepOpen(event)
+      is StepEvent.RunbookStepFinished -> renderStepClose(event)
+      is StepEvent.RunbookContractFailed -> renderContractFailed(event)
+      is StepEvent.StepStarted -> "│ · ${event.name}\n"
       is StepEvent.StepFinished -> renderFinished(event)
-      is StepEvent.LedgerSkipped -> "↩  LEDGER-SKIP ${event.path} reused=${event.reused}\n"
-      is StepEvent.RequestSkipped -> "⤫  REQ-SKIP ${event.path}\n"
-      is StepEvent.Jumped -> "↪  JUMP ${event.path} → ${event.toPath}\n"
-      is StepEvent.RunStopped -> "■  STOP ${event.path}: ${event.reason}\n"
-      is StepEvent.LoopBudgetExceeded -> "✖  LOOP-BUDGET ${event.path} budget=${event.budget}\n"
-      // Minimal stub arms for new coarse runbook events — Task 7 will implement proper rendering
-      is StepEvent.PhaseEntered -> "═══ PHASE ${event.phase.name}\n"
-      is StepEvent.RunbookStepStarted -> "┌─ RUNBOOK-STEP ${event.intent} [${event.phase.name}]\n"
-      is StepEvent.RunbookStepFinished ->
-        "└─ RUNBOOK-STEP ${event.intent} ${event.outcome} (${event.tookMs}ms)\n"
-      is StepEvent.RunbookContractFailed -> "✖  CONTRACT-FAILED ${event.intent}\n"
+      is StepEvent.LedgerSkipped -> "│ ↺ reused ${event.reused}\n"
+      is StepEvent.RequestSkipped -> "│ ⊘ skipped ${event.path}\n"
+      is StepEvent.Jumped -> "│ ↪ ${event.path} → ${event.toPath}\n"
+      is StepEvent.RunStopped -> "■ STOP ${event.path}: ${event.reason}\n"
+      is StepEvent.LoopBudgetExceeded -> "✖ LOOP-BUDGET ${event.path} budget=${event.budget}\n"
     }
 
+  /**
+   * Renders a phase boundary as a horizontal rule filled to [RULE_WIDTH] characters. Example: `━━
+   * SEED ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n`
+   */
+  private fun phaseRule(name: String): String {
+    val prefix = "━━ $name "
+    val fill = (RULE_WIDTH - prefix.length).coerceAtLeast(3)
+    return prefix + "━".repeat(fill) + "\n"
+  }
+
+  /**
+   * Renders a runbook step's opening line: `┌ <marker> <intent> ⟵ <consumes>` + optional `★ UNDER
+   * TEST`. Marker is `◆` when [StepEvent.RunbookStepStarted.underTest], else `▶`.
+   */
+  private fun renderStepOpen(e: StepEvent.RunbookStepStarted): String {
+    val marker = if (e.underTest) "◆" else "▶"
+    val consumes = if (e.consumes.isEmpty()) "—" else e.consumes.joinToString(", ")
+    val underTest = if (e.underTest) "   ★ UNDER TEST" else ""
+    return "┌ $marker ${e.intent}          ⟵ $consumes$underTest\n"
+  }
+
+  /**
+   * Renders a runbook step's closing line: `└ <✔ or ✘> <intent> ⟶ <produced>`. Marker is `✘` when
+   * [StepEvent.RunbookStepFinished.outcome] is [Outcome.FAILED], else `✔`.
+   */
+  private fun renderStepClose(e: StepEvent.RunbookStepFinished): String {
+    val marker = if (e.outcome == Outcome.FAILED) "✘" else "✔"
+    val produced =
+      if (e.produced.isEmpty()) "—"
+      else e.produced.entries.joinToString(", ") { (k, v) -> if (v == null) k else "$k=$v" }
+    return "└ $marker ${e.intent}          ⟶ $produced\n"
+  }
+
+  /**
+   * Renders a contract violation: `│ ⚠ CONTRACT <detail>` where detail lists missing
+   * consumed/produced keys and value mismatches.
+   */
+  private fun renderContractFailed(e: StepEvent.RunbookContractFailed): String {
+    val parts =
+      listOfNotNull(
+        e.missingConsumed.takeIf { it.isNotEmpty() }?.let { "missing consumed: $it" },
+        e.missingProduced.takeIf { it.isNotEmpty() }?.let { "missing produced: $it" },
+        e.valueMismatches
+          .takeIf { it.isNotEmpty() }
+          ?.let { "value mismatch (expected→actual): $it" },
+      )
+    return "│ ⚠ CONTRACT  ${parts.joinToString("; ")}\n"
+  }
+
+  /**
+   * Renders a child request step's finished line: `│ <status> <OK|FAIL|SKIP> <ms>ms` + optional
+   * consumed/produced keys + optional REQ/RESP blocks (all indented with `│` gutter).
+   */
   private fun renderFinished(event: StepEvent.StepFinished): String {
-    val header =
-      "── STEP ${event.path} [${event.httpStatus}] ${event.outcome} (${event.tookMs}ms)\n"
+    val word =
+      when (event.outcome) {
+        Outcome.SUCCESS -> "OK"
+        Outcome.FAILED -> "FAIL"
+        Outcome.SKIPPED -> "SKIP"
+      }
+    val header = "│   ${event.httpStatus} $word ${event.tookMs}ms\n"
     val keys =
       if (event.produced.isEmpty() && event.consumed.isEmpty()) ""
-      else "   produced=${event.produced}  consumed=${event.consumed}\n"
-    val req = event.requestMsg?.let { "REQ:\n$it\n" } ?: ""
-    val resp = event.responseMsg?.let { "RESP:\n$it\n" } ?: ""
+      else "│   ⟵ ${event.consumed}  ⟶ ${event.produced}\n"
+    val req = event.requestMsg?.let { "│ REQ:\n$it\n" } ?: ""
+    val resp = event.responseMsg?.let { "│ RESP:\n$it\n" } ?: ""
     return header + keys + req + resp
+  }
+
+  private companion object {
+    /** Fixed width for phase-rule horizontal lines. */
+    const val RULE_WIDTH = 52
   }
 }

--- a/src/main/kotlin/com/salesforce/revoman/output/log/ConsoleRunLogSink.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/log/ConsoleRunLogSink.kt
@@ -7,7 +7,10 @@
  */
 package com.salesforce.revoman.output.log
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import java.io.PrintStream
+
+private val logger = KotlinLogging.logger {}
 
 /**
  * A built-in [RunLogSink] that renders the structured [StepEvent] stream to a [PrintStream]
@@ -46,7 +49,10 @@ class ConsoleRunLogSink(private val out: PrintStream = System.out) : RunLogSink 
   }
 
   override fun event(event: StepEvent) {
+    // Honor the "MUST NOT throw" contract, but leave a breadcrumb so a render/IO bug isn't
+    // invisible.
     runCatching { out.print(render(event)) }
+      .onFailure { logger.debug { "run-log sink render failed (ignored): $it" } }
   }
 
   /**

--- a/src/main/kotlin/com/salesforce/revoman/output/log/ConsoleRunLogSink.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/log/ConsoleRunLogSink.kt
@@ -60,6 +60,12 @@ class ConsoleRunLogSink(private val out: PrintStream = System.out) : RunLogSink 
       is StepEvent.Jumped -> "↪  JUMP ${event.path} → ${event.toPath}\n"
       is StepEvent.RunStopped -> "■  STOP ${event.path}: ${event.reason}\n"
       is StepEvent.LoopBudgetExceeded -> "✖  LOOP-BUDGET ${event.path} budget=${event.budget}\n"
+      // Minimal stub arms for new coarse runbook events — Task 7 will implement proper rendering
+      is StepEvent.PhaseEntered -> "═══ PHASE ${event.phase.name}\n"
+      is StepEvent.RunbookStepStarted -> "┌─ RUNBOOK-STEP ${event.intent} [${event.phase.name}]\n"
+      is StepEvent.RunbookStepFinished ->
+        "└─ RUNBOOK-STEP ${event.intent} ${event.outcome} (${event.tookMs}ms)\n"
+      is StepEvent.RunbookContractFailed -> "✖  CONTRACT-FAILED ${event.intent}\n"
     }
 
   private fun renderFinished(event: StepEvent.StepFinished): String {

--- a/src/main/kotlin/com/salesforce/revoman/output/log/ConsoleRunLogSink.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/log/ConsoleRunLogSink.kt
@@ -40,6 +40,9 @@ class ConsoleRunLogSink(private val out: PrintStream = System.out) : RunLogSink 
      * are no-ops), so a single instance is safe to share across every Kick and revUp run.
      */
     @JvmField val DEFAULT: ConsoleRunLogSink = ConsoleRunLogSink()
+
+    /** Fixed width for phase-rule horizontal lines. */
+    private const val RULE_WIDTH = 52
   }
 
   override fun event(event: StepEvent) {
@@ -133,10 +136,5 @@ class ConsoleRunLogSink(private val out: PrintStream = System.out) : RunLogSink 
     val req = event.requestMsg?.let { "│ REQ:\n$it\n" } ?: ""
     val resp = event.responseMsg?.let { "│ RESP:\n$it\n" } ?: ""
     return header + keys + req + resp
-  }
-
-  private companion object {
-    /** Fixed width for phase-rule horizontal lines. */
-    const val RULE_WIDTH = 52
   }
 }

--- a/src/main/kotlin/com/salesforce/revoman/output/log/StepEvent.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/log/StepEvent.kt
@@ -7,6 +7,8 @@
  */
 package com.salesforce.revoman.output.log
 
+import com.salesforce.revoman.input.config.Phase
+
 /**
  * Per-step outcome surfaced to a [RunLogSink]; mirrors a
  * [com.salesforce.revoman.output.report.StepReport].
@@ -58,4 +60,36 @@ sealed interface StepEvent {
 
   /** A jump loop exceeded the per-run execution [budget] at [path]. */
   data class LoopBudgetExceeded(override val path: String, val budget: Int) : StepEvent
+
+  /** A runbook phase boundary opened. Coarse event bracketing the per-request events below it. */
+  data class PhaseEntered(val phase: Phase) : StepEvent {
+    override val path: String = phase.name
+  }
+
+  /** A runbook step (one whole collection/[com.salesforce.revoman.input.config.Kick]) opened. */
+  data class RunbookStepStarted(
+    override val path: String,
+    val intent: String,
+    val phase: Phase,
+    val consumes: Set<String>,
+    val underTest: Boolean,
+  ) : StepEvent
+
+  /** A runbook step finished with [outcome]; [produced] maps declared produced keys to values. */
+  data class RunbookStepFinished(
+    override val path: String,
+    val intent: String,
+    val outcome: Outcome,
+    val produced: Map<String, String?>,
+    val tookMs: Long,
+  ) : StepEvent
+
+  /** A runbook step breached its data-flow contract. */
+  data class RunbookContractFailed(
+    override val path: String,
+    val intent: String,
+    val missingConsumed: Set<String>,
+    val missingProduced: Set<String>,
+    val valueMismatches: Map<String, Pair<String?, String?>>,
+  ) : StepEvent
 }

--- a/src/test/java/com/salesforce/revoman/input/config/RunbookJavaDslTest.java
+++ b/src/test/java/com/salesforce/revoman/input/config/RunbookJavaDslTest.java
@@ -1,0 +1,43 @@
+/***************************************************************************************************
+ *  Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier:
+ *           Apache License Version 2.0
+ *  For full license text, see the LICENSE file in the repo root or
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ **************************************************************************************************/
+
+package com.salesforce.revoman.input.config;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.salesforce.revoman.input.config.Phase.ACT;
+import static com.salesforce.revoman.input.config.Phase.SETUP;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class RunbookJavaDslTest {
+  private static Kick anyKick(final String name) {
+    return Kick.configure().templatePath("pm-templates/v3/" + name).off();
+  }
+
+  @Test
+  void javaBuilderBuildsOrderedSteps() {
+    final var runbook =
+        Runbook.configure()
+            .name("wfs double book")
+            .step("login as admin", SETUP, anyKick("cf-stop"), s -> s.produces("authToken"))
+            .step(
+                "schedule",
+                ACT,
+                anyKick("cf-loop"),
+                s ->
+                    s.underTest()
+                        .consumes("authToken")
+                        .produces(Map.of("schedulingStatus", "Success")))
+            .off();
+    assertThat(runbook.getName()).isEqualTo("wfs double book");
+    assertThat(runbook.getSteps()).hasSize(2);
+    assertThat(runbook.getSteps().get(1).getUnderTest()).isTrue();
+    assertThat(runbook.getSteps().get(1).getProduces())
+        .containsEntry("schedulingStatus", "Success");
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/RunbookExeE2ETest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/RunbookExeE2ETest.kt
@@ -1,0 +1,126 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.input.config.Kick
+import com.salesforce.revoman.input.config.Phase
+import com.salesforce.revoman.input.config.Runbook
+import com.salesforce.revoman.input.config.step
+import com.sun.net.httpserver.HttpServer
+import java.net.InetSocketAddress
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class RunbookExeE2ETest {
+  private val collection = "pm-templates/v3/cf-ledger-jump"
+
+  private fun kick(seed: Map<String, Any?> = emptyMap()) =
+    Kick.configure()
+      .templatePath(collection)
+      .dynamicEnvironment("baseUrl", baseUrl)
+      .let { seed.entries.fold(it) { k, (key, value) -> k.dynamicEnvironment(key, value) } }
+      .insecureHttp(true)
+      .off()
+
+  @Test
+  fun `runbook threads env across steps like the multi-kick fold`() {
+    val rr =
+      ReVoman.revUp(
+        Runbook("thread") {
+          step {
+            intent = "seed"
+            phase = Phase.SETUP
+            kick = kick(mapOf("count" to 42))
+          }
+          step {
+            intent = "use"
+            phase = Phase.ACT
+            kick = kick()
+          }
+        }
+      )
+    assertThat(rr).hasSize(2)
+    assertThat(rr[1].mutableEnv["count"]).isEqualTo(42)
+    assertThat(rr.stepFor("use")).isNotNull()
+  }
+
+  @Test
+  fun `consumes breach halts at the step`() {
+    val ex =
+      assertThrows<AssertionError> {
+        ReVoman.revUp(
+          Runbook {
+            step {
+              intent = "needs token"
+              phase = Phase.ACT
+              kick = kick()
+              consumes("authToken")
+            }
+          }
+        )
+      }
+    assertThat(ex).hasMessageThat().contains("authToken")
+  }
+
+  @Test
+  fun `produces value mismatch halts at the step`() {
+    val ex =
+      assertThrows<AssertionError> {
+        ReVoman.revUp(
+          Runbook {
+            step {
+              intent = "wrong value"
+              phase = Phase.ACT
+              kick = kick(mapOf("count" to 42))
+              produces("count" to "999")
+            }
+          }
+        )
+      }
+    assertThat(ex).hasMessageThat().contains("count")
+  }
+
+  @Test
+  fun `assertAfter runs and can pass`() {
+    val rr =
+      ReVoman.revUp(
+        Runbook {
+          step {
+            intent = "assert"
+            phase = Phase.ACT
+            kick = kick(mapOf("count" to 42))
+            assertAfter { _, env -> assertThat(env["count"]).isEqualTo(42) }
+          }
+        }
+      )
+    assertThat(rr).hasSize(1)
+  }
+
+  companion object {
+    private lateinit var server: HttpServer
+    private lateinit var baseUrl: String
+
+    @BeforeAll
+    @JvmStatic
+    fun startServer() {
+      server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+      server.createContext("/") { exchange ->
+        val body = "{}".toByteArray()
+        exchange.sendResponseHeaders(200, body.size.toLong())
+        exchange.responseBody.use { it.write(body) }
+      }
+      server.start()
+      baseUrl = "http://127.0.0.1:${server.address.port}"
+    }
+
+    @AfterAll @JvmStatic fun stopServer() = server.stop(0)
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/RunbookExeE2ETest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/RunbookExeE2ETest.kt
@@ -11,11 +11,18 @@ import com.google.common.truth.Truth.assertThat
 import com.salesforce.revoman.input.config.Kick
 import com.salesforce.revoman.input.config.Phase
 import com.salesforce.revoman.input.config.Runbook
+import com.salesforce.revoman.input.config.haltOnStepFailure
+import com.salesforce.revoman.input.config.runLogSink
 import com.salesforce.revoman.input.config.step
+import com.salesforce.revoman.output.log.ConsoleRunLogSink
 import com.sun.net.httpserver.HttpServer
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
 import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicInteger
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
@@ -27,6 +34,14 @@ class RunbookExeE2ETest {
       .templatePath(collection)
       .dynamicEnvironment("baseUrl", baseUrl)
       .let { seed.entries.fold(it) { k, (key, value) -> k.dynamicEnvironment(key, value) } }
+      .insecureHttp(true)
+      .off()
+
+  /** A one-step collection with a hardcoded URL — [name] selects the loopback handler. */
+  private fun soloKick(name: String) =
+    Kick.configure()
+      .templatePath("pm-templates/v3/$name")
+      .dynamicEnvironment("baseUrl", baseUrl)
       .insecureHttp(true)
       .off()
 
@@ -104,9 +119,144 @@ class RunbookExeE2ETest {
     assertThat(rr).hasSize(1)
   }
 
+  @Test
+  fun `assertAfter throw halts and the downstream step never runs`() {
+    countHits.set(0)
+    val ex =
+      assertThrows<AssertionError> {
+        ReVoman.revUp(
+          Runbook {
+            step {
+              intent = "step 1 asserts and blows up"
+              phase = Phase.ACT
+              kick = soloKick("single-ok")
+              assertAfter { _, _ -> throw AssertionError("boom") }
+            }
+            step {
+              intent = "step 2 should never run"
+              phase = Phase.ACT
+              kick = soloKick("single-count")
+            }
+          }
+        )
+      }
+    assertThat(ex).hasMessageThat().contains("boom")
+    // Downstream step's collection was never dispatched (I1: halt aborts the fold).
+    assertThat(countHits.get()).isEqualTo(0)
+  }
+
+  @Test
+  fun `underlying step failure halts by default and the downstream step never runs`() {
+    countHits.set(0)
+    val ex =
+      assertThrows<AssertionError> {
+        ReVoman.revUp(
+          Runbook {
+            step {
+              intent = "hits a 500"
+              phase = Phase.ACT
+              kick = soloKick("single-fail")
+            }
+            step {
+              intent = "downstream must not run"
+              phase = Phase.ACT
+              kick = soloKick("single-count")
+            }
+          }
+        )
+      }
+    assertThat(ex).hasMessageThat().contains("hits a 500")
+    assertThat(ex).hasMessageThat().contains("unsuccessful")
+    assertThat(countHits.get()).isEqualTo(0)
+  }
+
+  @Test
+  fun `underlying step failure with haltOnStepFailure false continues and marks the step FAILED`() {
+    countHits.set(0)
+    val capturedOut = ByteArrayOutputStream()
+    val capturingSink = ConsoleRunLogSink(PrintStream(capturedOut))
+    val rr =
+      ReVoman.revUp(
+        Runbook("resilient") {
+          runLogSink = capturingSink
+          haltOnStepFailure = false
+          step {
+            intent = "hits a 500 but we carry on"
+            phase = Phase.ACT
+            kick = soloKick("single-fail")
+          }
+          step {
+            intent = "downstream still runs"
+            phase = Phase.ACT
+            kick = soloKick("single-count")
+          }
+        }
+      )
+    // Did NOT throw; both steps are captured and the downstream step actually ran.
+    assertThat(rr).hasSize(2)
+    assertThat(countHits.get()).isEqualTo(1)
+    val output = capturedOut.toString(Charsets.UTF_8)
+    // The failing step closed with a FAILED bracket (✘), not SUCCESS.
+    assertThat(output).containsMatch("└ ✘ hits a 500 but we carry on")
+  }
+
+  @Test
+  fun `produces mismatch emits RunbookContractFailed and a FAILED close through the sink`() {
+    val capturedOut = ByteArrayOutputStream()
+    val capturingSink = ConsoleRunLogSink(PrintStream(capturedOut))
+    assertThrows<AssertionError> {
+      ReVoman.revUp(
+        Runbook("contract") {
+          runLogSink = capturingSink
+          step {
+            intent = "produces wrong value"
+            phase = Phase.ACT
+            kick = kick(mapOf("count" to 42))
+            produces("count" to "999")
+          }
+        }
+      )
+    }
+    val output = capturedOut.toString(Charsets.UTF_8)
+    // The CONTRACT detail line surfaced the mismatch AND the step closed FAILED (FIX 2).
+    assertThat(output).contains("⚠ CONTRACT")
+    assertThat(output).contains("value mismatch")
+    assertThat(output).containsMatch("└ ✘ produces wrong value")
+  }
+
+  @Test
+  fun `consecutive same-phase steps emit exactly one phase rule`() {
+    val capturedOut = ByteArrayOutputStream()
+    val capturingSink = ConsoleRunLogSink(PrintStream(capturedOut))
+    ReVoman.revUp(
+      Runbook("phase dedup") {
+        runLogSink = capturingSink
+        step {
+          intent = "setup a"
+          phase = Phase.SETUP
+          kick = kick()
+        }
+        step {
+          intent = "setup b"
+          phase = Phase.SETUP
+          kick = kick()
+        }
+        step {
+          intent = "act c"
+          phase = Phase.ACT
+          kick = kick()
+        }
+      }
+    )
+    val output = capturedOut.toString(Charsets.UTF_8)
+    assertThat(output.split("━━ SETUP").size - 1).isEqualTo(1)
+    assertThat(output.split("━━ ACT").size - 1).isEqualTo(1)
+  }
+
   companion object {
     private lateinit var server: HttpServer
     private lateinit var baseUrl: String
+    private val countHits = AtomicInteger(0)
 
     @BeforeAll
     @JvmStatic
@@ -117,10 +267,26 @@ class RunbookExeE2ETest {
         exchange.sendResponseHeaders(200, body.size.toLong())
         exchange.responseBody.use { it.write(body) }
       }
+      server.createContext("/fail") { exchange ->
+        val body = "{\"error\":\"boom\"}".toByteArray()
+        exchange.sendResponseHeaders(500, body.size.toLong())
+        exchange.responseBody.use { it.write(body) }
+      }
+      server.createContext("/count") { exchange ->
+        countHits.incrementAndGet()
+        val body = "{}".toByteArray()
+        exchange.sendResponseHeaders(200, body.size.toLong())
+        exchange.responseBody.use { it.write(body) }
+      }
       server.start()
       baseUrl = "http://127.0.0.1:${server.address.port}"
     }
 
     @AfterAll @JvmStatic fun stopServer() = server.stop(0)
+  }
+
+  @BeforeEach
+  fun resetCounter() {
+    countHits.set(0)
   }
 }

--- a/src/test/kotlin/com/salesforce/revoman/RunbookLegibilityE2ETest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/RunbookLegibilityE2ETest.kt
@@ -11,6 +11,7 @@ import com.google.common.truth.Truth.assertThat
 import com.salesforce.revoman.input.config.Kick
 import com.salesforce.revoman.input.config.Phase
 import com.salesforce.revoman.input.config.Runbook
+import com.salesforce.revoman.input.config.runLogSink
 import com.salesforce.revoman.input.config.step
 import com.salesforce.revoman.output.log.ConsoleRunLogSink
 import com.sun.net.httpserver.HttpServer

--- a/src/test/kotlin/com/salesforce/revoman/RunbookLegibilityE2ETest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/RunbookLegibilityE2ETest.kt
@@ -14,6 +14,8 @@ import com.salesforce.revoman.input.config.Runbook
 import com.salesforce.revoman.input.config.step
 import com.salesforce.revoman.output.log.ConsoleRunLogSink
 import com.sun.net.httpserver.HttpServer
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
 import java.net.InetSocketAddress
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
@@ -25,7 +27,6 @@ class RunbookLegibilityE2ETest {
       .templatePath("pm-templates/v3/cf-ledger-jump")
       .dynamicEnvironment("baseUrl", baseUrl)
       .let { seed.entries.fold(it) { k, (key, value) -> k.dynamicEnvironment(key, value) } }
-      .runLogSink(ConsoleRunLogSink.DEFAULT)
       .insecureHttp(true)
       .off()
 
@@ -63,6 +64,46 @@ class RunbookLegibilityE2ETest {
     assertThat(md).contains("act under test")
     assertThat(md).contains("count=7")
     assertThat(rundown.toMermaid()).startsWith("sequenceDiagram")
+  }
+
+  @Test
+  fun `runbook-scope sink captures coarse events and nests child kick events`() {
+    // REGRESSION: prior to the stacking RunLogContext fix, coarse runbook events (PhaseEntered,
+    // RunbookStepStarted/Finished, RunbookContractFailed) were dropped because the executor emitted
+    // them BETWEEN revUp(kick) calls, when RunLogContext.current() was null. This test installs a
+    // sink at RUNBOOK scope (NOT at kick scope) and asserts the captured output contains, in order,
+    // a phase rule, a step-open bracket, at least one child request gutter line, and a step-close
+    // bracket. The fix: RunLogContext.install() now stacks via restore(), and executeRunbook()
+    // installs the runbook sink around the whole loop + threads it into each kick so child events
+    // nest coherently.
+    val capturedOut = ByteArrayOutputStream()
+    val capturingSink = ConsoleRunLogSink(PrintStream(capturedOut))
+
+    val rundown =
+      ReVoman.revUp(
+        Runbook("grouped log demo") {
+          runLogSink = capturingSink
+          step {
+            intent = "first step"
+            phase = Phase.SETUP
+            kick = kick()
+          }
+          step {
+            intent = "second step"
+            phase = Phase.ACT
+            kick = kick()
+          }
+        }
+      )
+
+    assertThat(rundown).hasSize(2)
+    val output = capturedOut.toString(Charsets.UTF_8)
+
+    // Assert coarse events + nested child events appear in order.
+    assertThat(output).contains("━━ SETUP") // phase rule
+    assertThat(output).containsMatch("┌ [▶◆]") // step-open bracket (▶ or ◆)
+    assertThat(output).containsMatch("│ [·\\s]") // child request gutter line (│ · or │   )
+    assertThat(output).containsMatch("└ [✔✘]") // step-close bracket (✔ or ✘)
   }
 
   companion object {

--- a/src/test/kotlin/com/salesforce/revoman/RunbookLegibilityE2ETest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/RunbookLegibilityE2ETest.kt
@@ -1,0 +1,87 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.input.config.Kick
+import com.salesforce.revoman.input.config.Phase
+import com.salesforce.revoman.input.config.Runbook
+import com.salesforce.revoman.input.config.step
+import com.salesforce.revoman.output.log.ConsoleRunLogSink
+import com.sun.net.httpserver.HttpServer
+import java.net.InetSocketAddress
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+
+class RunbookLegibilityE2ETest {
+  private fun kick(seed: Map<String, Any?> = emptyMap()) =
+    Kick.configure()
+      .templatePath("pm-templates/v3/cf-ledger-jump")
+      .dynamicEnvironment("baseUrl", baseUrl)
+      .let { seed.entries.fold(it) { k, (key, value) -> k.dynamicEnvironment(key, value) } }
+      .runLogSink(ConsoleRunLogSink.DEFAULT)
+      .insecureHttp(true)
+      .off()
+
+  @Test
+  fun `a runbook reads as a story, guards its handoffs, and renders a view`() {
+    val rundown =
+      ReVoman.revUp(
+        Runbook("legibility demo") {
+          step {
+            intent = "seed session token"
+            phase = Phase.SETUP
+            kick = kick(mapOf("authToken" to "tok-123"))
+            produces("authToken")
+          }
+          step {
+            intent = "act under test"
+            phase = Phase.ACT
+            kick = kick(mapOf("count" to 7))
+            underTest()
+            consumes("authToken")
+            produces("count" to "7")
+            assertAfter { _, env -> assertThat(env["count"]).isEqualTo(7) }
+          }
+        }
+      )
+
+    // Executes and threads env across steps.
+    assertThat(rundown).hasSize(2)
+    assertThat(rundown[1].mutableEnv["authToken"]).isEqualTo("tok-123")
+    // Step pairing accessible by intent.
+    assertThat(rundown.stepFor("act under test")).isNotNull()
+    // Generated view surfaces the story.
+    val md = rundown.toMarkdown()
+    assertThat(md).contains("seed session token")
+    assertThat(md).contains("act under test")
+    assertThat(md).contains("count=7")
+    assertThat(rundown.toMermaid()).startsWith("sequenceDiagram")
+  }
+
+  companion object {
+    private lateinit var server: HttpServer
+    private lateinit var baseUrl: String
+
+    @BeforeAll
+    @JvmStatic
+    fun startServer() {
+      server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+      server.createContext("/") { exchange ->
+        val body = "{}".toByteArray()
+        exchange.sendResponseHeaders(200, body.size.toLong())
+        exchange.responseBody.use { it.write(body) }
+      }
+      server.start()
+      baseUrl = "http://127.0.0.1:${server.address.port}"
+    }
+
+    @AfterAll @JvmStatic fun stopServer() = server.stop(0)
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/input/config/RunbookDslTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/input/config/RunbookDslTest.kt
@@ -9,6 +9,7 @@ package com.salesforce.revoman.input.config
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class RunbookDslTest {
   private fun anyKick(name: String): Kick =
@@ -40,5 +41,26 @@ class RunbookDslTest {
     assertThat(runbook.steps[1].underTest).isTrue()
     assertThat(runbook.steps[1].consumes).containsExactly("authToken")
     assertThat(runbook.steps[1].produces).containsEntry("schedulingStatus", "Success")
+  }
+
+  @Test
+  fun `building a runbook with duplicate step intents fails fast`() {
+    val ex =
+      assertThrows<IllegalArgumentException> {
+        Runbook {
+          step {
+            intent = "login"
+            phase = Phase.SETUP
+            kick = anyKick("cf-stop")
+          }
+          step {
+            intent = "login"
+            phase = Phase.ACT
+            kick = anyKick("cf-loop")
+          }
+        }
+      }
+    assertThat(ex).hasMessageThat().contains("distinct")
+    assertThat(ex).hasMessageThat().contains("login")
   }
 }

--- a/src/test/kotlin/com/salesforce/revoman/input/config/RunbookDslTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/input/config/RunbookDslTest.kt
@@ -1,0 +1,44 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.input.config
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class RunbookDslTest {
+  private fun anyKick(name: String): Kick =
+    Kick.configure().templatePath("pm-templates/v3/$name").off()
+
+  @Test
+  fun `Kotlin receiver DSL builds ordered steps`() {
+    val runbook =
+      Runbook(name = "wfs double book") {
+        step {
+          intent = "login as admin"
+          phase = Phase.SETUP
+          kick = anyKick("cf-stop")
+          produces("authToken")
+        }
+        step {
+          intent = "schedule"
+          phase = Phase.ACT
+          kick = anyKick("cf-loop")
+          underTest()
+          consumes("authToken")
+          produces("schedulingStatus" to "Success")
+        }
+      }
+    assertThat(runbook.name).isEqualTo("wfs double book")
+    assertThat(runbook.steps.map { it.intent })
+      .containsExactly("login as admin", "schedule")
+      .inOrder()
+    assertThat(runbook.steps[1].underTest).isTrue()
+    assertThat(runbook.steps[1].consumes).containsExactly("authToken")
+    assertThat(runbook.steps[1].produces).containsEntry("schedulingStatus", "Success")
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/input/config/StepSpecTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/input/config/StepSpecTest.kt
@@ -1,0 +1,69 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.input.config
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class StepSpecTest {
+  private fun anyKick(): Kick = Kick.configure().templatePath("pm-templates/v3/cf-stop").off()
+
+  @Test
+  fun `build snapshots spec into an immutable RunbookStep`() {
+    val step =
+      StepSpec()
+        .apply {
+          intent = "seed fixture"
+          phase = Phase.SEED
+          kick = anyKick()
+        }
+        .consumes("authToken")
+        .produces("accountId", "shiftIds")
+        .build()
+    assertThat(step.intent).isEqualTo("seed fixture")
+    assertThat(step.phase).isEqualTo(Phase.SEED)
+    assertThat(step.consumes).containsExactly("authToken")
+    assertThat(step.produces.keys).containsExactly("accountId", "shiftIds")
+    assertThat(step.produces.values.all { it == null }).isTrue()
+    assertThat(step.underTest).isFalse()
+    assertThat(step.assertAfter).isNull()
+  }
+
+  @Test
+  fun `produces with values and underTest are captured`() {
+    val step =
+      StepSpec()
+        .apply {
+          intent = "act"
+          phase = Phase.ACT
+          kick = anyKick()
+        }
+        .underTest()
+        .produces("schedulingStatus" to "Success")
+        .assertAfter { _, _ -> }
+        .build()
+    assertThat(step.underTest).isTrue()
+    assertThat(step.produces).containsEntry("schedulingStatus", "Success")
+    assertThat(step.assertAfter).isNotNull()
+  }
+
+  @Test
+  fun `build without a kick fails fast`() {
+    val ex =
+      assertThrows<IllegalStateException> {
+        StepSpec()
+          .apply {
+            intent = "no kick"
+            phase = Phase.SETUP
+          }
+          .build()
+      }
+    assertThat(ex).hasMessageThat().contains("kick")
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/input/config/StepSpecTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/input/config/StepSpecTest.kt
@@ -81,4 +81,18 @@ class StepSpecTest {
       }
     assertThat(ex).hasMessageThat().contains("non-blank intent")
   }
+
+  @Test
+  fun `build without a phase fails fast`() {
+    val ex =
+      assertThrows<IllegalStateException> {
+        StepSpec()
+          .apply {
+            intent = "no phase"
+            kick = anyKick()
+          }
+          .build()
+      }
+    assertThat(ex).hasMessageThat().contains("phase")
+  }
 }

--- a/src/test/kotlin/com/salesforce/revoman/input/config/StepSpecTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/input/config/StepSpecTest.kt
@@ -66,4 +66,19 @@ class StepSpecTest {
       }
     assertThat(ex).hasMessageThat().contains("kick")
   }
+
+  @Test
+  fun `build with blank intent fails fast`() {
+    val ex =
+      assertThrows<IllegalArgumentException> {
+        StepSpec()
+          .apply {
+            intent = "  "
+            phase = Phase.SETUP
+            kick = anyKick()
+          }
+          .build()
+      }
+    assertThat(ex).hasMessageThat().contains("non-blank intent")
+  }
 }

--- a/src/test/kotlin/com/salesforce/revoman/internal/exe/RunbookContractTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/exe/RunbookContractTest.kt
@@ -1,0 +1,74 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.internal.exe
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.input.config.Kick
+import com.salesforce.revoman.input.config.Phase
+import com.salesforce.revoman.input.config.RunbookStep
+import com.salesforce.revoman.output.postman.PostmanEnvironment
+import org.junit.jupiter.api.Test
+
+class RunbookContractTest {
+  private fun step(
+    consumes: Set<String> = emptySet(),
+    produces: Map<String, String?> = emptyMap(),
+  ) =
+    RunbookStep(
+      intent = "s",
+      phase = Phase.ACT,
+      kick = Kick.configure().templatePath("pm-templates/v3/cf-stop").off(),
+      consumes = consumes,
+      produces = produces,
+      underTest = false,
+      assertAfter = null,
+    )
+
+  private fun env(vararg entries: Pair<String, Any?>) =
+    PostmanEnvironment<Any?>(mutableMapOf(*entries))
+
+  @Test
+  fun `consumes passes when all declared keys present, ignoring extras`() {
+    val missing = checkConsumes(step(consumes = setOf("authToken")), setOf("authToken", "extra"))
+    assertThat(missing).isEmpty()
+  }
+
+  @Test
+  fun `consumes reports only the missing declared keys`() {
+    val missing = checkConsumes(step(consumes = setOf("authToken", "userId")), setOf("authToken"))
+    assertThat(missing).containsExactly("userId")
+  }
+
+  @Test
+  fun `produces key-only passes when present`() {
+    val v = checkProduces(step(produces = mapOf("accountId" to null)), env("accountId" to "001"))
+    assertThat(v.isEmpty()).isTrue()
+  }
+
+  @Test
+  fun `produces key-only reports missing key`() {
+    val v = checkProduces(step(produces = mapOf("accountId" to null)), env())
+    assertThat(v.missingProduced).containsExactly("accountId")
+  }
+
+  @Test
+  fun `produces key to value reports mismatch, passes on match`() {
+    val ok =
+      checkProduces(step(produces = mapOf("status" to "Success")), env("status" to "Success"))
+    assertThat(ok.isEmpty()).isTrue()
+    val bad = checkProduces(step(produces = mapOf("status" to "Success")), env("status" to "Error"))
+    assertThat(bad.valueMismatches).containsKey("status")
+    assertThat(bad.valueMismatches["status"]).isEqualTo("Success" to "Error")
+  }
+
+  @Test
+  fun `empty declarations are always satisfied`() {
+    assertThat(checkConsumes(step(), setOf("x"))).isEmpty()
+    assertThat(checkProduces(step(), env("x" to 1)).isEmpty()).isTrue()
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/internal/log/RunLogContextTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/internal/log/RunLogContextTest.kt
@@ -65,4 +65,31 @@ class RunLogContextTest {
     RevomanLog.info { "no sink" }
     RunLogContext.current() shouldBe null
   }
+
+  @Test
+  fun `install returns previous sink and restore stacks across nesting`() {
+    val outer = RecordingSink()
+    val inner = RecordingSink()
+    // Outer run installs on an empty context — previous is null.
+    val beforeOuter = RunLogContext.install(outer)
+    try {
+      beforeOuter shouldBe null
+      RunLogContext.current() shouldBe outer
+      // Nested run (e.g. a runbook step's kick) installs its own sink, capturing the outer.
+      val beforeInner = RunLogContext.install(inner)
+      try {
+        beforeInner shouldBe outer
+        RunLogContext.current() shouldBe inner
+      } finally {
+        // Restoring the captured sink brings the OUTER sink back — the old bare `remove()` would
+        // instead have wiped it, leaving `current()` null for the rest of the outer run.
+        RunLogContext.restore(beforeInner)
+      }
+      RunLogContext.current() shouldBe outer
+    } finally {
+      RunLogContext.restore(beforeOuter)
+    }
+    // restore(null) clears the context, matching the standalone (no outer sink) path.
+    RunLogContext.current() shouldBe null
+  }
 }

--- a/src/test/kotlin/com/salesforce/revoman/output/RunbookRundownTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/output/RunbookRundownTest.kt
@@ -1,0 +1,54 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.output
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.input.config.Kick
+import com.salesforce.revoman.input.config.Phase
+import com.salesforce.revoman.input.config.RunbookStep
+import com.salesforce.revoman.output.postman.PostmanEnvironment
+import org.junit.jupiter.api.Test
+
+class RunbookRundownTest {
+  private fun step(intent: String) =
+    RunbookStep(
+      intent,
+      Phase.ACT,
+      Kick.configure().templatePath("pm-templates/v3/cf-stop").off(),
+      emptySet(),
+      emptyMap(),
+      false,
+      null,
+    )
+
+  private fun rundown() =
+    Rundown(
+      mutableEnv = PostmanEnvironment(),
+      haltOnFailureOfTypeExcept = emptyMap(),
+      providedStepsToExecuteCount = 0,
+    )
+
+  @Test
+  fun `behaves as a List of Rundown in order`() {
+    val a = rundown()
+    val b = rundown()
+    val rr = RunbookRundown("rb", listOf(step("login") to a, step("act") to b))
+    assertThat(rr).hasSize(2)
+    assertThat(rr[0]).isSameInstanceAs(a)
+    assertThat(rr[1]).isSameInstanceAs(b)
+    assertThat(rr.last()).isSameInstanceAs(b)
+  }
+
+  @Test
+  fun `stepFor finds by intent`() {
+    val a = rundown()
+    val rr = RunbookRundown(null, listOf(step("login") to a))
+    assertThat(rr.stepFor("login")?.second).isSameInstanceAs(a)
+    assertThat(rr.stepFor("missing")).isNull()
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/output/RunbookRundownTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/output/RunbookRundownTest.kt
@@ -51,4 +51,23 @@ class RunbookRundownTest {
     assertThat(rr.stepFor("login")?.second).isSameInstanceAs(a)
     assertThat(rr.stepFor("missing")).isNull()
   }
+
+  @Test
+  fun `equals and hashCode delegate to the backing rundown list, matching List semantics`() {
+    val a = rundown()
+    val b = rundown()
+    val rr = RunbookRundown("rb", listOf(step("login") to a, step("act") to b))
+    val plainList = listOf(a, b)
+    // Symmetric structural equality with a plain List<Rundown> (both directions).
+    assertThat(rr).isEqualTo(plainList)
+    assertThat(plainList).isEqualTo(rr)
+    // hashCode matches the backing list (required by the equals/hashCode contract).
+    assertThat(rr.hashCode()).isEqualTo(plainList.hashCode())
+    // Two RunbookRundowns with the SAME rundowns are equal even if name/pairing differ.
+    val rrSameRundownsDifferentName =
+      RunbookRundown("other-name", listOf(step("x") to a, step("y") to b))
+    assertThat(rr).isEqualTo(rrSameRundownsDifferentName)
+    // A different rundown list is not equal.
+    assertThat(rr).isNotEqualTo(listOf(a))
+  }
 }

--- a/src/test/kotlin/com/salesforce/revoman/output/RunbookViewTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/output/RunbookViewTest.kt
@@ -1,0 +1,72 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.output
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.input.config.Kick
+import com.salesforce.revoman.input.config.Phase
+import com.salesforce.revoman.input.config.RunbookStep
+import com.salesforce.revoman.output.postman.PostmanEnvironment
+import org.junit.jupiter.api.Test
+
+class RunbookViewTest {
+  private fun step(
+    intent: String,
+    phase: Phase,
+    consumes: Set<String> = emptySet(),
+    produces: Map<String, String?> = emptyMap(),
+  ) =
+    RunbookStep(
+      intent,
+      phase,
+      Kick.configure().templatePath("pm-templates/v3/cf-stop").off(),
+      consumes,
+      produces,
+      false,
+      null,
+    )
+
+  private fun rundown() =
+    Rundown(
+      mutableEnv = PostmanEnvironment(),
+      haltOnFailureOfTypeExcept = emptyMap(),
+      providedStepsToExecuteCount = 0,
+    )
+
+  private fun rr() =
+    RunbookRundown(
+      "demo",
+      listOf(
+        step("login", Phase.SETUP, produces = mapOf("authToken" to null)) to rundown(),
+        step(
+          "schedule",
+          Phase.ACT,
+          consumes = setOf("authToken"),
+          produces = mapOf("status" to "Success"),
+        ) to rundown(),
+      ),
+    )
+
+  @Test
+  fun `markdown lists steps with phase, consumes, produces`() {
+    val md = rr().toMarkdown()
+    assertThat(md).contains("| Phase | Step |")
+    assertThat(md).contains("SETUP")
+    assertThat(md).contains("login")
+    assertThat(md).contains("authToken")
+    assertThat(md).contains("status=Success")
+  }
+
+  @Test
+  fun `mermaid is a sequence diagram naming each step intent`() {
+    val mmd = rr().toMermaid()
+    assertThat(mmd).startsWith("sequenceDiagram")
+    assertThat(mmd).contains("login")
+    assertThat(mmd).contains("schedule")
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/output/RunbookViewTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/output/RunbookViewTest.kt
@@ -20,6 +20,7 @@ class RunbookViewTest {
     phase: Phase,
     consumes: Set<String> = emptySet(),
     produces: Map<String, String?> = emptyMap(),
+    underTest: Boolean = false,
   ) =
     RunbookStep(
       intent,
@@ -27,7 +28,7 @@ class RunbookViewTest {
       Kick.configure().templatePath("pm-templates/v3/cf-stop").off(),
       consumes,
       produces,
-      false,
+      underTest,
       null,
     )
 
@@ -68,5 +69,28 @@ class RunbookViewTest {
     assertThat(mmd).startsWith("sequenceDiagram")
     assertThat(mmd).contains("login")
     assertThat(mmd).contains("schedule")
+  }
+
+  @Test
+  fun `mermaid shows consumes annotation and diamond marker for under-test steps`() {
+    val rrWithUnderTest =
+      RunbookRundown(
+        "mermaid test",
+        listOf(
+          step("seed data", Phase.SETUP, produces = mapOf("authToken" to null)) to rundown(),
+          step(
+            "act",
+            Phase.ACT,
+            consumes = setOf("authToken"),
+            produces = mapOf("result" to "ok"),
+            underTest = true,
+          ) to rundown(),
+        ),
+      )
+    val mmd = rrWithUnderTest.toMermaid()
+    // Assert consumes annotation (⟵ authToken) and under-test marker (◆) appear for the under-test
+    // step.
+    assertThat(mmd).contains("⟵ authToken")
+    assertThat(mmd).contains("◆")
   }
 }

--- a/src/test/kotlin/com/salesforce/revoman/output/log/ConsoleRunLogSinkTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/output/log/ConsoleRunLogSinkTest.kt
@@ -7,9 +7,11 @@
  */
 package com.salesforce.revoman.output.log
 
+import com.salesforce.revoman.input.config.Phase
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
+import io.kotest.matchers.string.shouldStartWith
 import io.kotest.matchers.types.shouldBeSameInstanceAs
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
@@ -22,14 +24,142 @@ class ConsoleRunLogSinkTest {
   private fun output(): String = buffer.toString(Charsets.UTF_8)
 
   @Test
-  fun `StepStarted renders path and name`() {
+  fun `PhaseEntered renders phase rule`() {
+    sink.event(StepEvent.PhaseEntered(Phase.SEED))
+    output() shouldStartWith "━━ SEED "
+    output() shouldContain "━━━━"
+  }
+
+  @Test
+  fun `RunbookStepStarted renders with regular marker when not under test`() {
+    sink.event(
+      StepEvent.RunbookStepStarted(
+        path = "schedule",
+        intent = "schedule appointment",
+        phase = Phase.ACT,
+        consumes = setOf("accountId"),
+        underTest = false,
+      )
+    )
+    output() shouldContain "┌ ▶ schedule appointment"
+    output() shouldContain "⟵ accountId"
+    output() shouldNotContain "★ UNDER TEST"
+  }
+
+  @Test
+  fun `RunbookStepStarted renders with diamond marker and under test flag when underTest`() {
+    sink.event(
+      StepEvent.RunbookStepStarted(
+        path = "schedule",
+        intent = "schedule appointment",
+        phase = Phase.ACT,
+        consumes = setOf("accountId", "slotId"),
+        underTest = true,
+      )
+    )
+    output() shouldContain "┌ ◆ schedule appointment"
+    output() shouldContain "⟵ accountId, slotId"
+    output() shouldContain "★ UNDER TEST"
+  }
+
+  @Test
+  fun `RunbookStepStarted with empty consumes shows dash`() {
+    sink.event(
+      StepEvent.RunbookStepStarted(
+        path = "schedule",
+        intent = "schedule appointment",
+        phase = Phase.ACT,
+        consumes = emptySet(),
+        underTest = false,
+      )
+    )
+    output() shouldContain "⟵ —"
+  }
+
+  @Test
+  fun `RunbookStepFinished renders success with checkmark and produced values`() {
+    sink.event(
+      StepEvent.RunbookStepFinished(
+        path = "schedule",
+        intent = "schedule appointment",
+        outcome = Outcome.SUCCESS,
+        produced = mapOf("schedulingStatus" to "Success", "saId" to "SA123"),
+        tookMs = 5,
+      )
+    )
+    output() shouldContain "└ ✔ schedule appointment"
+    output() shouldContain "⟶ schedulingStatus=Success, saId=SA123"
+  }
+
+  @Test
+  fun `RunbookStepFinished renders failure with cross mark`() {
+    sink.event(
+      StepEvent.RunbookStepFinished(
+        path = "schedule",
+        intent = "schedule appointment",
+        outcome = Outcome.FAILED,
+        produced = emptyMap(),
+        tookMs = 10,
+      )
+    )
+    output() shouldContain "└ ✘ schedule appointment"
+    output() shouldContain "⟶ —"
+  }
+
+  @Test
+  fun `RunbookStepFinished with null produced value shows key only`() {
+    sink.event(
+      StepEvent.RunbookStepFinished(
+        path = "schedule",
+        intent = "schedule appointment",
+        outcome = Outcome.SUCCESS,
+        produced = mapOf("schedulingStatus" to null, "saId" to "SA123"),
+        tookMs = 5,
+      )
+    )
+    output() shouldContain "⟶ schedulingStatus, saId=SA123"
+  }
+
+  @Test
+  fun `RunbookContractFailed renders with warning marker and details`() {
+    sink.event(
+      StepEvent.RunbookContractFailed(
+        path = "schedule",
+        intent = "schedule appointment",
+        missingConsumed = setOf("accountId"),
+        missingProduced = setOf("schedulingStatus"),
+        valueMismatches = emptyMap(),
+      )
+    )
+    output() shouldContain "│ ⚠ CONTRACT"
+    output() shouldContain "missing consumed: [accountId]"
+    output() shouldContain "missing produced: [schedulingStatus]"
+  }
+
+  @Test
+  fun `RunbookContractFailed with value mismatches`() {
+    sink.event(
+      StepEvent.RunbookContractFailed(
+        path = "schedule",
+        intent = "schedule appointment",
+        missingConsumed = emptySet(),
+        missingProduced = emptySet(),
+        valueMismatches = mapOf("status" to Pair("expected", "actual")),
+      )
+    )
+    output() shouldContain "│ ⚠ CONTRACT"
+    output() shouldContain "value mismatch (expected→actual): {status=(expected, actual)}"
+  }
+
+  @Test
+  fun `StepStarted renders as nested child request with gutter`() {
     sink.event(StepEvent.StepStarted(path = "10-book", name = "Book Appointment"))
-    output() shouldContain "STEP 10-book"
+    output() shouldStartWith "│ · "
     output() shouldContain "Book Appointment"
   }
 
   @Test
-  fun `StepFinished renders header with status outcome and tookMs`() {
+  fun `StepFinished renders with gutter and outcome word`() {
     sink.event(
       StepEvent.StepFinished(
         path = "10-book",
@@ -40,10 +170,38 @@ class ConsoleRunLogSinkTest {
         outcome = Outcome.SUCCESS,
       )
     )
-    output() shouldContain "STEP 10-book"
-    output() shouldContain "[200]"
-    output() shouldContain "SUCCESS"
-    output() shouldContain "42ms"
+    output() shouldStartWith "│   "
+    output() shouldContain "200 OK 42ms"
+  }
+
+  @Test
+  fun `StepFinished with FAILED outcome shows FAIL word`() {
+    sink.event(
+      StepEvent.StepFinished(
+        path = "10-book",
+        httpStatus = 400,
+        produced = emptySet(),
+        consumed = emptySet(),
+        tookMs = 5,
+        outcome = Outcome.FAILED,
+      )
+    )
+    output() shouldContain "400 FAIL 5ms"
+  }
+
+  @Test
+  fun `StepFinished with SKIPPED outcome shows SKIP word`() {
+    sink.event(
+      StepEvent.StepFinished(
+        path = "10-book",
+        httpStatus = null,
+        produced = emptySet(),
+        consumed = emptySet(),
+        tookMs = 0,
+        outcome = Outcome.SKIPPED,
+      )
+    )
+    output() shouldContain "null SKIP 0ms"
   }
 
   @Test
@@ -65,7 +223,7 @@ class ConsoleRunLogSinkTest {
   }
 
   @Test
-  fun `StepFinished emits REQ and RESP blocks when messages present`() {
+  fun `StepFinished emits REQ and RESP blocks with gutter when messages present`() {
     sink.event(
       StepEvent.StepFinished(
         path = "10-book",
@@ -78,8 +236,8 @@ class ConsoleRunLogSinkTest {
         responseMsg = "{\"error\":\"bad\"}",
       )
     )
-    output() shouldContain "REQ:\nPOST /book"
-    output() shouldContain "RESP:\n{\"error\":\"bad\"}"
+    output() shouldContain "│ REQ:\nPOST /book"
+    output() shouldContain "│ RESP:\n{\"error\":\"bad\"}"
   }
 
   @Test
@@ -94,12 +252,12 @@ class ConsoleRunLogSinkTest {
         outcome = Outcome.SUCCESS,
       )
     )
-    output() shouldNotContain "produced="
-    output() shouldNotContain "consumed="
+    output() shouldNotContain "⟵"
+    output() shouldNotContain "⟶"
   }
 
   @Test
-  fun `StepFinished emits keys line when produced or consumed present`() {
+  fun `StepFinished emits keys line with arrows when produced or consumed present`() {
     sink.event(
       StepEvent.StepFinished(
         path = "10-book",
@@ -110,42 +268,37 @@ class ConsoleRunLogSinkTest {
         outcome = Outcome.SUCCESS,
       )
     )
-    output() shouldContain "produced=[saId]"
-    output() shouldContain "consumed=[token]"
+    output() shouldContain "│   ⟵ [token]  ⟶ [saId]"
   }
 
   @Test
-  fun `LedgerSkipped renders path and reused keys`() {
+  fun `LedgerSkipped renders with gutter and circular arrow`() {
     sink.event(StepEvent.LedgerSkipped(path = "10-book", reused = setOf("saId")))
-    output() shouldContain "LEDGER-SKIP 10-book"
-    output() shouldContain "reused=[saId]"
+    output() shouldContain "│ ↺ reused [saId]"
   }
 
   @Test
-  fun `RequestSkipped renders path`() {
+  fun `RequestSkipped renders with gutter and skip symbol`() {
     sink.event(StepEvent.RequestSkipped(path = "10-book"))
-    output() shouldContain "REQ-SKIP 10-book"
+    output() shouldContain "│ ⊘ skipped 10-book"
   }
 
   @Test
-  fun `Jumped renders from and to path`() {
+  fun `Jumped renders with gutter and jump arrow`() {
     sink.event(StepEvent.Jumped(path = "10-book", toPath = "30-verify"))
-    output() shouldContain "JUMP 10-book"
-    output() shouldContain "30-verify"
+    output() shouldContain "│ ↪ 10-book → 30-verify"
   }
 
   @Test
-  fun `RunStopped renders path and reason`() {
+  fun `RunStopped renders with stop square`() {
     sink.event(StepEvent.RunStopped(path = "10-book", reason = "setNextRequest(null)"))
-    output() shouldContain "STOP 10-book"
-    output() shouldContain "setNextRequest(null)"
+    output() shouldContain "■ STOP 10-book: setNextRequest(null)"
   }
 
   @Test
-  fun `LoopBudgetExceeded renders path and budget`() {
+  fun `LoopBudgetExceeded renders with cross mark`() {
     sink.event(StepEvent.LoopBudgetExceeded(path = "10-book", budget = 100))
-    output() shouldContain "LOOP-BUDGET 10-book"
-    output() shouldContain "budget=100"
+    output() shouldContain "✖ LOOP-BUDGET 10-book budget=100"
   }
 
   @Test
@@ -159,7 +312,7 @@ class ConsoleRunLogSinkTest {
     sink.close()
     // stream still writable after close(): a subsequent event still renders.
     sink.event(StepEvent.RequestSkipped(path = "20-after-close"))
-    output() shouldContain "20-after-close"
+    output() shouldContain "│ ⊘ skipped 20-after-close"
   }
 
   @Test

--- a/src/test/kotlin/com/salesforce/revoman/output/log/RunbookStepEventTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/output/log/RunbookStepEventTest.kt
@@ -1,0 +1,38 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.output.log
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.input.config.Phase
+import org.junit.jupiter.api.Test
+
+class RunbookStepEventTest {
+  @Test
+  fun `PhaseEntered path derives from phase name`() {
+    assertThat(StepEvent.PhaseEntered(Phase.SEED).path).isEqualTo("SEED")
+  }
+
+  @Test
+  fun `runbook step events carry narration`() {
+    val started = StepEvent.RunbookStepStarted("act", "schedule", Phase.ACT, setOf("id"), true)
+    assertThat(started.intent).isEqualTo("schedule")
+    assertThat(started.underTest).isTrue()
+    val finished =
+      StepEvent.RunbookStepFinished(
+        "act",
+        "schedule",
+        Outcome.SUCCESS,
+        mapOf("s" to "Success"),
+        12L,
+      )
+    assertThat(finished.produced).containsEntry("s", "Success")
+    val failed =
+      StepEvent.RunbookContractFailed("act", "schedule", emptySet(), setOf("s"), emptyMap())
+    assertThat(failed.missingProduced).containsExactly("s")
+  }
+}

--- a/src/test/resources/pm-templates/v3/single-count/.resources/definition.yaml
+++ b/src/test/resources/pm-templates/v3/single-count/.resources/definition.yaml
@@ -1,0 +1,1 @@
+$kind: collection

--- a/src/test/resources/pm-templates/v3/single-count/c.request.yaml
+++ b/src/test/resources/pm-templates/v3/single-count/c.request.yaml
@@ -1,0 +1,5 @@
+$kind: http-request
+name: c
+url: "{{baseUrl}}/count"
+method: GET
+order: 1000

--- a/src/test/resources/pm-templates/v3/single-fail/.resources/definition.yaml
+++ b/src/test/resources/pm-templates/v3/single-fail/.resources/definition.yaml
@@ -1,0 +1,1 @@
+$kind: collection

--- a/src/test/resources/pm-templates/v3/single-fail/f.request.yaml
+++ b/src/test/resources/pm-templates/v3/single-fail/f.request.yaml
@@ -1,0 +1,5 @@
+$kind: http-request
+name: f
+url: "{{baseUrl}}/fail"
+method: GET
+order: 1000

--- a/src/test/resources/pm-templates/v3/single-ok/.resources/definition.yaml
+++ b/src/test/resources/pm-templates/v3/single-ok/.resources/definition.yaml
@@ -1,0 +1,1 @@
+$kind: collection

--- a/src/test/resources/pm-templates/v3/single-ok/o.request.yaml
+++ b/src/test/resources/pm-templates/v3/single-ok/o.request.yaml
@@ -1,0 +1,5 @@
+$kind: http-request
+name: o
+url: "{{baseUrl}}/ok"
+method: GET
+order: 1000


### PR DESCRIPTION
## Problem

A ReVoman test acts as a **runbook** — it chains loosely-coupled Postman collections into an ordered story (login → set policy → seed fixture → schedule → control). Today that runbook is **implicit**: spread across a separate config file of `Kick` constants, their order in a flat `revUp(...)` vararg, and hand-written comments. The reader can't see the story, the data handoffs between collections, or which step is the act-step under test.

## Solution

A thin **Runbook** layer that wraps each `Kick` with narration and drives the existing multi-kick `revUp` fold. The same declaration surfaces the runbook **three ways**:

**1. The test code** — a fluent DSL (Kotlin receiver / Java builder):

```kotlin
val rundown = ReVoman.revUp(
  Runbook("wfs double book") {
    runLogSink = ConsoleRunLogSink.DEFAULT
    step { intent = "login as admin"; phase = SETUP; kick = AUTH_CONFIG;    produces("authToken") }
    step { intent = "seed fixture";   phase = SEED;  kick = FIXTURE_CONFIG; consumes("authToken"); produces("accountId") }
    step { intent = "schedule";       phase = ACT;   kick = SCHEDULE_CONFIG
           underTest(); consumes("accountId"); produces("schedulingStatus" to "Success") }
  })
```

Java gets the same via `Runbook.configure().step(intent, phase, kick, Consumer<StepSpec>).off()`.

**2. The log** — an overhauled grouped, narrated console render:

```
━━ SEED ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
┌ ▶ seed fixture                            ⟵ authToken
│   POST composite/graph         201 OK    512ms
└ ✔ seed fixture                            ⟶ accountId
━━ ACT ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
┌ ◆ schedule                                ⟵ accountId   ★ UNDER TEST
│   POST actions/schedule        200 OK    876ms
└ ✔ schedule                                ⟶ schedulingStatus=Success
```

**3. Generated views** — `toMarkdown()` / `toMermaid()` on demand, plus an auto markdown summary at run end.

## Data-flow contract

`consumes` / `produces` use **subset / at-least semantics** — declare only the handoff keys that matter to the story; extra env churn is ignored; empty = pure narration. `produces("key" to "value")` adds an optional value check. First breach **halts** at that step and the log marks `✘` at the exact broken handoff. Complementary to (not a replacement for) Truth assertions, via per-step `assertAfter`.

## Backward compatibility

- `Kick` is **untouched**; existing `revUp(vararg Kick)` / `revUp(List<Kick>)` are behavior-identical.
- `revUp(Runbook): RunbookRundown` is a new opt-in overload. `RunbookRundown` implements `List<Rundown>` so it drops in wherever today's return is consumed.
- The env-threading in the runbook executor mirrors the existing multi-kick fold exactly (verified).
- Zero-config (no `runLogSink`) path is bit-identical to before — the runbook-scope sink is installed only when non-NoOp.

## How it was built

Brainstorm → design spec → 9-task TDD plan → subagent-driven execution, each task spec+quality reviewed, then a whole-branch review.

- `docs/superpowers/specs/2026-07-13-runbook-legibility-design.md`
- `docs/superpowers/plans/2026-07-13-runbook-legibility.md`

The **whole-branch review caught a Critical bug** the per-task reviews missed: coarse log events were emitted outside the `revUp(kick)` sink-install window, silently dropping the grouped-log surface. Fixed by making `RunLogContext` stacking (install returns previous + `restore`) and installing a runbook-scope sink around the loop — verified by sabotage (a regression test fails without the fix, passes with it).

## Testing

- Full unit suite **506/506 passing** (rebased on current master); spotlessCheck + detekt + kover pass.
- The 6 `integrationTest` failures on the author's box are the known restful-api.dev HTTP-405 daily-quota flakes (not regressions); CI has fresh quota + the retry plugin.
