### PR TITLE
feat(env): regex key-query variants + non-null keys + query-method coverage

### DIFF
--- a/src/main/kotlin/com/salesforce/revoman/output/postman/PostmanEnvironment.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/postman/PostmanEnvironment.kt
@@ -159,8 +159,6 @@ constructor(
       moshiReVoman,
     )
 
-  // ! TODO 24/06/23 gopala.akshintala: Support for Regex while querying environment
-
   fun getAsString(key: String) = moshiReVoman.anyToString(mutableEnv[key])
 
   fun getInt(key: String) = mutableEnv[key] as? Int
@@ -237,6 +235,49 @@ constructor(
       moshiReVoman,
     )
 
+  /**
+   * Copy of [mutableEnv] retaining entries whose (typed) value is a [type] instance AND whose key
+   * matches ANY of [keyPatterns]. Patterns are compiled ONCE per call and matched via
+   * [Regex.containsMatchIn] (partial): a bare `"saId"` matches anywhere in the key, so anchor with
+   * `^`/`$` for prefix/suffix/exact matching. An empty [keyPatterns] retains nothing.
+   */
+  fun <T> mutableEnvCopyWithKeysMatching(
+    type: Class<T>,
+    vararg keyPatterns: String,
+  ): PostmanEnvironment<T> {
+    val regexes: List<Regex> = keyPatterns.map(::Regex)
+    return PostmanEnvironment(
+      mutableEnv
+        .filter {
+          type.isInstance(it.value) && regexes.any { regex -> regex.containsMatchIn(it.key) }
+        }
+        .mapValues { type.cast(it.value) }
+        .toMutableMap(),
+      moshiReVoman,
+    )
+  }
+
+  /**
+   * Copy of [mutableEnv] retaining entries whose (typed) value is a [type] instance AND whose key
+   * matches NONE of [keyPatterns]. Patterns are compiled ONCE per call and matched via
+   * [Regex.containsMatchIn] (partial). An empty [keyPatterns] retains all [type]-typed entries.
+   */
+  fun <T> mutableEnvCopyWithKeysNotMatching(
+    type: Class<T>,
+    vararg keyPatterns: String,
+  ): PostmanEnvironment<T> {
+    val regexes: List<Regex> = keyPatterns.map(::Regex)
+    return PostmanEnvironment(
+      mutableEnv
+        .filter {
+          type.isInstance(it.value) && regexes.none { regex -> regex.containsMatchIn(it.key) }
+        }
+        .mapValues { type.cast(it.value) }
+        .toMutableMap(),
+      moshiReVoman,
+    )
+  }
+
   fun <T> valuesForKeysStartingWith(type: Class<T>, prefix: String): Set<T> =
     valuesForKeysStartingWith(type, *arrayOf(prefix))
 
@@ -274,6 +315,39 @@ constructor(
       .filter { type.isInstance(it.value) && suffixes.all { suffix -> !it.key.endsWith(suffix) } }
       .mapNotNull { type.cast(it.value) }
       .toSet()
+
+  /**
+   * Values of entries whose (typed) value is a [type] instance AND whose key matches ANY of
+   * [keyPatterns]. Patterns are compiled ONCE per call and matched via [Regex.containsMatchIn]
+   * (partial): anchor with `^`/`$` for prefix/suffix/exact matching. An empty [keyPatterns] yields
+   * an empty set.
+   */
+  fun <T> valuesForKeysMatching(type: Class<T>, vararg keyPatterns: String): Set<T> {
+    val regexes: List<Regex> = keyPatterns.map(::Regex)
+    return mutableEnv.entries
+      .asSequence()
+      .filter {
+        type.isInstance(it.value) && regexes.any { regex -> regex.containsMatchIn(it.key) }
+      }
+      .mapNotNull { type.cast(it.value) }
+      .toSet()
+  }
+
+  /**
+   * Values of entries whose (typed) value is a [type] instance AND whose key matches NONE of
+   * [keyPatterns]. Patterns are compiled ONCE per call and matched via [Regex.containsMatchIn]
+   * (partial). An empty [keyPatterns] yields all [type]-typed values.
+   */
+  fun <T> valuesForKeysNotMatching(type: Class<T>, vararg keyPatterns: String): Set<T> {
+    val regexes: List<Regex> = keyPatterns.map(::Regex)
+    return mutableEnv.entries
+      .asSequence()
+      .filter {
+        type.isInstance(it.value) && regexes.none { regex -> regex.containsMatchIn(it.key) }
+      }
+      .mapNotNull { type.cast(it.value) }
+      .toSet()
+  }
 }
 
 private val logger = KotlinLogging.logger {}

--- a/src/main/kotlin/com/salesforce/revoman/output/postman/PostmanEnvironment.kt
+++ b/src/main/kotlin/com/salesforce/revoman/output/postman/PostmanEnvironment.kt
@@ -161,9 +161,9 @@ constructor(
 
   // ! TODO 24/06/23 gopala.akshintala: Support for Regex while querying environment
 
-  fun getAsString(key: String?) = moshiReVoman.anyToString(mutableEnv[key])
+  fun getAsString(key: String) = moshiReVoman.anyToString(mutableEnv[key])
 
-  fun getInt(key: String?) = mutableEnv[key] as? Int
+  fun getInt(key: String) = mutableEnv[key] as? Int
 
   @JvmOverloads
   fun <PojoT : Any> getTypedObj(

--- a/src/test/kotlin/com/salesforce/revoman/output/postman/EnvKeyQueryTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/output/postman/EnvKeyQueryTest.kt
@@ -1,0 +1,89 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.output.postman
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Coverage for the key/value query methods that had no other caller in the project:
+ * [PostmanEnvironment.mutableEnvCopyWithValuesOfType] (reified),
+ * [PostmanEnvironment.mutableEnvCopyWithKeysNotStartingWith],
+ * [PostmanEnvironment.valuesForKeysNotStartingWith], [PostmanEnvironment.valuesForKeysEndingWith]
+ * (vararg) and [PostmanEnvironment.valuesForKeysNotEndingWith].
+ */
+class EnvKeyQueryTest {
+  private val env =
+    PostmanEnvironment<Any?>(
+      mutableMapOf(
+        "saId1" to "a",
+        "saId2" to "b",
+        "userId" to "c",
+        "accountName" to "d",
+        "num" to 1,
+      )
+    )
+
+  @Test
+  fun `reified mutableEnvCopyWithValuesOfType retains only values of that type`() {
+    assertThat(env.mutableEnvCopyWithValuesOfType<String>())
+      .containsExactlyEntriesIn(
+        mapOf("saId1" to "a", "saId2" to "b", "userId" to "c", "accountName" to "d")
+      )
+    assertThat(env.mutableEnvCopyWithValuesOfType<Int>())
+      .containsExactlyEntriesIn(mapOf("num" to 1))
+  }
+
+  @Test
+  fun `mutableEnvCopyWithKeysNotStartingWith drops keys starting with any prefix`() {
+    assertThat(env.mutableEnvCopyWithKeysNotStartingWith(String::class.java, "saId", "user"))
+      .containsExactlyEntriesIn(mapOf("accountName" to "d"))
+  }
+
+  @Test
+  fun `mutableEnvCopyWithKeysNotStartingWith with no prefixes retains all typed entries`() {
+    assertThat(env.mutableEnvCopyWithKeysNotStartingWith(String::class.java))
+      .containsExactlyEntriesIn(
+        mapOf("saId1" to "a", "saId2" to "b", "userId" to "c", "accountName" to "d")
+      )
+  }
+
+  @Test
+  fun `valuesForKeysNotStartingWith returns values of keys not starting with any prefix`() {
+    assertThat(env.valuesForKeysNotStartingWith(String::class.java, "saId", "user"))
+      .containsExactly("d")
+  }
+
+  @Test
+  fun `valuesForKeysNotStartingWith filters by type`() {
+    assertThat(env.valuesForKeysNotStartingWith(Integer::class.java, "saId")).containsExactly(1)
+  }
+
+  @Test
+  fun `valuesForKeysEndingWith vararg matches any suffix`() {
+    assertThat(env.valuesForKeysEndingWith(String::class.java, "Id1", "Name"))
+      .containsExactly("a", "d")
+  }
+
+  @Test
+  fun `valuesForKeysEndingWith vararg no match is empty`() {
+    assertThat(env.valuesForKeysEndingWith(String::class.java, "zzz")).isEmpty()
+  }
+
+  @Test
+  fun `valuesForKeysNotEndingWith excludes values whose keys end with any suffix`() {
+    assertThat(env.valuesForKeysNotEndingWith(String::class.java, "Id1", "Id2"))
+      .containsExactly("c", "d")
+  }
+
+  @Test
+  fun `valuesForKeysNotEndingWith with no suffixes returns all typed values`() {
+    assertThat(env.valuesForKeysNotEndingWith(String::class.java))
+      .containsExactly("a", "b", "c", "d")
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/output/postman/KeysMatchingRegexTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/output/postman/KeysMatchingRegexTest.kt
@@ -1,0 +1,102 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.output.postman
+
+import com.google.common.truth.Truth.assertThat
+import java.util.regex.PatternSyntaxException
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class KeysMatchingRegexTest {
+  private val env =
+    PostmanEnvironment<Any?>(
+      mutableMapOf(
+        "saId1" to "a",
+        "saId2" to "b",
+        "my_saId" to "c",
+        "other" to "d",
+        "num1" to 1,
+        "num2" to 2,
+      )
+    )
+
+  @Test
+  fun `valuesForKeysMatching partial matches anywhere in the key`() {
+    // bare pattern is a contains-match: hits both prefixed and infixed keys
+    assertThat(env.valuesForKeysMatching(String::class.java, "saId")).containsExactly("a", "b", "c")
+  }
+
+  @Test
+  fun `valuesForKeysMatching anchored prefix`() {
+    assertThat(env.valuesForKeysMatching(String::class.java, "^saId")).containsExactly("a", "b")
+  }
+
+  @Test
+  fun `valuesForKeysMatching anchored suffix`() {
+    assertThat(env.valuesForKeysMatching(String::class.java, "saId$")).containsExactly("c")
+  }
+
+  @Test
+  fun `valuesForKeysMatching exact anchored match`() {
+    assertThat(env.valuesForKeysMatching(String::class.java, "^saId1$")).containsExactly("a")
+  }
+
+  @Test
+  fun `valuesForKeysMatching filters by type`() {
+    assertThat(env.valuesForKeysMatching(Integer::class.java, "num")).containsExactly(1, 2)
+  }
+
+  @Test
+  fun `valuesForKeysMatching OR across multiple patterns`() {
+    assertThat(env.valuesForKeysMatching(String::class.java, "^saId1$", "^other$"))
+      .containsExactly("a", "d")
+  }
+
+  @Test
+  fun `valuesForKeysMatching no match is empty`() {
+    assertThat(env.valuesForKeysMatching(String::class.java, "zzz")).isEmpty()
+  }
+
+  @Test
+  fun `valuesForKeysMatching empty patterns is empty`() {
+    assertThat(env.valuesForKeysMatching(String::class.java)).isEmpty()
+  }
+
+  @Test
+  fun `valuesForKeysNotMatching excludes keys matching any pattern`() {
+    assertThat(env.valuesForKeysNotMatching(String::class.java, "saId")).containsExactly("d")
+  }
+
+  @Test
+  fun `valuesForKeysNotMatching empty patterns returns all typed values`() {
+    assertThat(env.valuesForKeysNotMatching(String::class.java)).containsExactly("a", "b", "c", "d")
+  }
+
+  @Test
+  fun `mutableEnvCopyWithKeysMatching retains only matching entries`() {
+    assertThat(env.mutableEnvCopyWithKeysMatching(String::class.java, "^saId"))
+      .containsExactlyEntriesIn(mapOf("saId1" to "a", "saId2" to "b"))
+  }
+
+  @Test
+  fun `mutableEnvCopyWithKeysNotMatching drops matching entries`() {
+    assertThat(env.mutableEnvCopyWithKeysNotMatching(String::class.java, "saId"))
+      .containsExactlyEntriesIn(mapOf("other" to "d"))
+  }
+
+  @Test
+  fun `mutableEnvCopyWithKeysMatching filters by type`() {
+    assertThat(env.mutableEnvCopyWithKeysMatching(Integer::class.java, "num"))
+      .containsExactlyEntriesIn(mapOf("num1" to 1, "num2" to 2))
+  }
+
+  @Test
+  fun `invalid regex surfaces PatternSyntaxException`() {
+    assertThrows<PatternSyntaxException> { env.valuesForKeysMatching(String::class.java, "[") }
+  }
+}

--- a/src/test/kotlin/com/salesforce/revoman/output/report/PostmanEnvironmentKtTest.kt
+++ b/src/test/kotlin/com/salesforce/revoman/output/report/PostmanEnvironmentKtTest.kt
@@ -102,6 +102,5 @@ class PostmanEnvironmentKtTest {
     JSONAssert.assertEquals("""{"a":1}""", pmEnv.getAsString("key7"), JSONCompareMode.STRICT)
     pmEnv.getAsString("key8") shouldBe "null"
     pmEnv.getAsString("missing") shouldBe "null"
-    pmEnv.getAsString(null) shouldBe "null"
   }
 }


### PR DESCRIPTION
## What

Three related changes to `PostmanEnvironment`:

1. **`refactor(env)`** — tighten `getInt`/`getAsString` `key` param from `String?` to non-null `String`. Map key type is non-null, so a null key was always a guaranteed miss compiling into a silent null instead of a compile error, and was inconsistent with the non-null key params on `getObj`/`getTypedObj`. `getInt` keeps its `Int?` return (`as?` is already a safe cast).

2. **`feat(env)`** — resolve the long-standing "Support for Regex while querying environment" TODO. Four new methods mirroring the existing prefix/suffix key-query family:
   - `mutableEnvCopyWithKeysMatching` / `NotMatching`
   - `valuesForKeysMatching` / `NotMatching`

   Patterns are `vararg String` (Java-friendly, matches the family), compiled to `Regex` once per call, matched via `containsMatchIn` (partial — anchor with `^`/`$`). `Matching` = key matches ANY pattern; `NotMatching` = NONE.

3. **`test(env)`** — cover five public query methods IDEA flagged with no in-project caller (`mutableEnvCopyWithValuesOfType` reified, `mutableEnvCopyWithKeysNotStartingWith`, `valuesForKeysNotStartingWith`, `valuesForKeysEndingWith` vararg, `valuesForKeysNotEndingWith`).

## Tests

- `KeysMatchingRegexTest` — 13 cases (partial/anchored/exact, type filter, OR, empty-vararg, NotMatching, invalid-pattern throws)
- `EnvKeyQueryTest` — 9 cases for the previously-untested methods
- Full `./gradlew test` green