### PR TITLE
feat(agentic-harness): local runnable agentic API-orchestration harness on ReVoman

### DIFF
--- a/agentic-harness/build.gradle.kts
+++ b/agentic-harness/build.gradle.kts
@@ -58,6 +58,13 @@ tasks.register<JavaExec>("runContractDemo") {
   classpath = sourceSets["main"].runtimeClasspath
 }
 
+tasks.register<JavaExec>("runContractEvalDemo") {
+  group = "harness"
+  description = "Blue-box evals: contract fidelity (drift catch) + ablation accuracy delta"
+  mainClass.set("com.salesforce.revoman.harness.ContractEvalDemoKt")
+  classpath = sourceSets["main"].runtimeClasspath
+}
+
 // --- Isolated `claude` source set: the ONLY place koog lives -------------------------------------
 // Quarantines koog (a large Kotlin-multiplatform dependency built against a different Kotlin
 // version) so a resolution/compat problem can never break the default `test`/`build`/`check`

--- a/agentic-harness/build.gradle.kts
+++ b/agentic-harness/build.gradle.kts
@@ -37,6 +37,13 @@ tasks.register<JavaExec>("runStage2Demo") {
   classpath = sourceSets["main"].runtimeClasspath
 }
 
+tasks.register<JavaExec>("runStage3Demo") {
+  group = "harness"
+  description = "Run the evals + calibration demo (confusion matrix, BFCL, tau-bench, LLM-judge)"
+  mainClass.set("com.salesforce.revoman.harness.Stage3DemoKt")
+  classpath = sourceSets["main"].runtimeClasspath
+}
+
 // --- Isolated `claude` source set: the ONLY place koog lives -------------------------------------
 // Quarantines koog (a large Kotlin-multiplatform dependency built against a different Kotlin
 // version) so a resolution/compat problem can never break the default `test`/`build`/`check`

--- a/agentic-harness/build.gradle.kts
+++ b/agentic-harness/build.gradle.kts
@@ -77,8 +77,12 @@ tasks.register<JavaExec>("runContractEvalDemo") {
 // version) so a resolution/compat problem can never break the default `test`/`build`/`check`
 // tasks, which never compile this source set. `compileClaudeKotlin` / `claudeDemo` are opt-in.
 val claude: SourceSet by sourceSets.creating {
-  compileClasspath += sourceSets["main"].output
-  runtimeClasspath += sourceSets["main"].output
+  // Inherit main's OWN dependencies (snakeyaml, the :revoman project, etc.) — not just its compiled
+  // output — so the live ClaudeDemo can load OAS/graphs at runtime. koog is layered on top via
+  // `claudeImplementation` below. This keeps the quarantine intact: the default build still never
+  // compiles this set.
+  compileClasspath += sourceSets["main"].compileClasspath + sourceSets["main"].output
+  runtimeClasspath += sourceSets["main"].runtimeClasspath + sourceSets["main"].output
 }
 
 dependencies {

--- a/agentic-harness/build.gradle.kts
+++ b/agentic-harness/build.gradle.kts
@@ -46,7 +46,10 @@ val claude: SourceSet by sourceSets.creating {
   runtimeClasspath += sourceSets["main"].output
 }
 
-dependencies { "claudeImplementation"("ai.koog:koog-agents:1.1.1") }
+dependencies {
+  "claudeImplementation"("ai.koog:koog-agents:1.1.1")
+  "claudeImplementation"("ai.koog:koog-agents-additions:1.1.1-beta")
+}
 
 tasks.register<JavaExec>("claudeDemo") {
   group = "harness"

--- a/agentic-harness/build.gradle.kts
+++ b/agentic-harness/build.gradle.kts
@@ -11,6 +11,8 @@ dependencies {
   // The deterministic execution engine. `project(":")` is the ReVoman library module.
   implementation(project(":"))
 
+  implementation(libs.snakeyaml)
+
   // Truth for assertions, matching ReVoman's own revUp tests (RestfulAPIDevKtTest).
   testImplementation(libs.truth)
 }

--- a/agentic-harness/build.gradle.kts
+++ b/agentic-harness/build.gradle.kts
@@ -36,3 +36,21 @@ tasks.register<JavaExec>("runStage2Demo") {
   mainClass.set("com.salesforce.revoman.harness.Stage2DemoKt")
   classpath = sourceSets["main"].runtimeClasspath
 }
+
+// --- Isolated `claude` source set: the ONLY place koog lives -------------------------------------
+// Quarantines koog (a large Kotlin-multiplatform dependency built against a different Kotlin
+// version) so a resolution/compat problem can never break the default `test`/`build`/`check`
+// tasks, which never compile this source set. `compileClaudeKotlin` / `claudeDemo` are opt-in.
+val claude: SourceSet by sourceSets.creating {
+  compileClasspath += sourceSets["main"].output
+  runtimeClasspath += sourceSets["main"].output
+}
+
+dependencies { "claudeImplementation"("ai.koog:koog-agents:1.1.1") }
+
+tasks.register<JavaExec>("claudeDemo") {
+  group = "harness"
+  description = "Run the orchestrator with the REAL Claude LLM (requires ANTHROPIC_API_KEY)"
+  mainClass.set("com.salesforce.revoman.harness.ClaudeDemoKt")
+  classpath = claude.runtimeClasspath
+}

--- a/agentic-harness/build.gradle.kts
+++ b/agentic-harness/build.gradle.kts
@@ -20,3 +20,10 @@ testing {
     getByName<JvmTestSuite>("test") { useJUnitJupiter(libs.versions.junit.get()) }
   }
 }
+
+tasks.register<JavaExec>("runStage1Demo") {
+  group = "harness"
+  description = "Boot the mock CPQ server and run the configure->price->quote graph chain"
+  mainClass.set("com.salesforce.revoman.harness.Stage1DemoKt")
+  classpath = sourceSets["main"].runtimeClasspath
+}

--- a/agentic-harness/build.gradle.kts
+++ b/agentic-harness/build.gradle.kts
@@ -44,6 +44,13 @@ tasks.register<JavaExec>("runStage3Demo") {
   classpath = sourceSets["main"].runtimeClasspath
 }
 
+tasks.register<JavaExec>("runStage4Demo") {
+  group = "harness"
+  description = "Run the observability + feedback-flywheel demo (spans, confirm gate, nightly batch)"
+  mainClass.set("com.salesforce.revoman.harness.Stage4DemoKt")
+  classpath = sourceSets["main"].runtimeClasspath
+}
+
 // --- Isolated `claude` source set: the ONLY place koog lives -------------------------------------
 // Quarantines koog (a large Kotlin-multiplatform dependency built against a different Kotlin
 // version) so a resolution/compat problem can never break the default `test`/`build`/`check`

--- a/agentic-harness/build.gradle.kts
+++ b/agentic-harness/build.gradle.kts
@@ -1,0 +1,22 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+plugins { id("revoman.kt-conventions") }
+
+dependencies {
+  // The deterministic execution engine. `project(":")` is the ReVoman library module.
+  implementation(project(":"))
+
+  // Truth for assertions, matching ReVoman's own revUp tests (RestfulAPIDevKtTest).
+  testImplementation(libs.truth)
+}
+
+testing {
+  suites {
+    getByName<JvmTestSuite>("test") { useJUnitJupiter(libs.versions.junit.get()) }
+  }
+}

--- a/agentic-harness/build.gradle.kts
+++ b/agentic-harness/build.gradle.kts
@@ -51,6 +51,13 @@ tasks.register<JavaExec>("runStage4Demo") {
   classpath = sourceSets["main"].runtimeClasspath
 }
 
+tasks.register<JavaExec>("runStage5Demo") {
+  group = "harness"
+  description = "Run the complete reasoning layer (retrieve -> route -> fill -> gate: ask|confirm|proceed)"
+  mainClass.set("com.salesforce.revoman.harness.Stage5DemoKt")
+  classpath = sourceSets["main"].runtimeClasspath
+}
+
 tasks.register<JavaExec>("runContractDemo") {
   group = "harness"
   description = "Print the unified GraphContract (descriptor + runtime + dataFlow) at all verbosity tiers"

--- a/agentic-harness/build.gradle.kts
+++ b/agentic-harness/build.gradle.kts
@@ -29,3 +29,10 @@ tasks.register<JavaExec>("runStage1Demo") {
   mainClass.set("com.salesforce.revoman.harness.Stage1DemoKt")
   classpath = sourceSets["main"].runtimeClasspath
 }
+
+tasks.register<JavaExec>("runStage2Demo") {
+  group = "harness"
+  description = "Run the orchestrator-workers loop (route -> slot-fill -> revUp) with the stub LLM"
+  mainClass.set("com.salesforce.revoman.harness.Stage2DemoKt")
+  classpath = sourceSets["main"].runtimeClasspath
+}

--- a/agentic-harness/build.gradle.kts
+++ b/agentic-harness/build.gradle.kts
@@ -51,6 +51,13 @@ tasks.register<JavaExec>("runStage4Demo") {
   classpath = sourceSets["main"].runtimeClasspath
 }
 
+tasks.register<JavaExec>("runContractDemo") {
+  group = "harness"
+  description = "Print the unified GraphContract (descriptor + runtime + dataFlow) at all verbosity tiers"
+  mainClass.set("com.salesforce.revoman.harness.ContractDemoKt")
+  classpath = sourceSets["main"].runtimeClasspath
+}
+
 // --- Isolated `claude` source set: the ONLY place koog lives -------------------------------------
 // Quarantines koog (a large Kotlin-multiplatform dependency built against a different Kotlin
 // version) so a resolution/compat problem can never break the default `test`/`build`/`check`

--- a/agentic-harness/src/claude/kotlin/com/salesforce/revoman/harness/ClaudeDemo.kt
+++ b/agentic-harness/src/claude/kotlin/com/salesforce/revoman/harness/ClaudeDemo.kt
@@ -1,0 +1,40 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness
+
+import com.salesforce.revoman.harness.llm.claude.ClaudeLlmClient
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import com.salesforce.revoman.harness.orchestrator.Orchestrator
+import com.salesforce.revoman.harness.orchestrator.OrchestrationResult
+
+/** Live demo of the orchestrator with the REAL Claude LLM. No-ops (skips) when the key is absent. */
+fun main() {
+  val llm = ClaudeLlmClient.fromEnv()
+  if (llm == null) {
+    println("ANTHROPIC_API_KEY not set — skipping the live Claude demo.")
+    return
+  }
+  val server = MockCpqServer()
+  val baseUrl = "http://127.0.0.1:${server.start()}"
+  val orchestrator = Orchestrator(baseUrl, GraphRegistry.loadToolDefs(), llm)
+  try {
+    println("Live Claude demo, mock CPQ at $baseUrl")
+    listOf("I want to configure ten of SKU-2", "how much will this cost").forEach { utterance ->
+      println("\n>>> $utterance")
+      when (val r = orchestrator.orchestrate(utterance)) {
+        is OrchestrationResult.NoGraphMatched -> println("No graph matched.")
+        is OrchestrationResult.SlotsRejected -> println("Slots rejected for '${r.graph}': ${r.errors}")
+        is OrchestrationResult.Executed -> println("Routed to '${r.graph}', slots=${r.slots}\n${r.context}")
+      }
+    }
+    println("\nFinal mock DB state: ${server.db}")
+  } finally {
+    server.stop()
+  }
+}

--- a/agentic-harness/src/claude/kotlin/com/salesforce/revoman/harness/ClaudeDemo.kt
+++ b/agentic-harness/src/claude/kotlin/com/salesforce/revoman/harness/ClaudeDemo.kt
@@ -15,9 +15,9 @@ import com.salesforce.revoman.harness.orchestrator.OrchestrationResult
 
 /** Live demo of the orchestrator with the REAL Claude LLM. No-ops (skips) when the key is absent. */
 fun main() {
-  val llm = ClaudeLlmClient.fromEnv()
+  val llm = ClaudeLlmClient.fromBedrockEnv() ?: ClaudeLlmClient.fromEnv()
   if (llm == null) {
-    println("ANTHROPIC_API_KEY not set — skipping the live Claude demo.")
+    println("Neither ANTHROPIC_BEDROCK_BASE_URL+ANTHROPIC_AUTH_TOKEN nor ANTHROPIC_API_KEY set — skipping the live Claude demo.")
     return
   }
   val server = MockCpqServer()

--- a/agentic-harness/src/claude/kotlin/com/salesforce/revoman/harness/llm/claude/ClaudeLlmClient.kt
+++ b/agentic-harness/src/claude/kotlin/com/salesforce/revoman/harness/llm/claude/ClaudeLlmClient.kt
@@ -1,0 +1,93 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.llm.claude
+
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.executor.clients.anthropic.AnthropicModels
+import ai.koog.prompt.executor.llms.all.simpleAnthropicExecutor
+import com.salesforce.revoman.harness.llm.LlmClient
+import com.salesforce.revoman.harness.llm.RouteDecision
+import com.salesforce.revoman.harness.tooldef.ToolDef
+import kotlinx.coroutines.runBlocking
+
+/**
+ * The REAL [LlmClient] backed by Claude via koog. Confined to the isolated `claude` source set so
+ * koog never touches the CI-tested core. Bridges koog's suspend API with [runBlocking] to satisfy
+ * the synchronous [LlmClient] contract. Never required to run tests — gated on [fromEnv].
+ */
+class ClaudeLlmClient(apiKey: String) : LlmClient {
+  private val executor = simpleAnthropicExecutor(apiKey)
+  private val model = AnthropicModels.Sonnet_4_5
+
+  override fun route(utterance: String, tools: List<ToolDef>): RouteDecision {
+    val toolBlock =
+      tools.joinToString("\n\n") { t ->
+        buildString {
+          appendLine("graph: ${t.graphName}")
+          appendLine("when_to_use: ${t.whenToUse}")
+          appendLine("when_not_to_use: ${t.whenNotToUse.joinToString("; ")}")
+          appendLine("example_queries: ${t.exampleQueries.joinToString("; ")}")
+        }
+      }
+    val text =
+      runBlocking {
+        executor
+          .execute(
+            prompt("route") {
+              system(
+                "You are a router. Choose exactly ONE graph name for the user's request, or the " +
+                  "literal word NONE if no graph fits. Reply with ONLY the graph name or NONE.\n\n" +
+                  toolBlock
+              )
+              user(utterance)
+            },
+            model,
+          )
+          .content
+          .trim()
+      }
+    val chosen = tools.firstOrNull { it.graphName.equals(text, ignoreCase = true) }?.graphName
+    return RouteDecision(chosen, "claude replied: $text")
+  }
+
+  override fun fillSlots(utterance: String, tool: ToolDef): Map<String, String> {
+    val schema =
+      tool.slots.entries.joinToString("\n") { (name, s) ->
+        "- $name: type=${s.type}${if (s.values.isNotEmpty()) ", allowed=${s.values}" else ""}"
+      }
+    val examples = tool.inputExamples.joinToString("\n") { it.toString() }
+    val text =
+      runBlocking {
+        executor
+          .execute(
+            prompt("slot-fill") {
+              system(
+                "Extract the input slots for the '${tool.graphName}' graph from the user request. " +
+                  "Reply with ONLY compact JSON of slot->string-value. Use only these slots:\n" +
+                  "$schema\n\nExamples:\n$examples"
+              )
+              user(utterance)
+            },
+            model,
+          )
+          .content
+          .trim()
+      }
+    return parseFlatJson(text)
+  }
+
+  /** Minimal flat-JSON parser for `{"k":"v",...}` — the slot-fill reply shape. */
+  private fun parseFlatJson(json: String): Map<String, String> =
+    Regex(""""(\w+)"\s*:\s*"?([^",}]+)"?""")
+      .findAll(json)
+      .associate { it.groupValues[1] to it.groupValues[2].trim() }
+
+  companion object {
+    fun fromEnv(): LlmClient? = System.getenv("ANTHROPIC_API_KEY")?.let(::ClaudeLlmClient)
+  }
+}

--- a/agentic-harness/src/claude/kotlin/com/salesforce/revoman/harness/llm/claude/ClaudeLlmClient.kt
+++ b/agentic-harness/src/claude/kotlin/com/salesforce/revoman/harness/llm/claude/ClaudeLlmClient.kt
@@ -48,7 +48,7 @@ class ClaudeLlmClient(apiKey: String) : LlmClient {
             },
             model,
           )
-          .content
+          .textContent()
           .trim()
       }
     val chosen = tools.firstOrNull { it.graphName.equals(text, ignoreCase = true) }?.graphName
@@ -75,7 +75,7 @@ class ClaudeLlmClient(apiKey: String) : LlmClient {
             },
             model,
           )
-          .content
+          .textContent()
           .trim()
       }
     return parseFlatJson(text)

--- a/agentic-harness/src/claude/kotlin/com/salesforce/revoman/harness/llm/claude/ClaudeLlmClient.kt
+++ b/agentic-harness/src/claude/kotlin/com/salesforce/revoman/harness/llm/claude/ClaudeLlmClient.kt
@@ -60,7 +60,10 @@ class ClaudeLlmClient(apiKey: String) : LlmClient {
       tool.slots.entries.joinToString("\n") { (name, s) ->
         "- $name: type=${s.type}${if (s.values.isNotEmpty()) ", allowed=${s.values}" else ""}"
       }
-    val examples = tool.inputExamples.joinToString("\n") { it.toString() }
+    val examples =
+      tool.inputExamples.joinToString("\n") { ex ->
+        ex.entries.joinToString(", ", "{", "}") { (k, v) -> "\"$k\":\"$v\"" }
+      }
     val text =
       runBlocking {
         executor

--- a/agentic-harness/src/claude/kotlin/com/salesforce/revoman/harness/llm/claude/ClaudeLlmClient.kt
+++ b/agentic-harness/src/claude/kotlin/com/salesforce/revoman/harness/llm/claude/ClaudeLlmClient.kt
@@ -9,7 +9,12 @@ package com.salesforce.revoman.harness.llm.claude
 
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.clients.anthropic.AnthropicModels
+import ai.koog.prompt.executor.clients.bedrock.BedrockClientSettings
+import ai.koog.prompt.executor.clients.bedrock.BedrockModels
 import ai.koog.prompt.executor.llms.all.simpleAnthropicExecutor
+import ai.koog.prompt.executor.llms.all.simpleBedrockExecutorWithBearerToken
+import ai.koog.prompt.executor.model.PromptExecutor
+import ai.koog.prompt.llm.LLModel
 import com.salesforce.revoman.harness.llm.LlmClient
 import com.salesforce.revoman.harness.llm.RouteDecision
 import com.salesforce.revoman.harness.tooldef.ToolDef
@@ -20,9 +25,9 @@ import kotlinx.coroutines.runBlocking
  * koog never touches the CI-tested core. Bridges koog's suspend API with [runBlocking] to satisfy
  * the synchronous [LlmClient] contract. Never required to run tests — gated on [fromEnv].
  */
-class ClaudeLlmClient(apiKey: String) : LlmClient {
-  private val executor = simpleAnthropicExecutor(apiKey)
-  private val model = AnthropicModels.Sonnet_4_5
+class ClaudeLlmClient(private val executor: PromptExecutor, private val model: LLModel) : LlmClient {
+  /** Secondary constructor for the direct Anthropic API (sk-ant-... key). */
+  constructor(apiKey: String) : this(simpleAnthropicExecutor(apiKey), AnthropicModels.Sonnet_4_5)
 
   override fun route(utterance: String, tools: List<ToolDef>): RouteDecision {
     val toolBlock =
@@ -91,6 +96,20 @@ class ClaudeLlmClient(apiKey: String) : LlmClient {
       .associate { it.groupValues[1] to it.groupValues[2].trim() }
 
   companion object {
+    /** Direct public Anthropic API (sk-ant-... key). Null when unset. */
     fun fromEnv(): LlmClient? = System.getenv("ANTHROPIC_API_KEY")?.let(::ClaudeLlmClient)
+
+    /**
+     * This environment's path: an AWS Bedrock proxy (bearer token + custom gateway URL) rather
+     * than the public Anthropic API. Best-effort — koog's Bedrock client may or may not accept a
+     * non-AWS gateway; if it doesn't, the caller falls back to skip.
+     */
+    fun fromBedrockEnv(): LlmClient? {
+      val token = System.getenv("ANTHROPIC_AUTH_TOKEN") ?: return null
+      val baseUrl = System.getenv("ANTHROPIC_BEDROCK_BASE_URL") ?: return null
+      val executor =
+        simpleBedrockExecutorWithBearerToken(token, BedrockClientSettings(endpointUrl = baseUrl))
+      return ClaudeLlmClient(executor, BedrockModels.AnthropicClaude45Opus)
+    }
   }
 }

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/ContractDemo.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/ContractDemo.kt
@@ -1,0 +1,43 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness
+
+import com.salesforce.revoman.harness.contract.toJson
+import com.salesforce.revoman.harness.llm.StubLlmClient
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import com.salesforce.revoman.harness.orchestrator.Orchestrator
+import com.salesforce.revoman.harness.orchestrator.OrchestrationResult
+import com.salesforce.revoman.output.Verbosity
+
+/**
+ * Blue-box demo: the unified GraphContract in action. Orchestrates one intent, then prints the SAME
+ * contract at SUMMARY / STANDARD / VERBOSE so the tiers are visible side by side — descriptor
+ * metadata + runtime outcome + data-lineage, fused, deterministic, no LLM key.
+ */
+fun main() {
+  val tools = GraphRegistry.loadToolDefs()
+  val server = MockCpqServer()
+  val baseUrl = "http://127.0.0.1:${server.start()}"
+  try {
+    val result =
+      Orchestrator(baseUrl, tools, StubLlmClient()).orchestrate("configure 2 units of SKU-1")
+    val contract =
+      (result as? OrchestrationResult.Executed)?.contract
+        ?: run {
+          println("No contract (outcome: $result)")
+          return
+        }
+    listOf(Verbosity.SUMMARY, Verbosity.STANDARD, Verbosity.VERBOSE).forEach { v ->
+      println("\n===== GraphContract @ $v =====")
+      println(contract.toJson(v))
+    }
+  } finally {
+    server.stop()
+  }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/ContractEvalDemo.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/ContractEvalDemo.kt
@@ -1,0 +1,65 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness
+
+import com.salesforce.revoman.harness.GraphRunner
+import com.salesforce.revoman.harness.contract.ContractAblationEval
+import com.salesforce.revoman.harness.contract.ContractFidelityCheck
+import com.salesforce.revoman.harness.contract.GraphContract
+import com.salesforce.revoman.harness.eval.EvalSet
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import com.salesforce.revoman.harness.tooldef.GraphMetadataParser
+import com.salesforce.revoman.harness.tooldef.GraphOasLoader
+import com.salesforce.revoman.harness.tooldef.GraphSpec
+import com.salesforce.revoman.harness.tooldef.ToolDefGenerator
+
+/**
+ * Blue-box eval demo: how we TEST and IMPROVE the unified contract, deterministic (no key).
+ * (1) Fidelity — the contract's runtime matches its declared metadata (Layer-1, no LLM).
+ * (2) Simulated drift — a declared output the run never produces is caught.
+ * (3) Efficacy — enriching the contract raises graph-selection accuracy on the eval set.
+ */
+fun main() {
+  val server = MockCpqServer()
+  val baseUrl = "http://127.0.0.1:${server.start()}"
+  try {
+    val descriptor =
+      ToolDefGenerator.generate(GraphMetadataParser.parse("configure"), GraphOasLoader.load("configure"))
+    val slots = mapOf("productCode" to "SKU-1", "quantity" to "2")
+    val contract =
+      GraphContract.of(descriptor, slots, GraphRunner.runChain(baseUrl, listOf("configure"), slots).single())
+    val check = ContractFidelityCheck()
+
+    println("=== 1. Fidelity: does the contract mirror reality? (no LLM) ===")
+    val spec = GraphMetadataParser.parse("configure")
+    val ok = check.check(contract, spec)
+    println("  configure faithful=${ok.faithful} (declared==actually-produced)")
+
+    println("\n=== 2. Simulated API drift: metadata declares an output the run never produces ===")
+    val drifted = GraphSpec(spec.name, spec.description, spec.slots, spec.outputKeys + "discountId")
+    val drift = check.check(contract, drifted)
+    println("  faithful=${drift.faithful}  missingProduced=${drift.missingProduced}  <-- drift caught in CI")
+
+    println("\n=== 3. Efficacy: enrich the contract, measure accuracy on the eval set ===")
+    val cases = EvalSet.load()
+    val stripped = GraphRegistry.loadToolDefs().map { it.copy(whenNotToUse = emptyList()) }
+    val enriched =
+      stripped.map {
+        if (it.graphName == "quote")
+          it.copy(whenNotToUse = listOf("Do not use when the user asks for a price or cost — that is the price graph."))
+        else it
+      }
+    val (a, b) = ContractAblationEval().compare(cases, "stripped" to stripped, "enriched" to enriched)
+    println("  ${a.variantName}: ${a.accuracyCorrect}/${a.accuracyTotal}")
+    println("  ${b.variantName}: ${b.accuracyCorrect}/${b.accuracyTotal}")
+    println("  contract enrichment moved accuracy: ${a.accuracyCorrect}/${a.accuracyTotal} -> ${b.accuracyCorrect}/${b.accuracyTotal}")
+  } finally {
+    server.stop()
+  }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/GraphRunner.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/GraphRunner.kt
@@ -1,0 +1,47 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness
+
+import com.salesforce.revoman.ReVoman
+import com.salesforce.revoman.input.config.Kick
+import com.salesforce.revoman.output.Rundown
+import com.salesforce.revoman.output.Verbosity
+import com.salesforce.revoman.output.toJson
+
+/**
+ * The deterministic worker: runs one or more ReVoman V3 graph collections in order, threading the
+ * mutable environment forward from each graph into the next (this is the {{var}} edge mechanism —
+ * no LLM, no @{ref.id} operator). Wraps `ReVoman.revUp(List<Kick>)`.
+ */
+object GraphRunner {
+  val DEFAULT_CHAIN: List<String> = listOf("configure", "price", "quote")
+
+  fun runChain(
+    baseUrl: String,
+    graphs: List<String> = DEFAULT_CHAIN,
+    seedEnv: Map<String, Any?> = emptyMap(),
+  ): List<Rundown> {
+    val runtimeEnv: Map<String, Any?> = mapOf("baseUrl" to baseUrl) + seedEnv
+    val kicks =
+      graphs.map { graph ->
+        Kick.configure()
+          .templatePath("graphs/$graph")
+          .environmentPath("graphs/$graph/$graph.environment.yaml")
+          .dynamicEnvironment(runtimeEnv)
+          .off()
+      }
+    return ReVoman.revUp(kicks)
+  }
+
+  fun runChainAndSummarize(
+    baseUrl: String,
+    graphs: List<String> = DEFAULT_CHAIN,
+    seedEnv: Map<String, Any?> = emptyMap(),
+  ): String =
+    runChain(baseUrl, graphs, seedEnv).joinToString("\n") { it.toJson(Verbosity.SUMMARY) }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/GraphRunner.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/GraphRunner.kt
@@ -26,6 +26,7 @@ object GraphRunner {
     graphs: List<String> = DEFAULT_CHAIN,
     seedEnv: Map<String, Any?> = emptyMap(),
   ): List<Rundown> {
+    logger.log(System.Logger.Level.INFO, "Starting graph chain: baseUrl={0}, graphs={1}", baseUrl, graphs.joinToString(","))
     val runtimeEnv: Map<String, Any?> = mapOf("baseUrl" to baseUrl) + seedEnv
     val kicks =
       graphs.map { graph ->
@@ -35,7 +36,10 @@ object GraphRunner {
           .dynamicEnvironment(runtimeEnv)
           .off()
       }
-    return ReVoman.revUp(kicks)
+    val rundowns = ReVoman.revUp(kicks)
+    val summary = rundowns.joinToString(", ") { "${it.stopReason}" }
+    logger.log(System.Logger.Level.INFO, "Graph chain completed: {0}", summary)
+    return rundowns
   }
 
   fun runChainAndSummarize(
@@ -45,3 +49,5 @@ object GraphRunner {
   ): String =
     runChain(baseUrl, graphs, seedEnv).joinToString("\n") { it.toJson(Verbosity.SUMMARY) }
 }
+
+private val logger: System.Logger = System.getLogger("com.salesforce.revoman.harness.GraphRunner")

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/Stage1Demo.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/Stage1Demo.kt
@@ -1,0 +1,27 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness
+
+import com.salesforce.revoman.harness.mock.MockCpqServer
+
+/**
+ * Stage 1 runnable demo: boot the mock CPQ server, run the configure->price->quote graph chain
+ * through ReVoman, and print each Rundown summary. This is the deterministic worker, end to end,
+ * with no LLM involved.
+ */
+fun main() {
+  val server = MockCpqServer()
+  val baseUrl = "http://127.0.0.1:${server.start()}"
+  try {
+    println("Mock CPQ server up at $baseUrl")
+    println(GraphRunner.runChainAndSummarize(baseUrl))
+    println("Final mock DB state: ${server.db}")
+  } finally {
+    server.stop()
+  }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/Stage2Demo.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/Stage2Demo.kt
@@ -1,0 +1,49 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness
+
+import com.salesforce.revoman.harness.llm.StubLlmClient
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import com.salesforce.revoman.harness.orchestrator.Orchestrator
+import com.salesforce.revoman.harness.orchestrator.OrchestrationResult
+
+/**
+ * Stage 2 runnable demo: the orchestrator-workers loop end to end with the deterministic stub LLM
+ * (no API key needed). Routes a handful of utterances, fills+validates slots, executes the chosen
+ * graph via ReVoman, and prints the outcome + the Rundown context that would flow back to the LLM.
+ */
+fun main() {
+  val server = MockCpqServer()
+  val baseUrl = "http://127.0.0.1:${server.start()}"
+  val tools = GraphRegistry.loadToolDefs()
+  val orchestrator = Orchestrator(baseUrl, tools, StubLlmClient())
+  val utterances =
+    listOf(
+      "configure 2 units of SKU-1",
+      "what is the weather today",
+    )
+  try {
+    println("Mock CPQ server up at $baseUrl")
+    utterances.forEach { utterance ->
+      println("\n>>> $utterance")
+      when (val result = orchestrator.orchestrate(utterance)) {
+        is OrchestrationResult.NoGraphMatched -> println("No graph matched.")
+        is OrchestrationResult.SlotsRejected ->
+          println("Slots rejected for '${result.graph}': ${result.errors}")
+        is OrchestrationResult.Executed -> {
+          println("Routed to '${result.graph}', slots=${result.slots}")
+          println(result.context)
+        }
+      }
+    }
+    println("\nFinal mock DB state: ${server.db}")
+  } finally {
+    server.stop()
+  }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/Stage3Demo.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/Stage3Demo.kt
@@ -1,0 +1,81 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness
+
+import com.salesforce.revoman.harness.eval.BfclCheck
+import com.salesforce.revoman.harness.eval.EvalSet
+import com.salesforce.revoman.harness.eval.GroundTruth
+import com.salesforce.revoman.harness.eval.RouterEvaluator
+import com.salesforce.revoman.harness.eval.SlotFillGoldSet
+import com.salesforce.revoman.harness.eval.StubJudge
+import com.salesforce.revoman.harness.eval.TaskCase
+import com.salesforce.revoman.harness.eval.TauBenchCheck
+import com.salesforce.revoman.harness.llm.ScoringLlmClient
+import com.salesforce.revoman.harness.llm.StubLlmClient
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import com.salesforce.revoman.harness.orchestrator.Orchestrator
+import com.salesforce.revoman.harness.orchestrator.OrchestrationResult
+
+/**
+ * Stage 3 runnable demo: evals + calibration in action, entirely deterministic (no API key). Shows
+ * (1) the confusion matrix before/after adding a `when_not_to_use` clause and the accuracy move,
+ * (2) BFCL slot-fill checks vs gold, (3) a tau-bench final-DB-state check, (4) an LLM-as-judge
+ * screening a fuzzy metric alongside the deterministic ground-truth gate.
+ */
+fun main() {
+  val cases = EvalSet.load()
+  val evaluator = RouterEvaluator(ScoringLlmClient())
+  val seedTools = GraphRegistry.loadToolDefs().map { it.copy(whenNotToUse = emptyList()) }
+  val clause = "Do not use when the user asks for a price or cost — that is the price graph."
+  val calibratedTools =
+    seedTools.map { if (it.graphName == "quote") it.copy(whenNotToUse = listOf(clause)) else it }
+
+  println("=== 1. Graph-selection confusion matrix (SEED, un-calibrated) ===")
+  val seed = evaluator.evaluate(cases, seedTools)
+  println(seed.matrix.render())
+  println("misses: ${seed.misses}")
+
+  println("\n=== 2. Calibration: add when_not_to_use to 'quote' ===")
+  println("  + $clause")
+  val calibrated = evaluator.evaluate(cases, calibratedTools)
+  println(calibrated.matrix.render())
+  println(
+    "accuracy moved: ${seed.matrix.correct}/${seed.matrix.total} -> " +
+      "${calibrated.matrix.correct}/${calibrated.matrix.total}"
+  )
+
+  println("\n=== 3. BFCL-style slot-fill check (predicted call vs gold) ===")
+  val tools = GraphRegistry.loadToolDefs()
+  val bfcl = BfclCheck(StubLlmClient(), tools)
+  SlotFillGoldSet.load().forEach { gold ->
+    val r = bfcl.check(gold)
+    println("  ${if (r.pass) "PASS" else "FAIL"}  '${gold.utterance}' -> ${r.predictedGraph} ${r.predictedSlots}")
+  }
+
+  val server = MockCpqServer()
+  val baseUrl = "http://127.0.0.1:${server.start()}"
+  try {
+    println("\n=== 4. tau-bench-style task success (final DB state) ===")
+    val tau = TauBenchCheck(baseUrl, tools, StubLlmClient())
+    val taskCase = TaskCase("configure 2 units of SKU-1", listOf("SKU-1 x2"))
+    println("  ${if (tau.check(server, taskCase)) "PASS" else "FAIL"}  final DB = ${server.db}")
+
+    println("\n=== 5. LLM-as-judge (screen) alongside deterministic ground-truth (gate) ===")
+    when (val result = Orchestrator(baseUrl, tools, StubLlmClient()).orchestrate("configure 2 units of SKU-1")) {
+      is OrchestrationResult.Executed -> {
+        val judgment = StubJudge().judge("configure 2 units of SKU-1", result.context)
+        println("  judge (advisory screen): pass=${judgment.pass} — ${judgment.reason}")
+        println("  ground-truth (gate):     pass=${GroundTruth.allStepsSucceeded(result.rundowns)}")
+      }
+      else -> println("  (unexpected: $result)")
+    }
+  } finally {
+    server.stop()
+  }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/Stage4Demo.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/Stage4Demo.kt
@@ -1,0 +1,83 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness
+
+import com.salesforce.revoman.harness.eval.RouterEvaluator
+import com.salesforce.revoman.harness.eval.EvalSet
+import com.salesforce.revoman.harness.feedback.ConfirmGate
+import com.salesforce.revoman.harness.feedback.Decision
+import com.salesforce.revoman.harness.feedback.FeedbackLabel
+import com.salesforce.revoman.harness.feedback.NightlyBatch
+import com.salesforce.revoman.harness.feedback.Proposal
+import com.salesforce.revoman.harness.llm.ScoringLlmClient
+import com.salesforce.revoman.harness.llm.StubLlmClient
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import com.salesforce.revoman.harness.orchestrator.Orchestrator
+import com.salesforce.revoman.harness.orchestrator.OrchestrationResult
+import com.salesforce.revoman.harness.telemetry.GenAiTracer
+
+/**
+ * Stage 4 runnable demo: observability + the feedback flywheel, all deterministic (no API key).
+ * (1) Traces turns with OpenTelemetry GenAI-convention spans printed to console. (2) Runs each
+ * executed proposal through the HITL confirm gate (a scripted confirm + a reject of the near-miss).
+ * (3) Runs the nightly batch to grow the eval set and draft a `when_not_to_use` clause. (4) Closes
+ * the loop: re-evaluates the router on the grown set, showing the CI gate tighten.
+ */
+fun main() {
+  val tools = GraphRegistry.loadToolDefs()
+  val server = MockCpqServer()
+  val baseUrl = "http://127.0.0.1:${server.start()}"
+  val tracer = GenAiTracer()
+  val orchestrator = Orchestrator(baseUrl, tools, StubLlmClient(), tracer)
+
+  try {
+    println("=== 1. Traced orchestration turns (OTel GenAI spans to console) ===")
+    val executed = orchestrator.orchestrate("configure 2 units of SKU-1")
+
+    println("\n=== 2. HITL confirm gate ===")
+    val labels = mutableListOf<FeedbackLabel>()
+    if (executed is OrchestrationResult.Executed) {
+      val proposal = Proposal("configure 2 units of SKU-1", executed.graph, executed.slots)
+      val label = ConfirmGate.apply(proposal, Decision.Confirm)
+      labels.add(label)
+      println("  confirm -> $label")
+    }
+    // A human rejects the near-miss the router would get wrong, stating the correct graph.
+    val rejectProposal = Proposal("quote me a price for this config", "quote", emptyMap())
+    val rejectLabel = ConfirmGate.apply(rejectProposal, Decision.Reject(correctGraph = "price"))
+    labels.add(rejectLabel)
+    println("  reject  -> $rejectLabel")
+
+    println("\n=== 3. Nightly batch (mine labels -> grow eval set + draft when_not_to_use) ===")
+    // For the demo, use a seed eval set that excludes the near-miss case, so we can show growth.
+    val fullEval = EvalSet.load()
+    val seedEval = fullEval.filter { it.utterance != "quote me a price for this config" }
+    val batch = NightlyBatch.run(seedEval, labels)
+    println("  eval set grew: ${seedEval.size} -> ${batch.grownEvalSet.size} cases")
+    batch.draftedClauses.forEach { (graph, clauses) ->
+      clauses.forEach { println("  drafted when_not_to_use for '$graph': $it") }
+    }
+
+    println("\n=== 4. Close the loop: re-eval shows the CI gate tighten ===")
+    val evaluator = RouterEvaluator(ScoringLlmClient())
+    val seedTools = tools.map { it.copy(whenNotToUse = emptyList()) }
+    val calibratedTools =
+      seedTools.map {
+        if (batch.draftedClauses.containsKey(it.graphName))
+          it.copy(whenNotToUse = batch.draftedClauses[it.graphName]!!)
+        else it
+      }
+    val before = evaluator.evaluate(batch.grownEvalSet, seedTools)
+    val after = evaluator.evaluate(batch.grownEvalSet, calibratedTools)
+    println("  accuracy on grown eval set: ${before.matrix.correct}/${before.matrix.total} -> " +
+      "${after.matrix.correct}/${after.matrix.total}  (auto-drafted from a rejected turn)")
+  } finally {
+    server.stop()
+  }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/Stage5Demo.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/Stage5Demo.kt
@@ -1,0 +1,55 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness
+
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import com.salesforce.revoman.harness.reasoning.ConfidencePolicy
+import com.salesforce.revoman.harness.reasoning.ReasoningLayer
+import com.salesforce.revoman.harness.reasoning.ReasoningOutcome
+import com.salesforce.revoman.harness.telemetry.GenAiTracer
+
+/**
+ * Stage 5 runnable demo: the complete reasoning layer with all six scaffolds, deterministic (no
+ * key). Shows the four outcomes — proceed (read), confirm-then-execute (write), ask (ambiguous),
+ * no-match — each traced with OTel GenAI-convention spans printed to console.
+ */
+fun main() {
+  val tools = GraphRegistry.loadToolDefs()
+  val server = MockCpqServer()
+  val baseUrl = "http://127.0.0.1:${server.start()}"
+  // A high 'configure' threshold forces the ambiguous case to ask.
+  val policy = ConfidencePolicy(perGraphThreshold = mapOf("configure" to 0.99))
+  val layer = ReasoningLayer(tools, policy = policy, tracer = GenAiTracer())
+
+  try {
+    listOf(
+      "price configuration cfg-1", // confident read -> Proceed
+      "create a draft quote for prc-2", // confident write -> ConfirmRequired -> confirm
+      "configure or price this", // ambiguous -> Clarify (ask, don't guess)
+      "what is the weather", // no match
+    )
+      .forEach { intent ->
+        println("\n>>> $intent")
+        when (val outcome = layer.handle(intent)) {
+          is ReasoningOutcome.Proceed -> println("  PROCEED: ${outcome.graph} slots=${outcome.slots}")
+          is ReasoningOutcome.ConfirmRequired -> {
+            println("  CONFIRM REQUIRED (write): ${outcome.preview}")
+            // Seed the database with the required price for the quote graph to succeed
+            if (intent.contains("prc-2")) server.db["price:prc-2"] = 100.0
+            val rundowns = layer.confirm(outcome.preview, baseUrl)
+            println("  confirmed -> executed ${rundowns.size} graph(s); DB=${server.db}")
+          }
+          is ReasoningOutcome.Clarify -> println("  ASK: ${outcome.question} candidates=${outcome.candidates}")
+          is ReasoningOutcome.NoMatch -> println("  NO MATCH")
+        }
+      }
+  } finally {
+    server.stop()
+  }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/Stage5Demo.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/Stage5Demo.kt
@@ -16,33 +16,34 @@ import com.salesforce.revoman.harness.telemetry.GenAiTracer
 
 /**
  * Stage 5 runnable demo: the complete reasoning layer with all six scaffolds, deterministic (no
- * key). Shows the four outcomes — proceed (read), confirm-then-execute (write), ask (ambiguous),
- * no-match — each traced with OTel GenAI-convention spans printed to console.
+ * key). Shows the five outcomes — proceed (read), confirm-then-execute (write), ask (slot-missing),
+ * ask (low-margin), no-match — each traced with OTel GenAI-convention spans printed to console.
  */
 fun main() {
   val tools = GraphRegistry.loadToolDefs()
+  val stripped = tools.map { it.copy(whenNotToUse = emptyList()) }
   val server = MockCpqServer()
   val baseUrl = "http://127.0.0.1:${server.start()}"
-  // A high 'configure' threshold forces the ambiguous case to ask.
-  val policy = ConfidencePolicy(perGraphThreshold = mapOf("configure" to 0.99))
-  val layer = ReasoningLayer(tools, policy = policy, tracer = GenAiTracer())
+  // Seed the database with the required price for the quote graph to succeed
+  server.db["price:prc-2"] = 100.0
+  val layer = ReasoningLayer(tools, tracer = GenAiTracer())
+  val strippedLayer = ReasoningLayer(stripped, tracer = GenAiTracer())
 
   try {
     listOf(
-      "price configuration cfg-1", // confident read -> Proceed
-      "create a draft quote for prc-2", // confident write -> ConfirmRequired -> confirm
-      "configure or price this", // ambiguous -> Clarify (ask, don't guess)
-      "what is the weather", // no match
+      Triple("price configuration cfg-1", layer, false), // confident read -> Proceed
+      Triple("create a draft quote for prc-2", layer, false), // confident write -> ConfirmRequired -> confirm
+      Triple("configure or price this", layer, false), // slot-missing -> Clarify (ask, don't guess)
+      Triple("price configuration or draft quote", strippedLayer, false), // low-margin -> Clarify (ambiguous between two graphs)
+      Triple("what is the weather", layer, false), // no match
     )
-      .forEach { intent ->
+      .forEach { (intent, reasoningLayer, _) ->
         println("\n>>> $intent")
-        when (val outcome = layer.handle(intent)) {
+        when (val outcome = reasoningLayer.handle(intent)) {
           is ReasoningOutcome.Proceed -> println("  PROCEED: ${outcome.graph} slots=${outcome.slots}")
           is ReasoningOutcome.ConfirmRequired -> {
             println("  CONFIRM REQUIRED (write): ${outcome.preview}")
-            // Seed the database with the required price for the quote graph to succeed
-            if (intent.contains("prc-2")) server.db["price:prc-2"] = 100.0
-            val rundowns = layer.confirm(outcome.preview, baseUrl)
+            val rundowns = reasoningLayer.confirm(outcome.preview, baseUrl)
             println("  confirmed -> executed ${rundowns.size} graph(s); DB=${server.db}")
           }
           is ReasoningOutcome.Clarify -> println("  ASK: ${outcome.question} candidates=${outcome.candidates}")

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/contract/ContractAblationEval.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/contract/ContractAblationEval.kt
@@ -1,0 +1,41 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.contract
+
+import com.salesforce.revoman.harness.eval.EvalCase
+import com.salesforce.revoman.harness.eval.RouterEvaluator
+import com.salesforce.revoman.harness.llm.ScoringLlmClient
+import com.salesforce.revoman.harness.tooldef.ToolDef
+
+/** Graph-selection accuracy for one contract variant on a fixed eval set. */
+data class AblationResult(val variantName: String, val accuracyCorrect: Int, val accuracyTotal: Int) {
+  val accuracy: Double
+    get() = if (accuracyTotal == 0) 0.0 else accuracyCorrect.toDouble() / accuracyTotal
+}
+
+/**
+ * The blue-box efficacy eval: hold the reasoning fixed, vary the CONTRACT content, and measure the
+ * accuracy delta on the same labeled eval set — reusing the Stage-3 confusion matrix as the
+ * instrument. This grades the contract by how well it makes the reasoning work, and is the
+ * generalization of the manual calibration loop: any difference between two `ToolDef` variants
+ * (richer descriptions, added examples, disambiguating clauses) is measured, not guessed.
+ */
+class ContractAblationEval(
+  private val evaluator: RouterEvaluator = RouterEvaluator(ScoringLlmClient())
+) {
+  fun compare(
+    cases: List<EvalCase>,
+    variantA: Pair<String, List<ToolDef>>,
+    variantB: Pair<String, List<ToolDef>>,
+  ): Pair<AblationResult, AblationResult> = result(cases, variantA) to result(cases, variantB)
+
+  private fun result(cases: List<EvalCase>, variant: Pair<String, List<ToolDef>>): AblationResult {
+    val report = evaluator.evaluate(cases, variant.second)
+    return AblationResult(variant.first, report.matrix.correct, report.matrix.total)
+  }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/contract/ContractFidelityCheck.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/contract/ContractFidelityCheck.kt
@@ -1,0 +1,38 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.contract
+
+import com.salesforce.revoman.harness.tooldef.GraphSpec
+
+/** Whether a contract's runtime data-flow matches what its metadata declared, and how it drifted. */
+data class FidelityReport(
+  val graph: String,
+  val missingProduced: Set<String>,
+  val unexpectedProduced: Set<String>,
+) {
+  val faithful: Boolean
+    get() = missingProduced.isEmpty() && unexpectedProduced.isEmpty()
+}
+
+/**
+ * The blue-box Layer-1 eval: deterministic, no LLM. Compares what the graph's metadata DECLARES it
+ * produces ([GraphSpec.outputKeys]) against what the run ACTUALLY produced (the contract's data-flow
+ * producers). Any mismatch is API drift — the production contract changing under the graph — caught
+ * in CI before an agent ever reasons over a stale descriptor.
+ */
+class ContractFidelityCheck {
+  fun check(contract: GraphContract, spec: GraphSpec): FidelityReport {
+    val declared = spec.outputKeys.toSet()
+    val actual = contract.dataFlow.filter { it.producedByStep != null }.map { it.key }.toSet()
+    return FidelityReport(
+      graph = spec.name,
+      missingProduced = declared - actual,
+      unexpectedProduced = actual - declared,
+    )
+  }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/contract/DataFlowEdge.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/contract/DataFlowEdge.kt
@@ -1,0 +1,20 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.contract
+
+/**
+ * The provenance of one environment variable within a graph run: which step WROTE it
+ * (`pm.environment.set`), and which steps READ it (`{{key}}`). This is the data-lineage ReVoman
+ * captures in [com.salesforce.revoman.output.report.StepEnvVars] but never surfaces — the piece
+ * that lets the contract explain "where did this value come from".
+ */
+data class DataFlowEdge(
+  val key: String,
+  val producedByStep: String?,
+  val consumedBySteps: List<String>,
+)

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/contract/GraphContract.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/contract/GraphContract.kt
@@ -1,0 +1,53 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.contract
+
+import com.salesforce.revoman.harness.tooldef.ToolDef
+import com.salesforce.revoman.output.Rundown
+
+/**
+ * The blue-box unified contract: the single deterministic artifact that feeds the LLM, fusing the
+ * two halves that otherwise live apart —
+ *  - the pre-execution METADATA descriptor ([descriptor], a [ToolDef]: when_to_use / when_not_to_use
+ *    / example_queries / input_examples + typed slots), and
+ *  - the post-execution RUNTIME information ([outcome], a ReVoman [Rundown]: steps, stopReason,
+ *    per-step request/response, env) —
+ * plus [invocationSlots] (what the graph was actually called with) and [dataFlow] (provenance: which
+ * `{{var}}` came from which step). A [contractVersion] stamps the schema so consumers detect drift.
+ *
+ * Deterministic and testable like ordinary software — the ReVoman-owned half of the system. The
+ * probabilistic reasoning that CONSUMES this contract (router / confidence gate) is a separate layer.
+ */
+data class GraphContract(
+  val descriptor: ToolDef,
+  val invocationSlots: Map<String, String>,
+  val outcome: Rundown,
+  val contractVersion: String = CONTRACT_VERSION,
+) {
+  val succeeded: Boolean
+    get() = outcome.areAllStepsSuccessful
+
+  /** Per-env-key provenance derived from each step's produced/consumed sets. */
+  val dataFlow: List<DataFlowEdge> by lazy {
+    val keys =
+      outcome.stepReports.flatMap { it.envVars.produced + it.envVars.consumed }.toSortedSet()
+    keys.map { key ->
+      val producer = outcome.stepReports.firstOrNull { key in it.envVars.produced }?.step?.name
+      val consumers =
+        outcome.stepReports.filter { key in it.envVars.consumed }.map { it.step.name }.distinct()
+      DataFlowEdge(key, producer, consumers)
+    }
+  }
+
+  companion object {
+    const val CONTRACT_VERSION: String = "1.0"
+
+    fun of(descriptor: ToolDef, invocationSlots: Map<String, String>, outcome: Rundown): GraphContract =
+      GraphContract(descriptor, invocationSlots, outcome)
+  }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/contract/GraphContractWriter.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/contract/GraphContractWriter.kt
@@ -50,7 +50,23 @@ private fun GraphContract.dataFlowJson(): String =
       "\"consumedBySteps\":${strList(edge.consumedBySteps)}}"
   }
 
-private fun str(s: String): String = "\"" + s.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+private fun str(s: String): String {
+  val sb = StringBuilder("\"")
+  for (c in s) {
+    when (c) {
+      '\\' -> sb.append("\\\\")
+      '"' -> sb.append("\\\"")
+      '\n' -> sb.append("\\n")
+      '\r' -> sb.append("\\r")
+      '\t' -> sb.append("\\t")
+      '\b' -> sb.append("\\b")
+      '' -> sb.append("\\f")
+      else -> if (c < ' ') sb.append("\\u%04x".format(c.code)) else sb.append(c)
+    }
+  }
+  sb.append("\"")
+  return sb.toString()
+}
 
 private fun strList(xs: List<String>): String = xs.joinToString(",", "[", "]") { str(it) }
 

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/contract/GraphContractWriter.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/contract/GraphContractWriter.kt
@@ -1,0 +1,61 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.contract
+
+import com.salesforce.revoman.output.Verbosity
+import com.salesforce.revoman.output.toJson
+
+/**
+ * Renders a [GraphContract] to JSON at matched [Verbosity] tiers — the single serializer that emits
+ * BOTH halves of the unified contract (metadata descriptor + runtime outcome) plus the data-lineage
+ * and version envelope. SUMMARY is a health check; STANDARD adds the descriptions and the dataFlow
+ * provenance; VERBOSE embeds the full nested ReVoman [com.salesforce.revoman.output.Rundown] JSON.
+ */
+fun GraphContract.toJson(verbosity: Verbosity = Verbosity.STANDARD): String {
+  val sb = StringBuilder()
+  sb.append("{")
+  sb.append("\"contractVersion\":").append(str(contractVersion))
+  sb.append(",\"graph\":").append(str(descriptor.graphName))
+  sb.append(",\"succeeded\":").append(succeeded)
+  sb.append(",\"invocationSlots\":").append(strMap(invocationSlots))
+  // SUMMARY-and-up: runtime stats.
+  sb.append(",\"stopReason\":").append(str(outcome.stopReason.toString()))
+  sb.append(",\"executedStepCount\":").append(outcome.executedStepCount)
+  sb.append(",\"unsuccessfulStepCount\":").append(outcome.unsuccessfulStepCount)
+
+  if (verbosity == Verbosity.STANDARD || verbosity == Verbosity.VERBOSE) {
+    sb.append(",\"whenToUse\":").append(str(descriptor.whenToUse))
+    sb.append(",\"whenNotToUse\":").append(strList(descriptor.whenNotToUse))
+    sb.append(",\"dataFlow\":").append(dataFlowJson())
+  }
+  if (verbosity == Verbosity.VERBOSE) {
+    sb.append(",\"exampleQueries\":").append(strList(descriptor.exampleQueries))
+    sb.append(",\"inputExamples\":").append(strMapList(descriptor.inputExamples))
+    // Embed the full ReVoman runtime JSON as a nested object (already valid JSON).
+    sb.append(",\"rundown\":").append(outcome.toJson(Verbosity.VERBOSE))
+  }
+  sb.append("}")
+  return sb.toString()
+}
+
+private fun GraphContract.dataFlowJson(): String =
+  dataFlow.joinToString(",", "[", "]") { edge ->
+    "{\"key\":${str(edge.key)}," +
+      "\"producedByStep\":${edge.producedByStep?.let { str(it) } ?: "null"}," +
+      "\"consumedBySteps\":${strList(edge.consumedBySteps)}}"
+  }
+
+private fun str(s: String): String = "\"" + s.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+
+private fun strList(xs: List<String>): String = xs.joinToString(",", "[", "]") { str(it) }
+
+private fun strMap(m: Map<String, String>): String =
+  m.entries.joinToString(",", "{", "}") { "${str(it.key)}:${str(it.value)}" }
+
+private fun strMapList(ms: List<Map<String, String>>): String =
+  ms.joinToString(",", "[", "]") { strMap(it) }

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/BfclCheck.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/BfclCheck.kt
@@ -1,0 +1,74 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.eval
+
+import com.salesforce.revoman.harness.llm.LlmClient
+import com.salesforce.revoman.harness.orchestrator.FillResult
+import com.salesforce.revoman.harness.orchestrator.Router
+import com.salesforce.revoman.harness.orchestrator.SlotFiller
+import com.salesforce.revoman.harness.tooldef.ToolDef
+import org.yaml.snakeyaml.Yaml
+
+/** BFCL-style gold: the exact graph + slot values an utterance should produce. */
+data class SlotFillGold(val utterance: String, val graph: String, val slots: Map<String, String>)
+
+/** Loads the BFCL gold set from a classpath YAML resource. */
+object SlotFillGoldSet {
+  fun load(resource: String = "evals/slotfill-gold.yaml"): List<SlotFillGold> {
+    val text =
+      javaClass.classLoader.getResourceAsStream(resource)?.bufferedReader()?.readText()
+        ?: error("Slot-fill gold not found on classpath: $resource")
+    @Suppress("UNCHECKED_CAST") val root = Yaml().load<Map<String, Any?>>(text)
+    @Suppress("UNCHECKED_CAST") val cases = (root["cases"] as? List<Map<String, Any?>>).orEmpty()
+    return cases.map { c ->
+      @Suppress("UNCHECKED_CAST") val slots = (c["slots"] as? Map<String, Any?>).orEmpty()
+      SlotFillGold(
+        c["utterance"].toString(),
+        c["graph"].toString(),
+        slots.mapValues { it.value.toString() },
+      )
+    }
+  }
+}
+
+/** The outcome of one BFCL comparison: predicted call vs gold, by value equality. */
+data class BfclResult(
+  val gold: SlotFillGold,
+  val predictedGraph: String?,
+  val predictedSlots: Map<String, String>,
+  val graphMatch: Boolean,
+  val slotsMatch: Boolean,
+) {
+  val pass: Boolean
+    get() = graphMatch && slotsMatch
+}
+
+/**
+ * BFCL-style check: run the router + slot-filler over an utterance and AST-compare the predicted
+ * call (graph name + filled slots) against gold by value equality. Rejected (invalid) slot-fills
+ * predict no slots — a clean fail, never a silent partial pass.
+ */
+class BfclCheck(private val llm: LlmClient, private val tools: List<ToolDef>) {
+  private val router = Router(llm, tools)
+  private val slotFiller = SlotFiller(llm)
+
+  fun check(gold: SlotFillGold): BfclResult {
+    val predictedGraph = router.route(gold.utterance).graphName
+    val tool = tools.firstOrNull { it.graphName == predictedGraph }
+    val predictedSlots =
+      if (tool == null) emptyMap()
+      else
+        when (val fill = slotFiller.fill(gold.utterance, tool)) {
+          is FillResult.Valid -> fill.slots
+          is FillResult.Invalid -> emptyMap()
+        }
+    val graphMatch = predictedGraph == gold.graph
+    val slotsMatch = predictedSlots == gold.slots
+    return BfclResult(gold, predictedGraph, predictedSlots, graphMatch, slotsMatch)
+  }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/ConfusionMatrix.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/ConfusionMatrix.kt
@@ -1,0 +1,58 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.eval
+
+/**
+ * A graph-selection confusion matrix: `counts[expected][predicted]` tallies how often the router
+ * predicted each graph for each gold label. The diagonal is correct; every off-diagonal cell is a
+ * confusion that Stage 3's calibration loop turns into a `when_not_to_use` clause.
+ */
+data class ConfusionMatrix(
+  val rowLabels: List<String>,
+  val colLabels: List<String>,
+  val counts: Map<String, Map<String, Int>>,
+) {
+  val total: Int
+    get() = counts.values.sumOf { row -> row.values.sum() }
+
+  val correct: Int
+    get() = rowLabels.sumOf { label -> counts[label]?.get(label) ?: 0 }
+
+  val accuracy: Double
+    get() = if (total == 0) 0.0 else correct.toDouble() / total
+
+  /** Renders an aligned text grid: rows are gold labels, columns are predictions. */
+  fun render(): String {
+    val width = (colLabels + rowLabels).maxOf { it.length } + 2
+    val header = "gold\\pred".padEnd(width) + colLabels.joinToString("") { it.padStart(width) }
+    val rows =
+      rowLabels.joinToString("\n") { row ->
+        row.padEnd(width) +
+          colLabels.joinToString("") { col -> (counts[row]?.get(col) ?: 0).toString().padStart(width) }
+      }
+    return "$header\n$rows\naccuracy: $correct/$total"
+  }
+}
+
+/** Builds a [ConfusionMatrix] from `(expected, predicted)` pairs; a null prediction becomes "none". */
+object ConfusionMatrices {
+  private const val NONE = "none"
+
+  fun from(pairs: List<Pair<String, String?>>): ConfusionMatrix {
+    val rowLabels = pairs.map { it.first }.distinct().sorted()
+    val predicted = pairs.map { it.second ?: NONE }.distinct()
+    val colLabels = (rowLabels + predicted).distinct()
+    val counts =
+      rowLabels.associateWith { row ->
+        colLabels.associateWith { col ->
+          pairs.count { it.first == row && (it.second ?: NONE) == col }
+        }
+      }
+    return ConfusionMatrix(rowLabels, colLabels, counts)
+  }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/EvalCase.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/EvalCase.kt
@@ -1,0 +1,11 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.eval
+
+/** One labeled router eval: a user utterance and the graph it should route to. */
+data class EvalCase(val utterance: String, val expected: String)

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/EvalSet.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/EvalSet.kt
@@ -1,0 +1,23 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.eval
+
+import org.yaml.snakeyaml.Yaml
+
+/** Loads the labeled router eval set from a classpath YAML resource. */
+object EvalSet {
+  fun load(resource: String = "evals/router-eval.yaml"): List<EvalCase> {
+    val text =
+      javaClass.classLoader.getResourceAsStream(resource)?.bufferedReader()?.readText()
+        ?: error("Eval set not found on classpath: $resource")
+    @Suppress("UNCHECKED_CAST") val root = Yaml().load<Map<String, Any?>>(text)
+    @Suppress("UNCHECKED_CAST")
+    val cases = (root["cases"] as? List<Map<String, Any?>>).orEmpty()
+    return cases.map { EvalCase(it["utterance"].toString(), it["expected"].toString()) }
+  }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/LlmJudge.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/LlmJudge.kt
@@ -25,8 +25,8 @@ interface LlmJudge {
 class StubJudge : LlmJudge {
   override fun judge(utterance: String, responseContext: String): Judgment {
     val clean =
-      responseContext.contains("\"unsuccessfulStepCount\":0") &&
-        responseContext.contains("\"succeeded\":true")
+      responseContext.contains("\"unsuccessfulStepCount\": 0") &&
+        responseContext.contains("\"areAllStepsSuccessful\": true")
     return if (clean) Judgment(true, "context reports all steps successful")
     else Judgment(false, "context does not report a clean, successful run")
   }

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/LlmJudge.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/LlmJudge.kt
@@ -25,8 +25,8 @@ interface LlmJudge {
 class StubJudge : LlmJudge {
   override fun judge(utterance: String, responseContext: String): Judgment {
     val clean =
-      responseContext.contains("\"unsuccessfulStepCount\": 0") &&
-        responseContext.contains("\"areAllStepsSuccessful\": true")
+      responseContext.contains("\"unsuccessfulStepCount\":0") &&
+        responseContext.contains("\"succeeded\":true")
     return if (clean) Judgment(true, "context reports all steps successful")
     else Judgment(false, "context does not report a clean, successful run")
   }

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/LlmJudge.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/LlmJudge.kt
@@ -1,0 +1,42 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.eval
+
+import com.salesforce.revoman.output.Rundown
+
+/** A judge's verdict on a fuzzy metric — advisory, used only to screen. */
+data class Judgment(val pass: Boolean, val reason: String)
+
+/**
+ * LLM-as-judge for fuzzy metrics (response helpfulness / trajectory quality). Bounded on purpose:
+ * it only SCREENS. The gate is always the deterministic [GroundTruth]. A real implementation would
+ * call Claude here; the [StubJudge] is the deterministic stand-in for CI.
+ */
+interface LlmJudge {
+  fun judge(utterance: String, responseContext: String): Judgment
+}
+
+/** Deterministic screening judge: "helpful" iff the response context reports a clean run. */
+class StubJudge : LlmJudge {
+  override fun judge(utterance: String, responseContext: String): Judgment {
+    val clean =
+      responseContext.contains("\"unsuccessfulStepCount\": 0") &&
+        responseContext.contains("\"areAllStepsSuccessful\": true")
+    return if (clean) Judgment(true, "context reports all steps successful")
+    else Judgment(false, "context does not report a clean, successful run")
+  }
+}
+
+/**
+ * The deterministic ground-truth gate that never drifts. Prefer this over the judge wherever a
+ * deterministic check exists; the judge only covers what this cannot.
+ */
+object GroundTruth {
+  fun allStepsSucceeded(rundowns: List<Rundown>): Boolean =
+    rundowns.isNotEmpty() && rundowns.all { it.areAllStepsSuccessful }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/RouterEvaluator.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/RouterEvaluator.kt
@@ -1,0 +1,40 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.eval
+
+import com.salesforce.revoman.harness.llm.LlmClient
+import com.salesforce.revoman.harness.orchestrator.Router
+import com.salesforce.revoman.harness.tooldef.ToolDef
+
+/** A single graph-selection mismatch from an eval run. */
+data class Miss(val utterance: String, val expected: String, val predicted: String?)
+
+/** The outcome of running the router over an eval set: the confusion matrix plus its misses. */
+data class EvalReport(val matrix: ConfusionMatrix, val misses: List<Miss>) {
+  val accuracy: Double
+    get() = matrix.accuracy
+}
+
+/**
+ * Runs the router over a labeled eval set and produces a confusion matrix + the list of misses.
+ * This is the design's Layer-2 graph-selection eval: run against gold, read the matrix, and turn
+ * each off-diagonal cell into a `when_not_to_use` clause. Re-running with the calibrated tool defs
+ * moves the number — the calibration loop, made measurable.
+ */
+class RouterEvaluator(private val llm: LlmClient) {
+  fun evaluate(cases: List<EvalCase>, tools: List<ToolDef>): EvalReport {
+    val router = Router(llm, tools)
+    val results = cases.map { it to router.route(it.utterance).graphName }
+    val matrix = ConfusionMatrices.from(results.map { (case, predicted) -> case.expected to predicted })
+    val misses =
+      results
+        .filter { (case, predicted) -> case.expected != predicted }
+        .map { (case, predicted) -> Miss(case.utterance, case.expected, predicted) }
+    return EvalReport(matrix, misses)
+  }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/TauBenchCheck.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/TauBenchCheck.kt
@@ -1,0 +1,32 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.eval
+
+import com.salesforce.revoman.harness.llm.LlmClient
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.orchestrator.Orchestrator
+import com.salesforce.revoman.harness.tooldef.ToolDef
+
+/** A task-success case: an utterance and the final DB values it should produce. */
+data class TaskCase(val utterance: String, val expectedDbValues: List<String>)
+
+/**
+ * tau-bench-style check: grade the final database STATE, not the chat transcript. Orchestrates the
+ * utterance end to end and asserts the mock CPQ DB's values contain every expected value.
+ */
+class TauBenchCheck(
+  private val baseUrl: String,
+  private val tools: List<ToolDef>,
+  private val llm: LlmClient,
+) {
+  fun check(server: MockCpqServer, case: TaskCase): Boolean {
+    Orchestrator(baseUrl, tools, llm).orchestrate(case.utterance)
+    val actual = server.db.values.map { it.toString() }
+    return case.expectedDbValues.all { expected -> actual.contains(expected) }
+  }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/feedback/ConfirmGate.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/feedback/ConfirmGate.kt
@@ -1,0 +1,47 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.feedback
+
+/** The write the agent proposes at the human confirm gate. */
+data class Proposal(val utterance: String, val graph: String, val slots: Map<String, String>)
+
+/** What the human does at the gate. */
+sealed interface Decision {
+  /** Approve the proposal as-is. */
+  object Confirm : Decision
+
+  /** Approve after fixing the slots. */
+  data class Edit(val correctedSlots: Map<String, String>) : Decision
+
+  /** Reject; optionally state the graph that should have been chosen. */
+  data class Reject(val correctGraph: String? = null) : Decision
+}
+
+/** The training signal the gate emits — the design's "free labeling machine". */
+sealed interface FeedbackLabel {
+  data class Positive(val proposal: Proposal) : FeedbackLabel
+
+  data class CorrectionPair(val proposal: Proposal, val correctedSlots: Map<String, String>) :
+    FeedbackLabel
+
+  data class Negative(val proposal: Proposal, val correctGraph: String?) : FeedbackLabel
+}
+
+/**
+ * The human-in-the-loop confirm gate on every write. Because a human confirms every mutation, the
+ * gate is the highest-value labeling signal available at no extra cost: confirm → positive, edit →
+ * a correction pair (proposed vs fixed), reject → a negative (mined for `when_not_to_use`).
+ */
+object ConfirmGate {
+  fun apply(proposal: Proposal, decision: Decision): FeedbackLabel =
+    when (decision) {
+      is Decision.Confirm -> FeedbackLabel.Positive(proposal)
+      is Decision.Edit -> FeedbackLabel.CorrectionPair(proposal, decision.correctedSlots)
+      is Decision.Reject -> FeedbackLabel.Negative(proposal, decision.correctGraph)
+    }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/feedback/NightlyBatch.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/feedback/NightlyBatch.kt
@@ -1,0 +1,57 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.feedback
+
+import com.salesforce.revoman.harness.eval.EvalCase
+
+/** What a nightly batch produces: the grown eval set and clauses drafted per wrongly-chosen graph. */
+data class BatchOutput(
+  val grownEvalSet: List<EvalCase>,
+  val draftedClauses: Map<String, List<String>>,
+)
+
+/**
+ * The nightly feedback batch: turns the confirm-gate labels into a bigger eval set and drafted
+ * `when_not_to_use` clauses — the flywheel that makes the CI gate tighten itself over time.
+ * Confirmed turns become positive golden cases; rejects with a known-right graph become both a
+ * regression case (so that exact miss never returns) and a drafted clause on the graph that was
+ * wrongly chosen. Slot corrections are slot-fill training data and do not affect router selection.
+ */
+object NightlyBatch {
+  fun run(seedEvalSet: List<EvalCase>, labels: List<FeedbackLabel>): BatchOutput {
+    val seenUtterances = seedEvalSet.map { it.utterance }.toMutableSet()
+    val grown = seedEvalSet.toMutableList()
+    val clauses = mutableMapOf<String, MutableList<String>>()
+
+    labels.forEach { label ->
+      when (label) {
+        is FeedbackLabel.Positive ->
+          addCase(grown, seenUtterances, label.proposal.utterance, label.proposal.graph)
+        is FeedbackLabel.Negative -> {
+          val correct = label.correctGraph ?: return@forEach
+          addCase(grown, seenUtterances, label.proposal.utterance, correct)
+          val clause =
+            "Do not use for requests like \"${label.proposal.utterance}\" — " +
+              "that is the $correct graph."
+          clauses.getOrPut(label.proposal.graph) { mutableListOf() }.add(clause)
+        }
+        is FeedbackLabel.CorrectionPair -> Unit // slot-fill signal; not a router-selection change
+      }
+    }
+    return BatchOutput(grown.toList(), clauses.mapValues { it.value.toList() })
+  }
+
+  private fun addCase(
+    into: MutableList<EvalCase>,
+    seen: MutableSet<String>,
+    utterance: String,
+    graph: String,
+  ) {
+    if (seen.add(utterance)) into.add(EvalCase(utterance, graph))
+  }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/llm/LlmClient.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/llm/LlmClient.kt
@@ -1,0 +1,25 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.llm
+
+import com.salesforce.revoman.harness.tooldef.ToolDef
+
+/** The router's output: the chosen graph (or null when nothing matched) and a short rationale. */
+data class RouteDecision(val graphName: String?, val rationale: String)
+
+/**
+ * The only probabilistic surface in the harness. Two jobs, exactly as the design specifies: pick a
+ * graph, and fill that graph's input slots. Synchronous by contract so the deterministic stub and
+ * the whole orchestrator core stay coroutine-free; the real Claude implementation lives in a
+ * separate source set and bridges its suspend calls internally.
+ */
+interface LlmClient {
+  fun route(utterance: String, tools: List<ToolDef>): RouteDecision
+
+  fun fillSlots(utterance: String, tool: ToolDef): Map<String, String>
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/llm/LlmClient.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/llm/LlmClient.kt
@@ -9,8 +9,19 @@ package com.salesforce.revoman.harness.llm
 
 import com.salesforce.revoman.harness.tooldef.ToolDef
 
-/** The router's output: the chosen graph (or null when nothing matched) and a short rationale. */
-data class RouteDecision(val graphName: String?, val rationale: String)
+/**
+ * The router's output: the chosen graph (or null when nothing matched), a short rationale, and the
+ * router's confidence signals. [confidence] is the normalized top score in [0,1]; [margin] is the
+ * normalized gap to the second-best graph in [0,1]. The disambiguation gate reads [margin] to
+ * decide whether to ask instead of guess. Both default so callers that don't produce them (the
+ * keyword stub, the Claude client) are unaffected.
+ */
+data class RouteDecision(
+  val graphName: String?,
+  val rationale: String,
+  val confidence: Double = 0.0,
+  val margin: Double = 0.0,
+)
 
 /**
  * The only probabilistic surface in the harness. Two jobs, exactly as the design specifies: pick a

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/llm/ScoringLlmClient.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/llm/ScoringLlmClient.kt
@@ -26,13 +26,23 @@ class ScoringLlmClient(private val slotDelegate: LlmClient = StubLlmClient()) : 
   private val penaltyPerClause = 5
 
   override fun route(utterance: String, tools: List<ToolDef>): RouteDecision {
-    val tokens = tokenize(utterance)
-    val best = tools.map { it to score(tokens, it) }.maxByOrNull { it.second }
-    return if (best == null || best.second <= 0) {
-      RouteDecision(null, "no graph scored above zero for: $utterance")
-    } else {
-      RouteDecision(best.first.graphName, "score=${best.second} for '${best.first.graphName}'")
+    val scored = scores(utterance, tools)
+    val ranked = scored.entries.sortedByDescending { it.value }
+    val top = ranked.firstOrNull()
+    if (top == null || top.value <= 0) {
+      return RouteDecision(null, "no graph scored above zero for: $utterance", 0.0, 0.0)
     }
+    val positiveSum = ranked.sumOf { maxOf(it.value, 0) }
+    val second = ranked.getOrNull(1)?.value?.coerceAtLeast(0) ?: 0
+    val confidence = if (positiveSum > 0) top.value.toDouble() / positiveSum else 0.0
+    val margin = (top.value - second).toDouble() / top.value
+    return RouteDecision(top.key, "score=${top.value} for '${top.key}'", confidence, margin)
+  }
+
+  /** The raw per-graph score for each tool — the basis for confidence, margin, and the gate. */
+  fun scores(utterance: String, tools: List<ToolDef>): Map<String, Int> {
+    val tokens = tokenize(utterance)
+    return tools.associate { it.graphName to score(tokens, it) }
   }
 
   override fun fillSlots(utterance: String, tool: ToolDef): Map<String, String> =

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/llm/ScoringLlmClient.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/llm/ScoringLlmClient.kt
@@ -43,10 +43,11 @@ class ScoringLlmClient(private val slotDelegate: LlmClient = StubLlmClient()) : 
       (tool.graphName + " " + tool.whenToUse + " " + tool.exampleQueries.joinToString(" "))
         .lowercase()
     val positive = tokens.count { token -> haystack.contains(token) }
+    val utteranceTokens = tokens.toSet()
     val penalty =
       tool.whenNotToUse.count { clause ->
         val triggers = tokenize(clause).filter { it.length >= 4 }
-        triggers.any { trigger -> tokens.any { it.contains(trigger) } }
+        triggers.any { trigger -> trigger in utteranceTokens }
       } * penaltyPerClause
     return positive - penalty
   }

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/llm/ScoringLlmClient.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/llm/ScoringLlmClient.kt
@@ -47,7 +47,8 @@ class ScoringLlmClient(private val slotDelegate: LlmClient = StubLlmClient()) : 
     val penalty =
       tool.whenNotToUse.count { clause ->
         val triggers = tokenize(clause).filter { it.length >= 4 }
-        triggers.any { trigger -> trigger in utteranceTokens }
+        val matchCount = triggers.count { trigger -> trigger in utteranceTokens }
+        matchCount >= 2  // Require at least 2 matching triggers to apply the penalty
       } * penaltyPerClause
     return positive - penalty
   }

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/llm/ScoringLlmClient.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/llm/ScoringLlmClient.kt
@@ -1,0 +1,56 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.llm
+
+import com.salesforce.revoman.harness.tooldef.ToolDef
+
+/**
+ * A deterministic, calibration-aware router. Scores each tool by keyword overlap between the
+ * utterance and the tool's `when_to_use` + `example_queries`, then subtracts a penalty for every
+ * `when_not_to_use` clause whose trigger words appear in the utterance. Unlike [StubLlmClient]'s
+ * fixed keyword map, this client's routing genuinely CHANGES when a `when_not_to_use` clause is
+ * added — which is what makes Stage 3's confusion-matrix calibration loop a real experiment, not a
+ * staged one. Slot-filling is delegated (calibration is about selection, not extraction).
+ */
+class ScoringLlmClient(private val slotDelegate: LlmClient = StubLlmClient()) : LlmClient {
+  private val stopwords =
+    setOf(
+      "the", "for", "this", "that", "with", "into", "from", "and", "you", "your", "does", "what",
+      "are", "our", "its", "new", "saved",
+    )
+  private val penaltyPerClause = 5
+
+  override fun route(utterance: String, tools: List<ToolDef>): RouteDecision {
+    val tokens = tokenize(utterance)
+    val best = tools.map { it to score(tokens, it) }.maxByOrNull { it.second }
+    return if (best == null || best.second <= 0) {
+      RouteDecision(null, "no graph scored above zero for: $utterance")
+    } else {
+      RouteDecision(best.first.graphName, "score=${best.second} for '${best.first.graphName}'")
+    }
+  }
+
+  override fun fillSlots(utterance: String, tool: ToolDef): Map<String, String> =
+    slotDelegate.fillSlots(utterance, tool)
+
+  private fun score(tokens: List<String>, tool: ToolDef): Int {
+    val haystack =
+      (tool.graphName + " " + tool.whenToUse + " " + tool.exampleQueries.joinToString(" "))
+        .lowercase()
+    val positive = tokens.count { token -> haystack.contains(token) }
+    val penalty =
+      tool.whenNotToUse.count { clause ->
+        val triggers = tokenize(clause).filter { it.length >= 4 }
+        triggers.any { trigger -> tokens.any { it.contains(trigger) } }
+      } * penaltyPerClause
+    return positive - penalty
+  }
+
+  private fun tokenize(text: String): List<String> =
+    text.lowercase().split(Regex("[^a-z0-9]+")).filter { it.length >= 3 && it !in stopwords }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/llm/StubLlmClient.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/llm/StubLlmClient.kt
@@ -1,0 +1,53 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.llm
+
+import com.salesforce.revoman.harness.tooldef.SlotType
+import com.salesforce.revoman.harness.tooldef.ToolDef
+
+/**
+ * A deterministic, network-free [LlmClient] for tests, CI, and the no-key demo. Routing is keyword
+ * matching; slot-filling is regex extraction. It stands in for a real model everywhere the key is
+ * absent, so the entire orchestrator is exercisable without an LLM.
+ */
+class StubLlmClient : LlmClient {
+  private val routingKeywords: Map<String, List<String>> =
+    mapOf(
+      "configure" to listOf("configure", "product", "set up", "add "),
+      "price" to listOf("price", "cost", "total", "how much"),
+      "quote" to listOf("quote", "draft"),
+    )
+  private val skuRegex = Regex("""SKU-\d+""")
+  private val configIdRegex = Regex("""cfg-\w+""")
+  private val priceIdRegex = Regex("""prc-\w+""")
+  private val intRegex = Regex("""\b(\d+)\b""")
+
+  override fun route(utterance: String, tools: List<ToolDef>): RouteDecision {
+    val lower = utterance.lowercase()
+    val match =
+      tools.firstOrNull { tool ->
+        routingKeywords[tool.graphName].orEmpty().any { lower.contains(it) }
+      }
+    return match?.let { RouteDecision(it.graphName, "keyword match on '${it.graphName}'") }
+      ?: RouteDecision(null, "no keyword matched any graph")
+  }
+
+  override fun fillSlots(utterance: String, tool: ToolDef): Map<String, String> =
+    tool.slots.keys
+      .mapNotNull { slot -> extract(slot, tool.slots[slot]!!.type, utterance)?.let { slot to it } }
+      .toMap()
+
+  private fun extract(slot: String, type: SlotType, utterance: String): String? =
+    when {
+      slot == "productCode" -> skuRegex.find(utterance)?.value
+      slot == "configId" -> configIdRegex.find(utterance)?.value
+      slot == "priceId" -> priceIdRegex.find(utterance)?.value
+      type == SlotType.INT -> intRegex.find(utterance)?.groupValues?.get(1)
+      else -> null
+    }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/mock/MockCpqServer.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/mock/MockCpqServer.kt
@@ -1,0 +1,88 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.mock
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * A local, in-process mock of the three Revenue-Cloud CPQ endpoints the harness graphs execute
+ * against — [/configure], [/price], [/quote]. Backed by an in-memory [db] map that stands in for
+ * the org's records (Stage 3's tau-bench-style checks assert on this final state). Uses the JDK
+ * [HttpServer], the same zero-dependency mock idiom ReVoman's own `ControlFlowE2ETest` uses.
+ */
+class MockCpqServer {
+  val db: MutableMap<String, Any?> = LinkedHashMap()
+  private val seq = AtomicInteger(0)
+  private lateinit var server: HttpServer
+
+  fun start(): Int {
+    server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+    server.createContext("/configure") { ex -> handleConfigure(ex) }
+    server.createContext("/price") { ex -> handlePrice(ex) }
+    server.createContext("/quote") { ex -> handleQuote(ex) }
+    server.start()
+    return server.address.port
+  }
+
+  fun stop() = server.stop(0)
+
+  // --- handlers
+  // -----------------------------------------------
+
+  private fun handleConfigure(ex: HttpExchange) {
+    val body = ex.readBody()
+    val productCode = body.field("productCode") ?: return ex.respond(400, """{"error":"missing productCode"}""")
+    val quantity = body.field("quantity") ?: "1"
+    val configId = "cfg-${seq.incrementAndGet()}"
+    db["config:$configId"] = "$productCode x$quantity"
+    ex.respond(200, """{"configId":"$configId"}""")
+  }
+
+  private fun handlePrice(ex: HttpExchange) {
+    val body = ex.readBody()
+    val configId = body.field("configId")
+    if (configId == null || !db.containsKey("config:$configId")) {
+      return ex.respond(400, """{"error":"unknown configId"}""")
+    }
+    val priceId = "prc-${seq.incrementAndGet()}"
+    val total = 100.0 // deterministic stub price
+    db["price:$priceId"] = total
+    ex.respond(200, """{"priceId":"$priceId","total":$total}""")
+  }
+
+  private fun handleQuote(ex: HttpExchange) {
+    val body = ex.readBody()
+    val priceId = body.field("priceId")
+    if (priceId == null || !db.containsKey("price:$priceId")) {
+      return ex.respond(400, """{"error":"unknown priceId"}""")
+    }
+    val quoteId = "qot-${seq.incrementAndGet()}"
+    db["quote:$quoteId"] = "DRAFT"
+    ex.respond(200, """{"quoteId":"$quoteId","status":"DRAFT"}""")
+  }
+
+  // --- tiny JSON helpers (no dep; naive on purpose — bodies are flat +
+  // trusted)
+  // ------
+
+  private fun HttpExchange.readBody(): String = requestBody.readBytes().decodeToString()
+
+  /** Extracts a flat JSON string/number field value by key, or null. */
+  private fun String.field(key: String): String? =
+    Regex(""""$key"\s*:\s*"?([^",}\s]+)"?""").find(this)?.groupValues?.get(1)
+
+  private fun HttpExchange.respond(status: Int, json: String) {
+    val bytes = json.encodeToByteArray()
+    responseHeaders.add("Content-Type", "application/json")
+    sendResponseHeaders(status, bytes.size.toLong())
+    responseBody.use { it.write(bytes) }
+  }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/mock/MockCpqServer.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/mock/MockCpqServer.kt
@@ -29,7 +29,9 @@ class MockCpqServer {
     server.createContext("/price") { ex -> handlePrice(ex) }
     server.createContext("/quote") { ex -> handleQuote(ex) }
     server.start()
-    return server.address.port
+    val port = server.address.port
+    logger.log(System.Logger.Level.INFO, "MockCpqServer started on port {0}", port)
+    return port
   }
 
   fun stop() = server.stop(0)
@@ -39,10 +41,15 @@ class MockCpqServer {
 
   private fun handleConfigure(ex: HttpExchange) {
     val body = ex.readBody()
-    val productCode = body.field("productCode") ?: return ex.respond(400, """{"error":"missing productCode"}""")
+    val productCode = body.field("productCode")
+    if (productCode == null) {
+      logger.log(System.Logger.Level.DEBUG, "/configure rejected: missing productCode")
+      return ex.respond(400, """{"error":"missing productCode"}""")
+    }
     val quantity = body.field("quantity") ?: "1"
     val configId = "cfg-${seq.incrementAndGet()}"
     db["config:$configId"] = "$productCode x$quantity"
+    logger.log(System.Logger.Level.DEBUG, "/configure → {0} (product={1}, qty={2})", configId, productCode, quantity)
     ex.respond(200, """{"configId":"$configId"}""")
   }
 
@@ -50,11 +57,13 @@ class MockCpqServer {
     val body = ex.readBody()
     val configId = body.field("configId")
     if (configId == null || !db.containsKey("config:$configId")) {
+      logger.log(System.Logger.Level.DEBUG, "/price rejected: unknown configId={0}", configId)
       return ex.respond(400, """{"error":"unknown configId"}""")
     }
     val priceId = "prc-${seq.incrementAndGet()}"
     val total = 100.0 // deterministic stub price
     db["price:$priceId"] = total
+    logger.log(System.Logger.Level.DEBUG, "/price → {0} (config={1}, total={2})", priceId, configId, total)
     ex.respond(200, """{"priceId":"$priceId","total":$total}""")
   }
 
@@ -62,10 +71,12 @@ class MockCpqServer {
     val body = ex.readBody()
     val priceId = body.field("priceId")
     if (priceId == null || !db.containsKey("price:$priceId")) {
+      logger.log(System.Logger.Level.DEBUG, "/quote rejected: unknown priceId={0}", priceId)
       return ex.respond(400, """{"error":"unknown priceId"}""")
     }
     val quoteId = "qot-${seq.incrementAndGet()}"
     db["quote:$quoteId"] = "DRAFT"
+    logger.log(System.Logger.Level.DEBUG, "/quote → {0} (price={1}, status=DRAFT)", quoteId, priceId)
     ex.respond(200, """{"quoteId":"$quoteId","status":"DRAFT"}""")
   }
 
@@ -86,3 +97,5 @@ class MockCpqServer {
     responseBody.use { it.write(bytes) }
   }
 }
+
+private val logger: System.Logger = System.getLogger("com.salesforce.revoman.harness.mock.MockCpqServer")

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/GraphRegistry.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/GraphRegistry.kt
@@ -1,0 +1,25 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.orchestrator
+
+import com.salesforce.revoman.harness.tooldef.GraphMetadataParser
+import com.salesforce.revoman.harness.tooldef.GraphOasLoader
+import com.salesforce.revoman.harness.tooldef.ToolDef
+import com.salesforce.revoman.harness.tooldef.ToolDefGenerator
+
+/**
+ * The static graph registry (design decision: static tool list at v1). Assembles the LLM-facing
+ * tool definitions for every graph from its metadata + OAS. Retrieval-based selection drops in here
+ * later without changing consumers.
+ */
+object GraphRegistry {
+  val GRAPHS: List<String> = listOf("configure", "price", "quote")
+
+  fun loadToolDefs(): List<ToolDef> =
+    GRAPHS.map { ToolDefGenerator.generate(GraphMetadataParser.parse(it), GraphOasLoader.load(it)) }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/Orchestrator.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/Orchestrator.kt
@@ -8,6 +8,8 @@
 package com.salesforce.revoman.harness.orchestrator
 
 import com.salesforce.revoman.harness.GraphRunner
+import com.salesforce.revoman.harness.contract.GraphContract
+import com.salesforce.revoman.harness.contract.toJson
 import com.salesforce.revoman.harness.llm.LlmClient
 import com.salesforce.revoman.harness.telemetry.NoopTracer
 import com.salesforce.revoman.harness.telemetry.Tracer
@@ -30,6 +32,7 @@ sealed interface OrchestrationResult {
     val slots: Map<String, String>,
     val rundowns: List<Rundown>,
     val context: String,
+    val contract: GraphContract? = null,
   ) : OrchestrationResult
 }
 
@@ -100,8 +103,9 @@ class Orchestrator(
         exec.setAttribute("stop_reason", last?.stopReason?.toString() ?: "NONE")
         exec.setAttribute("unsuccessful_steps", rundowns.sumOf { it.unsuccessfulStepCount })
         agent.setAttribute("turn.outcome", "executed")
-        val context = rundowns.joinToString("\n") { it.toJson(Verbosity.SUMMARY) }
-        OrchestrationResult.Executed(graphName, slots, rundowns, context)
+        val contract = GraphContract.of(tool, slots, rundowns.last())
+        val context = contract.toJson(Verbosity.STANDARD)
+        OrchestrationResult.Executed(graphName, slots, rundowns, context, contract)
       }
     }
 }

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/Orchestrator.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/Orchestrator.kt
@@ -9,6 +9,11 @@ package com.salesforce.revoman.harness.orchestrator
 
 import com.salesforce.revoman.harness.GraphRunner
 import com.salesforce.revoman.harness.llm.LlmClient
+import com.salesforce.revoman.harness.telemetry.NoopTracer
+import com.salesforce.revoman.harness.telemetry.Tracer
+import com.salesforce.revoman.harness.telemetry.chatAttrs
+import com.salesforce.revoman.harness.telemetry.executeToolAttrs
+import com.salesforce.revoman.harness.telemetry.invokeAgentAttrs
 import com.salesforce.revoman.harness.tooldef.ToolDef
 import com.salesforce.revoman.output.Rundown
 import com.salesforce.revoman.output.Verbosity
@@ -32,28 +37,71 @@ sealed interface OrchestrationResult {
  * The orchestrator-workers loop, made literal: the probabilistic layer (route + slot-fill) selects
  * and parameterises a graph; the deterministic worker ([GraphRunner] → ReVoman) executes it; the
  * `Rundown` flows back as context. The LLM never touches API sequencing or intra-graph threading.
+ *
+ * Each turn is traced with OpenTelemetry GenAI-convention spans via [tracer] (a no-op by default,
+ * so callers that don't want tracing are unaffected): an `invoke_agent` span for the turn, nested
+ * `chat` spans for the two LLM jobs, and an `execute_tool` span carrying the Rundown stats.
  */
 class Orchestrator(
   private val baseUrl: String,
   private val tools: List<ToolDef>,
   private val llm: LlmClient,
+  private val tracer: Tracer = NoopTracer(),
 ) {
   private val router = Router(llm, tools)
   private val slotFiller = SlotFiller(llm)
 
-  fun orchestrate(utterance: String): OrchestrationResult {
-    val graphName =
-      router.route(utterance).graphName ?: return OrchestrationResult.NoGraphMatched(utterance)
-    val tool =
-      tools.firstOrNull { it.graphName == graphName }
-        ?: return OrchestrationResult.NoGraphMatched(utterance)
-    val slots =
-      when (val fill = slotFiller.fill(utterance, tool)) {
-        is FillResult.Valid -> fill.slots
-        is FillResult.Invalid -> return OrchestrationResult.SlotsRejected(graphName, fill.errors)
+  fun orchestrate(utterance: String): OrchestrationResult =
+    tracer.span("invoke_agent", invokeAgentAttrs("q2c-agent")) { agent ->
+      agent.setAttribute("gen_ai.prompt", utterance)
+
+      val graphName =
+        tracer.span("chat", chatAttrs("router")) { chat ->
+          val decision = router.route(utterance)
+          chat.setAttribute("gen_ai.response.text", decision.graphName ?: "none")
+          decision.graphName
+        }
+      if (graphName == null) {
+        agent.setAttribute("turn.outcome", "no_graph_matched")
+        return@span OrchestrationResult.NoGraphMatched(utterance)
       }
-    val rundowns = GraphRunner.runChain(baseUrl, listOf(graphName), seedEnv = slots)
-    val context = rundowns.joinToString("\n") { it.toJson(Verbosity.SUMMARY) }
-    return OrchestrationResult.Executed(graphName, slots, rundowns, context)
-  }
+      val tool =
+        tools.firstOrNull { it.graphName == graphName }
+          ?: run {
+            agent.setAttribute("turn.outcome", "no_graph_matched")
+            return@span OrchestrationResult.NoGraphMatched(utterance)
+          }
+
+      val fill =
+        tracer.span("chat", chatAttrs("slot-filler")) { chat ->
+          val result = slotFiller.fill(utterance, tool)
+          chat.setAttribute(
+            "gen_ai.response.text",
+            when (result) {
+              is FillResult.Valid -> result.slots.toString()
+              is FillResult.Invalid -> "rejected: ${result.errors}"
+            },
+          )
+          result
+        }
+      val slots =
+        when (fill) {
+          is FillResult.Valid -> fill.slots
+          is FillResult.Invalid -> {
+            agent.setAttribute("turn.outcome", "slots_rejected")
+            return@span OrchestrationResult.SlotsRejected(graphName, fill.errors)
+          }
+        }
+
+      tracer.span("execute_tool", executeToolAttrs(graphName)) { exec ->
+        val rundowns = GraphRunner.runChain(baseUrl, listOf(graphName), seedEnv = slots)
+        val last = rundowns.lastOrNull()
+        exec.setAttribute("steps", rundowns.sumOf { it.executedStepCount })
+        exec.setAttribute("stop_reason", last?.stopReason?.toString() ?: "NONE")
+        exec.setAttribute("unsuccessful_steps", rundowns.sumOf { it.unsuccessfulStepCount })
+        agent.setAttribute("turn.outcome", "executed")
+        val context = rundowns.joinToString("\n") { it.toJson(Verbosity.SUMMARY) }
+        OrchestrationResult.Executed(graphName, slots, rundowns, context)
+      }
+    }
 }

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/Orchestrator.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/Orchestrator.kt
@@ -44,7 +44,9 @@ class Orchestrator(
   fun orchestrate(utterance: String): OrchestrationResult {
     val graphName =
       router.route(utterance).graphName ?: return OrchestrationResult.NoGraphMatched(utterance)
-    val tool = tools.first { it.graphName == graphName }
+    val tool =
+      tools.firstOrNull { it.graphName == graphName }
+        ?: return OrchestrationResult.NoGraphMatched(utterance)
     val slots =
       when (val fill = slotFiller.fill(utterance, tool)) {
         is FillResult.Valid -> fill.slots

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/Orchestrator.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/Orchestrator.kt
@@ -9,7 +9,6 @@ package com.salesforce.revoman.harness.orchestrator
 
 import com.salesforce.revoman.harness.GraphRunner
 import com.salesforce.revoman.harness.contract.GraphContract
-import com.salesforce.revoman.harness.contract.toJson
 import com.salesforce.revoman.harness.llm.LlmClient
 import com.salesforce.revoman.harness.telemetry.NoopTracer
 import com.salesforce.revoman.harness.telemetry.Tracer
@@ -104,7 +103,7 @@ class Orchestrator(
         exec.setAttribute("unsuccessful_steps", rundowns.sumOf { it.unsuccessfulStepCount })
         agent.setAttribute("turn.outcome", "executed")
         val contract = GraphContract.of(tool, slots, rundowns.last())
-        val context = contract.toJson(Verbosity.STANDARD)
+        val context = rundowns.joinToString("\n") { it.toJson(Verbosity.SUMMARY) }
         OrchestrationResult.Executed(graphName, slots, rundowns, context, contract)
       }
     }

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/Orchestrator.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/Orchestrator.kt
@@ -1,0 +1,57 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.orchestrator
+
+import com.salesforce.revoman.harness.GraphRunner
+import com.salesforce.revoman.harness.llm.LlmClient
+import com.salesforce.revoman.harness.tooldef.ToolDef
+import com.salesforce.revoman.output.Rundown
+import com.salesforce.revoman.output.Verbosity
+import com.salesforce.revoman.output.toJson
+
+/** The outcome of one orchestration turn. */
+sealed interface OrchestrationResult {
+  data class NoGraphMatched(val utterance: String) : OrchestrationResult
+
+  data class SlotsRejected(val graph: String, val errors: List<String>) : OrchestrationResult
+
+  data class Executed(
+    val graph: String,
+    val slots: Map<String, String>,
+    val rundowns: List<Rundown>,
+    val context: String,
+  ) : OrchestrationResult
+}
+
+/**
+ * The orchestrator-workers loop, made literal: the probabilistic layer (route + slot-fill) selects
+ * and parameterises a graph; the deterministic worker ([GraphRunner] → ReVoman) executes it; the
+ * `Rundown` flows back as context. The LLM never touches API sequencing or intra-graph threading.
+ */
+class Orchestrator(
+  private val baseUrl: String,
+  private val tools: List<ToolDef>,
+  private val llm: LlmClient,
+) {
+  private val router = Router(llm, tools)
+  private val slotFiller = SlotFiller(llm)
+
+  fun orchestrate(utterance: String): OrchestrationResult {
+    val graphName =
+      router.route(utterance).graphName ?: return OrchestrationResult.NoGraphMatched(utterance)
+    val tool = tools.first { it.graphName == graphName }
+    val slots =
+      when (val fill = slotFiller.fill(utterance, tool)) {
+        is FillResult.Valid -> fill.slots
+        is FillResult.Invalid -> return OrchestrationResult.SlotsRejected(graphName, fill.errors)
+      }
+    val rundowns = GraphRunner.runChain(baseUrl, listOf(graphName), seedEnv = slots)
+    val context = rundowns.joinToString("\n") { it.toJson(Verbosity.SUMMARY) }
+    return OrchestrationResult.Executed(graphName, slots, rundowns, context)
+  }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/Router.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/Router.kt
@@ -1,0 +1,17 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.orchestrator
+
+import com.salesforce.revoman.harness.llm.LlmClient
+import com.salesforce.revoman.harness.llm.RouteDecision
+import com.salesforce.revoman.harness.tooldef.ToolDef
+
+/** Prompt A: turns an intent into a graph choice by delegating to the pluggable [LlmClient]. */
+class Router(private val llm: LlmClient, private val tools: List<ToolDef>) {
+  fun route(utterance: String): RouteDecision = llm.route(utterance, tools)
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/SlotFiller.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/SlotFiller.kt
@@ -1,0 +1,46 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.orchestrator
+
+import com.salesforce.revoman.harness.llm.LlmClient
+import com.salesforce.revoman.harness.tooldef.SlotType
+import com.salesforce.revoman.harness.tooldef.ToolDef
+
+/** The result of slot-filling: validated arguments, or the list of validation failures. */
+sealed interface FillResult {
+  data class Valid(val slots: Map<String, String>) : FillResult
+
+  data class Invalid(val errors: List<String>) : FillResult
+}
+
+/**
+ * Prompt B: fills a graph's input placeholders via the [LlmClient], then validates every argument
+ * against the graph's typed schema BEFORE it can reach ReVoman. Hallucinated argument names,
+ * out-of-enum values, non-integer numbers, and missing required slots are all rejected at the door.
+ */
+class SlotFiller(private val llm: LlmClient) {
+  fun fill(utterance: String, tool: ToolDef): FillResult {
+    val filled = llm.fillSlots(utterance, tool)
+    val errors = buildList {
+      // Reject hallucinated slot names not declared by the graph.
+      (filled.keys - tool.slots.keys).forEach { add("unknown slot '$it' (not declared by graph '${tool.graphName}')") }
+      // Validate each declared slot.
+      tool.slots.forEach { (name, schema) ->
+        val value = filled[name]
+        when {
+          value == null -> if (schema.required) add("missing required slot '$name'")
+          schema.type == SlotType.INT && value.toIntOrNull() == null ->
+            add("slot '$name' expects an integer but got '$value'")
+          schema.type == SlotType.ENUM && value !in schema.values ->
+            add("slot '$name' value '$value' is not one of ${schema.values}")
+        }
+      }
+    }
+    return if (errors.isEmpty()) FillResult.Valid(filled) else FillResult.Invalid(errors)
+  }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/reasoning/ActionPreview.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/reasoning/ActionPreview.kt
@@ -1,0 +1,20 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.reasoning
+
+/**
+ * The confirm gate's proposed-action preview for a write: exactly what would run, shown to the
+ * human, executed only on confirm. Carries what `GraphRunner.runChain` needs so confirmation
+ * executes without re-deriving anything.
+ */
+data class ActionPreview(
+  val graph: String,
+  val slots: Map<String, String>,
+  val chain: List<String>,
+  val isWrite: Boolean,
+)

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/reasoning/ConfidencePolicy.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/reasoning/ConfidencePolicy.kt
@@ -1,0 +1,29 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.reasoning
+
+/**
+ * The tunable policy for the disambiguation gate: below a graph's [threshold] the layer asks
+ * instead of guessing. Write graphs default to the financial-services band (0.90) per the industry
+ * research; reads use [defaultThreshold]. Per-graph overrides win. The margin/threshold trade is
+ * deliberately tunable — that is the whole point of the gate.
+ */
+data class ConfidencePolicy(
+  val defaultThreshold: Double = 0.60,
+  val perGraphThreshold: Map<String, Double> = emptyMap(),
+  val writeGraphs: Set<String> = setOf("quote"),
+) {
+  fun isWrite(graph: String): Boolean = graph in writeGraphs
+
+  fun threshold(graph: String): Double =
+    perGraphThreshold[graph] ?: if (isWrite(graph)) FINANCIAL_SERVICES_BAND else defaultThreshold
+
+  companion object {
+    const val FINANCIAL_SERVICES_BAND: Double = 0.90
+  }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/reasoning/ConfidencePolicy.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/reasoning/ConfidencePolicy.kt
@@ -8,10 +8,12 @@
 package com.salesforce.revoman.harness.reasoning
 
 /**
- * The tunable policy for the disambiguation gate: below a graph's [threshold] the layer asks
- * instead of guessing. Write graphs default to the financial-services band (0.90) per the industry
- * research; reads use [defaultThreshold]. Per-graph overrides win. The margin/threshold trade is
- * deliberately tunable — that is the whole point of the gate.
+ * The tunable policy for the disambiguation gate: the gate compares the MARGIN (gap between the
+ * top-two scored graphs) against a [threshold]; if margin is below threshold, the layer asks
+ * instead of guessing. Absolute confidence is informational only (emitted as telemetry, not gating).
+ * Write graphs default to the financial-services band (0.90) per industry research; reads use
+ * [defaultThreshold]. Per-graph overrides win. The margin/threshold trade is deliberately tunable —
+ * that is the whole point of the gate.
  */
 data class ConfidencePolicy(
   val defaultThreshold: Double = 0.60,

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/reasoning/DisambiguationGate.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/reasoning/DisambiguationGate.kt
@@ -1,0 +1,49 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.reasoning
+
+import com.salesforce.revoman.harness.llm.RouteDecision
+import com.salesforce.revoman.harness.orchestrator.FillResult
+
+/**
+ * Scaffold 5, the single most important reliability rule: gate on uncertainty, never guess. When
+ * the top-two graphs are within the policy margin, or a required slot is missing/invalid, the layer
+ * returns a [ReasoningOutcome.Clarify] (ask the user) rather than a coin-flip. Confident writes
+ * route to [ReasoningOutcome.ConfirmRequired] (human validates before execution); confident reads
+ * [ReasoningOutcome.Proceed].
+ */
+class DisambiguationGate(private val policy: ConfidencePolicy = ConfidencePolicy()) {
+  fun decide(
+    decision: RouteDecision,
+    secondBestGraph: String?,
+    fill: FillResult,
+    chain: List<String>,
+  ): ReasoningOutcome {
+    val graph = decision.graphName ?: return ReasoningOutcome.NoMatch("(none)")
+
+    if (decision.margin < policy.threshold(graph)) {
+      val candidates = listOfNotNull(graph, secondBestGraph)
+      return ReasoningOutcome.Clarify(
+        "I'm not confident which action you want. Did you mean ${candidates.joinToString(" or ")}?",
+        candidates,
+      )
+    }
+
+    return when (fill) {
+      is FillResult.Invalid ->
+        ReasoningOutcome.Clarify(
+          "I need more detail before I can proceed: ${fill.errors.joinToString("; ")}",
+          listOf(graph),
+        )
+      is FillResult.Valid ->
+        if (policy.isWrite(graph))
+          ReasoningOutcome.ConfirmRequired(ActionPreview(graph, fill.slots, chain, isWrite = true))
+        else ReasoningOutcome.Proceed(graph, fill.slots)
+    }
+  }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/reasoning/ReasoningLayer.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/reasoning/ReasoningLayer.kt
@@ -28,6 +28,9 @@ import com.salesforce.revoman.output.Rundown
  */
 class ReasoningLayer(
   private val tools: List<ToolDef>,
+  // Must be ScoringLlmClient (not LlmClient) because the gate depends on margin, which only
+  // ScoringLlmClient populates. A bare LlmClient leaves margin=0.0, causing all decisions to fall
+  // below threshold and always route to Clarify.
   private val llm: ScoringLlmClient = ScoringLlmClient(),
   private val policy: ConfidencePolicy = ConfidencePolicy(),
   private val topK: Int = tools.size,

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/reasoning/ReasoningLayer.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/reasoning/ReasoningLayer.kt
@@ -1,0 +1,75 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.reasoning
+
+import com.salesforce.revoman.harness.GraphRunner
+import com.salesforce.revoman.harness.llm.ScoringLlmClient
+import com.salesforce.revoman.harness.orchestrator.SlotFiller
+import com.salesforce.revoman.harness.retrieval.RetrievalPreFilter
+import com.salesforce.revoman.harness.telemetry.NoopTracer
+import com.salesforce.revoman.harness.telemetry.Tracer
+import com.salesforce.revoman.harness.telemetry.chatAttrs
+import com.salesforce.revoman.harness.telemetry.executeToolAttrs
+import com.salesforce.revoman.harness.telemetry.invokeAgentAttrs
+import com.salesforce.revoman.harness.tooldef.ToolDef
+import com.salesforce.revoman.output.Rundown
+
+/**
+ * The complete reasoning layer: the one probabilistic surface, scaffolded for reliability.
+ * `handle` runs retrieve → route (with confidence) → fill (validated) → gate, and returns a
+ * [ReasoningOutcome] WITHOUT executing anything. `confirm` is the only path that hands a graph to
+ * ReVoman, and only after the gate said a human must approve (writes) or the caller chose to run a
+ * `Proceed`. Every turn is traced with OTel GenAI-convention spans.
+ */
+class ReasoningLayer(
+  private val tools: List<ToolDef>,
+  private val llm: ScoringLlmClient = ScoringLlmClient(),
+  private val policy: ConfidencePolicy = ConfidencePolicy(),
+  private val topK: Int = tools.size,
+  private val tracer: Tracer = NoopTracer(),
+) {
+  private val gate = DisambiguationGate(policy)
+  private val slotFiller = SlotFiller(llm)
+
+  fun handle(intent: String): ReasoningOutcome =
+    tracer.span("invoke_agent", invokeAgentAttrs("reasoning-layer")) { agent ->
+      agent.setAttribute("gen_ai.prompt", intent)
+      val candidates = RetrievalPreFilter.topK(intent, tools, topK)
+
+      val decision =
+        tracer.span("chat", chatAttrs("router")) { chat ->
+          val d = llm.route(intent, candidates)
+          chat.setAttribute("gen_ai.response.text", d.graphName ?: "none")
+          chat.setAttribute("confidence", d.confidence)
+          chat.setAttribute("margin", d.margin)
+          d
+        }
+      val graph = decision.graphName ?: return@span ReasoningOutcome.NoMatch(intent)
+      val tool = candidates.first { it.graphName == graph }
+
+      val secondBest =
+        llm.scores(intent, candidates)
+          .entries
+          .sortedByDescending { it.value }
+          .getOrNull(1)
+          ?.takeIf { it.value > 0 }
+          ?.key
+
+      val fill =
+        tracer.span("chat", chatAttrs("slot-filler")) { slotFiller.fill(intent, tool) }
+
+      val outcome = gate.decide(decision, secondBest, fill, chain = listOf(graph))
+      agent.setAttribute("turn.outcome", outcome::class.simpleName ?: "unknown")
+      outcome
+    }
+
+  fun confirm(preview: ActionPreview, baseUrl: String): List<Rundown> =
+    tracer.span("execute_tool", executeToolAttrs(preview.graph)) {
+      GraphRunner.runChain(baseUrl, preview.chain, seedEnv = preview.slots)
+    }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/reasoning/ReasoningOutcome.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/reasoning/ReasoningOutcome.kt
@@ -1,0 +1,22 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.reasoning
+
+/** The reasoning layer's decision for one intent — proceed, ask, confirm, or no match. */
+sealed interface ReasoningOutcome {
+  data class NoMatch(val intent: String) : ReasoningOutcome
+
+  /** The ask-don't-guess result: top-2 within margin, or a required slot missing/invalid. */
+  data class Clarify(val question: String, val candidates: List<String>) : ReasoningOutcome
+
+  /** A confident write: preview shown, nothing executed until the human confirms. */
+  data class ConfirmRequired(val preview: ActionPreview) : ReasoningOutcome
+
+  /** A confident read: safe to execute. */
+  data class Proceed(val graph: String, val slots: Map<String, String>) : ReasoningOutcome
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/retrieval/RetrievalPreFilter.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/retrieval/RetrievalPreFilter.kt
@@ -1,0 +1,50 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.retrieval
+
+import com.salesforce.revoman.harness.tooldef.ToolDef
+import kotlin.math.sqrt
+
+/**
+ * Scaffold 4: narrows many graphs to the top-K relevant candidates BEFORE the router reasons, so
+ * the model reasons over a small, clean set (the reliability control from `reasoning-layer.md`).
+ * The embedding is a local bag-of-tokens cosine stub — enough to prove the seam; a real vector
+ * store drops in behind the same `topK` signature. A no-op at 3 graphs (returns all), it
+ * demonstrably narrows a larger set.
+ */
+object RetrievalPreFilter {
+  fun topK(intent: String, tools: List<ToolDef>, k: Int): List<ToolDef> {
+    if (k >= tools.size) return tools
+    val q = vector(intent)
+    return tools
+      .withIndex()
+      .sortedWith(
+        compareByDescending<IndexedValue<ToolDef>> { cosine(q, vector(docText(it.value))) }
+          .thenBy { it.index }
+      )
+      .take(k)
+      .map { it.value }
+  }
+
+  private fun docText(tool: ToolDef): String =
+    tool.whenToUse + " " + tool.exampleQueries.joinToString(" ")
+
+  private fun vector(text: String): Map<String, Int> =
+    tokenize(text).groupingBy { it }.eachCount()
+
+  private fun cosine(a: Map<String, Int>, b: Map<String, Int>): Double {
+    if (a.isEmpty() || b.isEmpty()) return 0.0
+    val dot = a.keys.intersect(b.keys).sumOf { a.getValue(it) * b.getValue(it) }
+    val magA = sqrt(a.values.sumOf { it * it }.toDouble())
+    val magB = sqrt(b.values.sumOf { it * it }.toDouble())
+    return if (magA == 0.0 || magB == 0.0) 0.0 else dot / (magA * magB)
+  }
+
+  private fun tokenize(text: String): List<String> =
+    text.lowercase().split(Regex("[^a-z0-9]+")).filter { it.length >= 3 }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/telemetry/GenAiTracer.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/telemetry/GenAiTracer.kt
@@ -1,0 +1,82 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.telemetry
+
+/** A scope for adding attributes to the currently-open span. */
+interface SpanScope {
+  fun setAttribute(key: String, value: Any?)
+}
+
+/** Opens spans that nest via the block: a `span(...)` called inside another's block is its child. */
+interface Tracer {
+  fun <T> span(name: String, attributes: Map<String, Any?> = emptyMap(), block: (SpanScope) -> T): T
+}
+
+/** A tracer that runs blocks but records nothing — the default when tracing isn't wanted. */
+class NoopTracer : Tracer {
+  override fun <T> span(name: String, attributes: Map<String, Any?>, block: (SpanScope) -> T): T =
+    block(
+      object : SpanScope {
+        override fun setAttribute(key: String, value: Any?) {}
+      }
+    )
+}
+
+/**
+ * Records the OpenTelemetry GenAI-convention span tree and renders it to [sink] when each top-level
+ * span closes. Single-threaded by design (the harness confines a turn to one thread, exactly like
+ * ReVoman's `revUp`). Not the OTLP SDK — a dependency-free, faithful console rendering of the
+ * `invoke_agent` / `chat` / `execute_tool` span shape.
+ */
+class GenAiTracer(private val sink: (String) -> Unit = ::println) : Tracer {
+  private class Building(val name: String, val attributes: MutableMap<String, Any?>) : SpanScope {
+    val children: MutableList<Span> = mutableListOf()
+
+    override fun setAttribute(key: String, value: Any?) {
+      attributes[key] = value
+    }
+
+    fun toSpan(): Span = Span(name, attributes.toMap(), children.toList())
+  }
+
+  private val stack: ArrayDeque<Building> = ArrayDeque()
+  private val _rootSpans: MutableList<Span> = mutableListOf()
+
+  val rootSpans: List<Span>
+    get() = _rootSpans.toList()
+
+  override fun <T> span(name: String, attributes: Map<String, Any?>, block: (SpanScope) -> T): T {
+    val building = Building(name, attributes.toMutableMap())
+    stack.addLast(building)
+    try {
+      return block(building)
+    } finally {
+      stack.removeLast()
+      val span = building.toSpan()
+      val parent = stack.lastOrNull()
+      if (parent == null) {
+        _rootSpans.add(span)
+        sink(span.render())
+      } else {
+        parent.children.add(span)
+      }
+    }
+  }
+}
+
+/** GenAI-convention attributes for an agent-invocation (turn) span. */
+fun invokeAgentAttrs(agentName: String): Map<String, Any?> =
+  mapOf("gen_ai.operation.name" to "invoke_agent", "gen_ai.agent.name" to agentName)
+
+/** GenAI-convention attributes for an LLM chat span. */
+fun chatAttrs(model: String): Map<String, Any?> =
+  mapOf("gen_ai.operation.name" to "chat", "gen_ai.request.model" to model)
+
+/** GenAI-convention attributes for a tool-execution (graph run) span. */
+fun executeToolAttrs(toolName: String): Map<String, Any?> =
+  mapOf("gen_ai.operation.name" to "execute_tool", "gen_ai.tool.name" to toolName)

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/telemetry/Span.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/telemetry/Span.kt
@@ -1,0 +1,23 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.telemetry
+
+/**
+ * One completed span in the OpenTelemetry GenAI-convention shape: a name, `gen_ai.*` attributes,
+ * and nested child spans. This is a faithful model of the convention's span tree rendered to a
+ * console sink — not the OTLP wire SDK (no dependency), which is what the local demo needs.
+ */
+data class Span(val name: String, val attributes: Map<String, Any?>, val children: List<Span>) {
+  fun render(indent: Int = 0): String {
+    val pad = "  ".repeat(indent)
+    val attrs = attributes.entries.joinToString(", ") { "${it.key}=${it.value}" }
+    val head = "$pad• $name" + if (attrs.isEmpty()) "" else "  [$attrs]"
+    val kids = children.joinToString("") { "\n" + it.render(indent + 1) }
+    return head + kids
+  }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/GraphMetadataParser.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/GraphMetadataParser.kt
@@ -1,0 +1,52 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.tooldef
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.name
+import kotlin.io.path.readText
+
+/**
+ * Parses a V3 graph collection directory (on the classpath) into a [GraphSpec]. Placeholder and
+ * output extraction is done by regex over the raw request-yaml text — more robust for finding
+ * `{{var}}` tokens and `pm.environment.set` keys than parsing the YAML structure and re-scanning
+ * string values.
+ */
+object GraphMetadataParser {
+  private val INFRA_PLACEHOLDERS = setOf("baseUrl", "accessToken")
+  private val PLACEHOLDER = Regex("""\{\{(\w+)}}""")
+  private val ENV_SET = Regex("""pm\.environment\.set\(\s*["'](\w+)["']""")
+  private val DESCRIPTION = Regex("""^description:\s*["']?(.*?)["']?\s*$""", RegexOption.MULTILINE)
+
+  fun parse(graph: String): GraphSpec {
+    val dir = resourceDir("graphs/$graph")
+    val defText = dir.resolve(".resources/definition.yaml").readText()
+    val description = DESCRIPTION.find(defText)?.groupValues?.get(1)?.trim().orEmpty()
+
+    val requestText =
+      Files.list(dir).use { stream ->
+        stream
+          .filter { it.name.endsWith(".request.yaml") }
+          .map { it.readText() }
+          .toList()
+          .joinToString("\n")
+      }
+    val referenced = PLACEHOLDER.findAll(requestText).map { it.groupValues[1] }.toSet()
+    val outputKeys = ENV_SET.findAll(requestText).map { it.groupValues[1] }.toSet()
+    val slots = (referenced - INFRA_PLACEHOLDERS - outputKeys).sorted()
+    return GraphSpec(graph, description, slots, outputKeys.sorted())
+  }
+
+  private fun resourceDir(path: String): Path {
+    val url =
+      javaClass.classLoader.getResource(path)
+        ?: error("Graph resource directory not found on classpath: $path")
+    return Path.of(url.toURI())
+  }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/GraphOas.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/GraphOas.kt
@@ -1,0 +1,34 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.tooldef
+
+/** The type of a graph input slot, used to validate LLM-filled arguments before execution. */
+enum class SlotType {
+  STRING,
+  INT,
+  ENUM,
+}
+
+/** Schema for one input slot: its type, allowed values (for [SlotType.ENUM]), and whether required. */
+data class SlotSchema(
+  val type: SlotType,
+  val values: List<String> = emptyList(),
+  val required: Boolean = true,
+)
+
+/**
+ * A small, hand-authored OpenAPI-style spec for one graph. The [ToolDefGenerator] distils it — plus
+ * the graph metadata — into the four LLM-facing tool-def fields. Never dumped raw into a prompt.
+ */
+data class GraphOas(
+  val graph: String,
+  val slots: Map<String, SlotSchema>,
+  val exampleQueries: List<String>,
+  val inputExamples: List<Map<String, String>>,
+  val whenNotToUse: List<String> = emptyList(),
+)

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/GraphOasLoader.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/GraphOasLoader.kt
@@ -1,0 +1,42 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.tooldef
+
+import org.yaml.snakeyaml.Yaml
+
+/** Loads a graph's OAS from `oas/<graph>.yaml` on the classpath. */
+object GraphOasLoader {
+  fun load(graph: String): GraphOas {
+    val text =
+      javaClass.classLoader.getResourceAsStream("oas/$graph.yaml")?.bufferedReader()?.readText()
+        ?: error("OAS not found on classpath: oas/$graph.yaml")
+    @Suppress("UNCHECKED_CAST") val root = Yaml().load<Map<String, Any?>>(text)
+
+    @Suppress("UNCHECKED_CAST") val slotsRaw = (root["slots"] as? Map<String, Any?>).orEmpty()
+    val slots =
+      slotsRaw.mapValues { (_, v) ->
+        @Suppress("UNCHECKED_CAST") val s = v as Map<String, Any?>
+        val type = SlotType.valueOf((s["type"] as String).uppercase())
+        @Suppress("UNCHECKED_CAST") val values = (s["values"] as? List<Any?>).orEmpty().map { it.toString() }
+        val required = (s["required"] as? Boolean) ?: true
+        SlotSchema(type, values, required)
+      }
+
+    @Suppress("UNCHECKED_CAST")
+    val exampleQueries = (root["exampleQueries"] as? List<Any?>).orEmpty().map { it.toString() }
+    @Suppress("UNCHECKED_CAST")
+    val inputExamples =
+      (root["inputExamples"] as? List<Map<String, Any?>>).orEmpty().map { ex ->
+        ex.mapValues { it.value.toString() }
+      }
+    @Suppress("UNCHECKED_CAST")
+    val whenNotToUse = (root["whenNotToUse"] as? List<Any?>).orEmpty().map { it.toString() }
+
+    return GraphOas(root["graph"] as String, slots, exampleQueries, inputExamples, whenNotToUse)
+  }
+}

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/GraphSpec.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/GraphSpec.kt
@@ -1,0 +1,23 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.tooldef
+
+/**
+ * Structural metadata distilled from a ReVoman V3 graph collection — the raw material the
+ * [ToolDefGenerator] turns into an LLM-facing tool definition.
+ *
+ * @property slots the input `{{placeholder}}` names the LLM must fill (infra + intra-graph outputs
+ *   excluded — those are threaded deterministically by ReVoman, never by the LLM).
+ * @property outputKeys the `pm.environment.set(...)` keys the graph produces (its internal edges).
+ */
+data class GraphSpec(
+  val name: String,
+  val description: String,
+  val slots: List<String>,
+  val outputKeys: List<String>,
+)

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/ToolDef.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/ToolDef.kt
@@ -1,0 +1,22 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.tooldef
+
+/**
+ * The LLM-facing definition of one graph tool: the four calibration fields from the design
+ * (`when_to_use`, `when_not_to_use`, `example_queries`, `input_examples`) plus the slot schema the
+ * slot-filler validates against before execution.
+ */
+data class ToolDef(
+  val graphName: String,
+  val whenToUse: String,
+  val whenNotToUse: List<String>,
+  val exampleQueries: List<String>,
+  val inputExamples: List<Map<String, String>>,
+  val slots: Map<String, SlotSchema>,
+)

--- a/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/ToolDefGenerator.kt
+++ b/agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/ToolDefGenerator.kt
@@ -1,0 +1,33 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.tooldef
+
+/**
+ * Pure function: distils graph metadata + a small OAS into the four-field [ToolDef]. Reconciles the
+ * two sources — the OAS must declare a schema for exactly the graph's input slots (no more, no
+ * less) — so a graph and its spec cannot silently drift apart.
+ */
+object ToolDefGenerator {
+  fun generate(spec: GraphSpec, oas: GraphOas): ToolDef {
+    val metadataSlots = spec.slots.toSet()
+    val oasSlots = oas.slots.keys
+    require(metadataSlots == oasSlots) {
+      val missing = metadataSlots - oasSlots
+      val extra = oasSlots - metadataSlots
+      "OAS for '${spec.name}' does not match graph slots. missing schema for=$missing, unknown slots=$extra"
+    }
+    return ToolDef(
+      graphName = spec.name,
+      whenToUse = spec.description,
+      whenNotToUse = oas.whenNotToUse,
+      exampleQueries = oas.exampleQueries,
+      inputExamples = oas.inputExamples,
+      slots = oas.slots,
+    )
+  }
+}

--- a/agentic-harness/src/main/resources/evals/router-eval.yaml
+++ b/agentic-harness/src/main/resources/evals/router-eval.yaml
@@ -1,0 +1,12 @@
+# Labeled utterance -> expected graph. The single deliberate near-miss is the last case:
+# "quote me a price for this config" is really a PRICE request, but the word "quote" lures a
+# naive router to the quote graph. Stage 3's calibration loop fixes exactly this with a
+# when_not_to_use clause. Keep this file human-editable — Stage 4's flywheel appends to it.
+cases:
+  - { utterance: "configure 2 units of SKU-1", expected: configure }
+  - { utterance: "set up a new product configuration", expected: configure }
+  - { utterance: "what does this configuration cost", expected: price }
+  - { utterance: "compute the total for my config", expected: price }
+  - { utterance: "create a draft quote for prc-2", expected: quote }
+  - { utterance: "draft a quote from prc-2", expected: quote }
+  - { utterance: "quote me a price for this config", expected: price }

--- a/agentic-harness/src/main/resources/evals/slotfill-gold.yaml
+++ b/agentic-harness/src/main/resources/evals/slotfill-gold.yaml
@@ -1,0 +1,10 @@
+cases:
+  - utterance: "configure 2 units of SKU-1"
+    graph: configure
+    slots: { productCode: "SKU-1", quantity: "2" }
+  - utterance: "price configuration cfg-1"
+    graph: price
+    slots: { configId: "cfg-1" }
+  - utterance: "create a draft quote for prc-2"
+    graph: quote
+    slots: { priceId: "prc-2" }

--- a/agentic-harness/src/main/resources/graphs/configure/.resources/definition.yaml
+++ b/agentic-harness/src/main/resources/graphs/configure/.resources/definition.yaml
@@ -1,0 +1,8 @@
+$kind: collection
+description: "Configure a product: turn a product code + quantity into a saved configuration."
+auth:
+  - id: cfg-auth
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{accessToken}}"

--- a/agentic-harness/src/main/resources/graphs/configure/configure-product.request.yaml
+++ b/agentic-harness/src/main/resources/graphs/configure/configure-product.request.yaml
@@ -1,0 +1,16 @@
+$kind: http-request
+url: "{{baseUrl}}/configure"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: text
+  content: |-
+    {"productCode":"{{productCode}}","quantity":{{quantity}}}
+scripts:
+  - type: afterResponse
+    code: |-
+      var res = pm.response.json()
+      pm.environment.set("configId", res.configId)
+    language: text/javascript
+order: 1000

--- a/agentic-harness/src/main/resources/graphs/configure/configure.environment.yaml
+++ b/agentic-harness/src/main/resources/graphs/configure/configure.environment.yaml
@@ -1,0 +1,10 @@
+name: configure
+values:
+  - key: baseUrl
+    value: "http://127.0.0.1:0"
+  - key: accessToken
+    value: "local-dev-token"
+  - key: productCode
+    value: "SKU-1"
+  - key: quantity
+    value: "1"

--- a/agentic-harness/src/main/resources/graphs/price/.resources/definition.yaml
+++ b/agentic-harness/src/main/resources/graphs/price/.resources/definition.yaml
@@ -1,0 +1,8 @@
+$kind: collection
+description: "Price a saved configuration: compute the total for a configId."
+auth:
+  - id: prc-auth
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{accessToken}}"

--- a/agentic-harness/src/main/resources/graphs/price/price-config.request.yaml
+++ b/agentic-harness/src/main/resources/graphs/price/price-config.request.yaml
@@ -1,0 +1,17 @@
+$kind: http-request
+url: "{{baseUrl}}/price"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: text
+  content: |-
+    {"configId":"{{configId}}"}
+scripts:
+  - type: afterResponse
+    code: |-
+      var res = pm.response.json()
+      pm.environment.set("priceId", res.priceId)
+      pm.environment.set("total", res.total)
+    language: text/javascript
+order: 1000

--- a/agentic-harness/src/main/resources/graphs/price/price.environment.yaml
+++ b/agentic-harness/src/main/resources/graphs/price/price.environment.yaml
@@ -1,0 +1,8 @@
+name: price
+values:
+  - key: baseUrl
+    value: "http://127.0.0.1:0"
+  - key: accessToken
+    value: "local-dev-token"
+  - key: configId
+    value: ""

--- a/agentic-harness/src/main/resources/graphs/quote/.resources/definition.yaml
+++ b/agentic-harness/src/main/resources/graphs/quote/.resources/definition.yaml
@@ -1,0 +1,8 @@
+$kind: collection
+description: "Quote a priced configuration: create a draft quote from a priceId."
+auth:
+  - id: qot-auth
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{accessToken}}"

--- a/agentic-harness/src/main/resources/graphs/quote/quote-price.request.yaml
+++ b/agentic-harness/src/main/resources/graphs/quote/quote-price.request.yaml
@@ -1,0 +1,17 @@
+$kind: http-request
+url: "{{baseUrl}}/quote"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: text
+  content: |-
+    {"priceId":"{{priceId}}"}
+scripts:
+  - type: afterResponse
+    code: |-
+      var res = pm.response.json()
+      pm.environment.set("quoteId", res.quoteId)
+      pm.environment.set("quoteStatus", res.status)
+    language: text/javascript
+order: 1000

--- a/agentic-harness/src/main/resources/graphs/quote/quote.environment.yaml
+++ b/agentic-harness/src/main/resources/graphs/quote/quote.environment.yaml
@@ -1,0 +1,8 @@
+name: quote
+values:
+  - key: baseUrl
+    value: "http://127.0.0.1:0"
+  - key: accessToken
+    value: "local-dev-token"
+  - key: priceId
+    value: ""

--- a/agentic-harness/src/main/resources/oas/configure.yaml
+++ b/agentic-harness/src/main/resources/oas/configure.yaml
@@ -1,0 +1,13 @@
+graph: configure
+slots:
+  productCode: { type: enum, values: [SKU-1, SKU-2, SKU-3] }
+  quantity: { type: int }
+exampleQueries:
+  - "configure 2 units of SKU-1"
+  - "set up a new product configuration"
+  - "add SKU-2 to a fresh config"
+inputExamples:
+  - { productCode: "SKU-1", quantity: "2" }
+  - { productCode: "SKU-2", quantity: "10" }
+whenNotToUse:
+  - "Do not use to compute a price or total — that is the price graph."

--- a/agentic-harness/src/main/resources/oas/price.yaml
+++ b/agentic-harness/src/main/resources/oas/price.yaml
@@ -1,0 +1,12 @@
+graph: price
+slots:
+  configId: { type: string }
+exampleQueries:
+  - "price configuration cfg-1"
+  - "what does this configuration cost"
+  - "compute the total for my config"
+inputExamples:
+  - { configId: "cfg-1" }
+whenNotToUse:
+  - "Do not use to build a configuration from a product — that is the configure graph."
+  - "Do not use to create a draft quote — that is the quote graph."

--- a/agentic-harness/src/main/resources/oas/quote.yaml
+++ b/agentic-harness/src/main/resources/oas/quote.yaml
@@ -1,0 +1,11 @@
+graph: quote
+slots:
+  priceId: { type: string }
+exampleQueries:
+  - "create a draft quote for prc-2"
+  - "turn this price into a quote"
+  - "draft a quote"
+inputExamples:
+  - { priceId: "prc-2" }
+whenNotToUse:
+  - "Do not use to price a configuration — that is the price graph."

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/GraphRunnerTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/GraphRunnerTest.kt
@@ -1,0 +1,45 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GraphRunnerTest {
+  private lateinit var server: MockCpqServer
+  private var baseUrl: String = ""
+
+  @BeforeEach
+  fun setUp() {
+    server = MockCpqServer()
+    baseUrl = "http://127.0.0.1:${server.start()}"
+  }
+
+  @AfterEach fun tearDown() = server.stop()
+
+  @Test
+  fun `configure-price-quote chain threads ids forward and lands a draft quote`() {
+    val rundowns = GraphRunner.runChain(baseUrl)
+
+    // Three graphs ran, each with no failing step.
+    assertThat(rundowns).hasSize(3)
+    rundowns.forEach { assertThat(it.firstUnIgnoredUnsuccessfulStepReport).isNull() }
+
+    // The final env carries the threaded ids — proof {{var}} edges connected the graphs.
+    val finalEnv = rundowns.last().mutableEnv
+    assertThat(finalEnv.getAsString("configId")).startsWith("cfg-")
+    assertThat(finalEnv.getAsString("priceId")).startsWith("prc-")
+    assertThat(finalEnv.getAsString("quoteId")).startsWith("qot-")
+
+    // The mock "DB" recorded a DRAFT quote (tau-bench-style state proof, previewed here).
+    assertThat(server.db.values).contains("DRAFT")
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/Layer1ContractTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/Layer1ContractTest.kt
@@ -1,0 +1,43 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.output.StopReason
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * The design's "evals Layer 1" beat: deterministic API-graph contract tests, no LLM. Runs the
+ * graph chain against the mock and asserts on the Rundown — the exact same engine that will run
+ * graphs at agent runtime.
+ */
+class Layer1ContractTest {
+  private lateinit var server: MockCpqServer
+  private var baseUrl: String = ""
+
+  @BeforeEach
+  fun setUp() {
+    server = MockCpqServer()
+    baseUrl = "http://127.0.0.1:${server.start()}"
+  }
+
+  @AfterEach fun tearDown() = server.stop()
+
+  @Test
+  fun `every graph in the chain completes with no unsuccessful step`() {
+    val rundowns = GraphRunner.runChain(baseUrl)
+    rundowns.forEach { rundown ->
+      assertThat(rundown.areAllStepsSuccessful).isTrue()
+      assertThat(rundown.firstUnIgnoredUnsuccessfulStepReport).isNull()
+      assertThat(rundown.stopReason).isEqualTo(StopReason.COMPLETED)
+    }
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/ModuleWiringTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/ModuleWiringTest.kt
@@ -1,0 +1,20 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.ReVoman
+import org.junit.jupiter.api.Test
+
+class ModuleWiringTest {
+  @Test
+  fun `ReVoman engine is on the harness module classpath`() {
+    // ReVoman is a Kotlin `object` (singleton); referencing it proves the project dep resolves.
+    assertThat(ReVoman.toString()).isNotEmpty()
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/contract/ContractAblationEvalTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/contract/ContractAblationEvalTest.kt
@@ -1,0 +1,38 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.contract
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.eval.EvalSet
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import org.junit.jupiter.api.Test
+
+class ContractAblationEvalTest {
+  private val cases = EvalSet.load()
+
+  @Test
+  fun `enriching the contract (adding when_not_to_use) improves accuracy on the eval set`() {
+    // Variant A: descriptors with when_not_to_use STRIPPED (the poorer contract).
+    val stripped = GraphRegistry.loadToolDefs().map { it.copy(whenNotToUse = emptyList()) }
+    // Variant B: enrich the 'quote' descriptor with the disambiguating clause (the richer contract).
+    val enriched =
+      stripped.map {
+        if (it.graphName == "quote")
+          it.copy(whenNotToUse = listOf("Do not use when the user asks for a price or cost — that is the price graph."))
+        else it
+      }
+
+    val (a, b) =
+      ContractAblationEval().compare(cases, "stripped" to stripped, "enriched" to enriched)
+
+    assertThat(a.variantName).isEqualTo("stripped")
+    assertThat(b.variantName).isEqualTo("enriched")
+    // The richer contract scores strictly higher — the blue box improved reasoning accuracy.
+    assertThat(b.accuracyCorrect).isGreaterThan(a.accuracyCorrect)
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/contract/ContractFidelityCheckTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/contract/ContractFidelityCheckTest.kt
@@ -1,0 +1,62 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.contract
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.GraphRunner
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.tooldef.GraphMetadataParser
+import com.salesforce.revoman.harness.tooldef.GraphOasLoader
+import com.salesforce.revoman.harness.tooldef.GraphSpec
+import com.salesforce.revoman.harness.tooldef.ToolDefGenerator
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ContractFidelityCheckTest {
+  private lateinit var server: MockCpqServer
+  private lateinit var baseUrl: String
+  private val check = ContractFidelityCheck()
+
+  @BeforeEach
+  fun setUp() {
+    server = MockCpqServer()
+    baseUrl = "http://127.0.0.1:${server.start()}"
+  }
+
+  @AfterEach fun tearDown() = server.stop()
+
+  private fun configureContract(): GraphContract {
+    val descriptor =
+      ToolDefGenerator.generate(GraphMetadataParser.parse("configure"), GraphOasLoader.load("configure"))
+    val slots = mapOf("productCode" to "SKU-1", "quantity" to "2")
+    val rundowns = GraphRunner.runChain(baseUrl, listOf("configure"), seedEnv = slots)
+    return GraphContract.of(descriptor, slots, rundowns.single())
+  }
+
+  @Test
+  fun `a graph whose runtime matches its declared metadata is faithful`() {
+    val spec = GraphMetadataParser.parse("configure")
+    val report = check.check(configureContract(), spec)
+    assertThat(report.faithful).isTrue()
+    assertThat(report.missingProduced).isEmpty()
+    assertThat(report.unexpectedProduced).isEmpty()
+  }
+
+  @Test
+  fun `a declared output the run never produced is caught as drift`() {
+    // Simulate metadata drift: the spec claims an extra output 'discountId' the graph never sets.
+    val driftedSpec =
+      GraphMetadataParser.parse("configure").let {
+        GraphSpec(it.name, it.description, it.slots, it.outputKeys + "discountId")
+      }
+    val report = check.check(configureContract(), driftedSpec)
+    assertThat(report.faithful).isFalse()
+    assertThat(report.missingProduced).contains("discountId")
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/contract/GraphContractTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/contract/GraphContractTest.kt
@@ -1,0 +1,59 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.contract
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.GraphRunner
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import com.salesforce.revoman.harness.tooldef.GraphMetadataParser
+import com.salesforce.revoman.harness.tooldef.GraphOasLoader
+import com.salesforce.revoman.harness.tooldef.ToolDefGenerator
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GraphContractTest {
+  private lateinit var server: MockCpqServer
+  private lateinit var baseUrl: String
+
+  @BeforeEach
+  fun setUp() {
+    server = MockCpqServer()
+    baseUrl = "http://127.0.0.1:${server.start()}"
+  }
+
+  @AfterEach fun tearDown() = server.stop()
+
+  private fun configureContract(): GraphContract {
+    val descriptor =
+      ToolDefGenerator.generate(GraphMetadataParser.parse("configure"), GraphOasLoader.load("configure"))
+    val slots = mapOf("productCode" to "SKU-1", "quantity" to "2")
+    val rundowns = GraphRunner.runChain(baseUrl, listOf("configure"), seedEnv = slots)
+    return GraphContract.of(descriptor, slots, rundowns.single())
+  }
+
+  @Test
+  fun `fuses descriptor, invocation slots, and runtime outcome into one object`() {
+    val contract = configureContract()
+    assertThat(contract.descriptor.graphName).isEqualTo("configure")
+    assertThat(contract.invocationSlots).containsEntry("productCode", "SKU-1")
+    assertThat(contract.succeeded).isTrue()
+    assertThat(contract.contractVersion).isEqualTo("1.0")
+  }
+
+  @Test
+  fun `dataFlow exposes provenance — configId was produced by the configure step`() {
+    val contract = configureContract()
+    val configIdEdge = contract.dataFlow.firstOrNull { it.key == "configId" }
+    assertThat(configIdEdge).isNotNull()
+    assertThat(configIdEdge!!.producedByStep).isNotNull()
+    // The producing step's name identifies where the value came from.
+    assertThat(configIdEdge.producedByStep).contains("configure")
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/contract/GraphContractWriterTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/contract/GraphContractWriterTest.kt
@@ -65,4 +65,14 @@ class GraphContractWriterTest {
     assertThat(json).contains("\"rundown\"")
     assertThat(json).contains("\"exampleQueries\"")
   }
+
+  @Test
+  fun `verbose output is syntactically valid parseable JSON`() {
+    val json = contract().toJson(Verbosity.VERBOSE)
+    // JSON is a subset of YAML; snakeyaml parses it and throws on malformed input.
+    val parsed = org.yaml.snakeyaml.Yaml().load<Map<String, Any?>>(json)
+    assertThat(parsed).isNotNull()
+    assertThat(parsed["graph"]).isEqualTo("configure")
+    assertThat(parsed["contractVersion"]).isEqualTo("1.0")
+  }
 }

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/contract/GraphContractWriterTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/contract/GraphContractWriterTest.kt
@@ -1,0 +1,68 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.contract
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.GraphRunner
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.tooldef.GraphMetadataParser
+import com.salesforce.revoman.harness.tooldef.GraphOasLoader
+import com.salesforce.revoman.harness.tooldef.ToolDefGenerator
+import com.salesforce.revoman.output.Verbosity
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GraphContractWriterTest {
+  private lateinit var server: MockCpqServer
+  private lateinit var baseUrl: String
+
+  @BeforeEach
+  fun setUp() {
+    server = MockCpqServer()
+    baseUrl = "http://127.0.0.1:${server.start()}"
+  }
+
+  @AfterEach fun tearDown() = server.stop()
+
+  private fun contract(): GraphContract {
+    val descriptor =
+      ToolDefGenerator.generate(GraphMetadataParser.parse("configure"), GraphOasLoader.load("configure"))
+    val slots = mapOf("productCode" to "SKU-1", "quantity" to "2")
+    val rundowns = GraphRunner.runChain(baseUrl, listOf("configure"), seedEnv = slots)
+    return GraphContract.of(descriptor, slots, rundowns.single())
+  }
+
+  @Test
+  fun `summary carries version, graph, invocation slots, and outcome stats but not descriptions`() {
+    val json = contract().toJson(Verbosity.SUMMARY)
+    assertThat(json).contains("\"contractVersion\"")
+    assertThat(json).contains("\"graph\"")
+    assertThat(json).contains("configure")
+    assertThat(json).contains("\"invocationSlots\"")
+    assertThat(json).contains("\"stopReason\"")
+    // SUMMARY omits the heavy descriptor prose and dataFlow.
+    assertThat(json).doesNotContain("\"whenToUse\"")
+    assertThat(json).doesNotContain("\"dataFlow\"")
+  }
+
+  @Test
+  fun `standard adds descriptor whenToUse and the dataFlow provenance block`() {
+    val json = contract().toJson(Verbosity.STANDARD)
+    assertThat(json).contains("\"whenToUse\"")
+    assertThat(json).contains("\"dataFlow\"")
+    assertThat(json).contains("configId") // a produced key appears in the lineage
+  }
+
+  @Test
+  fun `verbose embeds the full nested rundown json`() {
+    val json = contract().toJson(Verbosity.VERBOSE)
+    assertThat(json).contains("\"rundown\"")
+    assertThat(json).contains("\"exampleQueries\"")
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/BfclCheckTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/BfclCheckTest.kt
@@ -40,4 +40,28 @@ class BfclCheckTest {
     val results = SlotFillGoldSet.load().map { bfcl.check(it) }
     assertThat(results.all { it.pass }).isTrue()
   }
+
+  @Test
+  fun `a gold with a wrong slot value does not pass`() {
+    // Gold claims quantity=99, but the stub extracts 2 from the utterance -> slotsMatch false.
+    val gold =
+      SlotFillGold(
+        "configure 2 units of SKU-1",
+        "configure",
+        mapOf("productCode" to "SKU-1", "quantity" to "99"),
+      )
+    val result = bfcl.check(gold)
+    assertThat(result.graphMatch).isTrue()
+    assertThat(result.slotsMatch).isFalse()
+    assertThat(result.pass).isFalse()
+  }
+
+  @Test
+  fun `a gold with a wrong graph does not pass`() {
+    // "configure ..." routes to configure, but gold claims price -> graphMatch false.
+    val gold = SlotFillGold("configure 2 units of SKU-1", "price", mapOf("configId" to "cfg-1"))
+    val result = bfcl.check(gold)
+    assertThat(result.graphMatch).isFalse()
+    assertThat(result.pass).isFalse()
+  }
 }

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/BfclCheckTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/BfclCheckTest.kt
@@ -1,0 +1,43 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.eval
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.llm.StubLlmClient
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import org.junit.jupiter.api.Test
+
+class BfclCheckTest {
+  private val tools = GraphRegistry.loadToolDefs()
+  private val bfcl = BfclCheck(StubLlmClient(), tools)
+
+  @Test
+  fun `loads the slot-fill gold set`() {
+    assertThat(SlotFillGoldSet.load()).hasSize(3)
+  }
+
+  @Test
+  fun `predicted call matches gold for a configure utterance`() {
+    val gold =
+      SlotFillGold(
+        "configure 2 units of SKU-1",
+        "configure",
+        mapOf("productCode" to "SKU-1", "quantity" to "2"),
+      )
+    val result = bfcl.check(gold)
+    assertThat(result.graphMatch).isTrue()
+    assertThat(result.slotsMatch).isTrue()
+    assertThat(result.pass).isTrue()
+  }
+
+  @Test
+  fun `every gold case passes with the stub client`() {
+    val results = SlotFillGoldSet.load().map { bfcl.check(it) }
+    assertThat(results.all { it.pass }).isTrue()
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/ConfusionMatrixTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/ConfusionMatrixTest.kt
@@ -1,0 +1,38 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.eval
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class ConfusionMatrixTest {
+  @Test
+  fun `counts correct and off-diagonal predictions`() {
+    val pairs =
+      listOf(
+        "configure" to "configure",
+        "price" to "price",
+        "price" to "quote", // one off-diagonal miss
+        "quote" to "quote",
+      )
+    val m = ConfusionMatrices.from(pairs)
+    assertThat(m.total).isEqualTo(4)
+    assertThat(m.correct).isEqualTo(3)
+    assertThat(m.accuracy).isWithin(1e-9).of(0.75)
+    assertThat(m.counts["price"]!!["quote"]).isEqualTo(1)
+    assertThat(m.counts["price"]!!["price"]).isEqualTo(1)
+  }
+
+  @Test
+  fun `renders a labeled grid and treats a null prediction as none`() {
+    val m = ConfusionMatrices.from(listOf("configure" to null, "price" to "price"))
+    val text = m.render()
+    assertThat(text).contains("price")
+    assertThat(text).contains("none")
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/EvalSetTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/EvalSetTest.kt
@@ -1,0 +1,23 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.eval
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class EvalSetTest {
+  @Test
+  fun `loads the labeled router eval set`() {
+    val cases = EvalSet.load()
+    assertThat(cases).hasSize(7)
+    assertThat(cases.first()).isEqualTo(EvalCase("configure 2 units of SKU-1", "configure"))
+    assertThat(cases.map { it.expected }.toSet()).containsExactly("configure", "price", "quote")
+    // The deliberate near-miss: a price intent phrased with the word "quote".
+    assertThat(cases.last()).isEqualTo(EvalCase("quote me a price for this config", "price"))
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/LlmJudgeTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/LlmJudgeTest.kt
@@ -1,0 +1,50 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.eval
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.llm.StubLlmClient
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import com.salesforce.revoman.harness.orchestrator.Orchestrator
+import com.salesforce.revoman.harness.orchestrator.OrchestrationResult
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class LlmJudgeTest {
+  private lateinit var server: MockCpqServer
+  private lateinit var baseUrl: String
+  private val tools = GraphRegistry.loadToolDefs()
+
+  @BeforeEach
+  fun setUp() {
+    server = MockCpqServer()
+    baseUrl = "http://127.0.0.1:${server.start()}"
+  }
+
+  @AfterEach fun tearDown() = server.stop()
+
+  @Test
+  fun `judge screens a successful turn and ground truth confirms it`() {
+    val result =
+      Orchestrator(baseUrl, tools, StubLlmClient()).orchestrate("configure 2 units of SKU-1")
+    val executed = result as OrchestrationResult.Executed
+
+    val judgment = StubJudge().judge("configure 2 units of SKU-1", executed.context)
+    assertThat(judgment.pass).isTrue()
+
+    // The deterministic gate agrees — the judge is only a screen, not the source of truth.
+    assertThat(GroundTruth.allStepsSucceeded(executed.rundowns)).isTrue()
+  }
+
+  @Test
+  fun `judge fails an empty or unsuccessful context`() {
+    assertThat(StubJudge().judge("x", "no useful context here").pass).isFalse()
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/RouterEvaluatorTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/RouterEvaluatorTest.kt
@@ -1,0 +1,54 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.eval
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.llm.ScoringLlmClient
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import com.salesforce.revoman.harness.tooldef.ToolDef
+import org.junit.jupiter.api.Test
+
+class RouterEvaluatorTest {
+  private val cases = EvalSet.load()
+  private val evaluator = RouterEvaluator(ScoringLlmClient())
+
+  // Seed = the four fields as generated, but with when_not_to_use STRIPPED (un-calibrated start).
+  private val seedTools: List<ToolDef> =
+    GraphRegistry.loadToolDefs().map { it.copy(whenNotToUse = emptyList()) }
+
+  // Calibrated = add the disambiguating clause to the quote graph (mined from the off-diagonal).
+  private val calibratedTools: List<ToolDef> =
+    seedTools.map {
+      if (it.graphName == "quote")
+        it.copy(
+          whenNotToUse =
+            listOf("Do not use when the user asks for a price or cost — that is the price graph.")
+        )
+      else it
+    }
+
+  @Test
+  fun `seed router confuses the price-phrased-as-quote utterance`() {
+    val report = evaluator.evaluate(cases, seedTools)
+    assertThat(report.matrix.correct).isEqualTo(6)
+    assertThat(report.matrix.total).isEqualTo(7)
+    // The single off-diagonal: a price intent predicted as quote.
+    assertThat(report.matrix.counts["price"]!!["quote"]).isEqualTo(1)
+    assertThat(report.misses)
+      .contains(Miss("quote me a price for this config", "price", "quote"))
+  }
+
+  @Test
+  fun `adding the when_not_to_use clause moves accuracy to 100 percent`() {
+    val report = evaluator.evaluate(cases, calibratedTools)
+    assertThat(report.matrix.correct).isEqualTo(7)
+    assertThat(report.matrix.total).isEqualTo(7)
+    assertThat(report.misses).isEmpty()
+    assertThat(report.matrix.counts["price"]!!["quote"]).isEqualTo(0)
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/TauBenchCheckTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/TauBenchCheckTest.kt
@@ -1,0 +1,45 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.eval
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.llm.StubLlmClient
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class TauBenchCheckTest {
+  private lateinit var server: MockCpqServer
+  private lateinit var baseUrl: String
+  private val tools = GraphRegistry.loadToolDefs()
+
+  @BeforeEach
+  fun setUp() {
+    server = MockCpqServer()
+    baseUrl = "http://127.0.0.1:${server.start()}"
+  }
+
+  @AfterEach fun tearDown() = server.stop()
+
+  @Test
+  fun `configure task reaches the expected final DB state`() {
+    val check = TauBenchCheck(baseUrl, tools, StubLlmClient())
+    val passed = check.check(server, TaskCase("configure 2 units of SKU-1", listOf("SKU-1 x2")))
+    assertThat(passed).isTrue()
+  }
+
+  @Test
+  fun `an unmet final state fails the task`() {
+    val check = TauBenchCheck(baseUrl, tools, StubLlmClient())
+    val passed =
+      check.check(server, TaskCase("configure 2 units of SKU-1", listOf("SKU-9 x99")))
+    assertThat(passed).isFalse()
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/feedback/ConfirmGateTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/feedback/ConfirmGateTest.kt
@@ -1,0 +1,40 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.feedback
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class ConfirmGateTest {
+  private val proposal =
+    Proposal("configure 2 units of SKU-1", "configure", mapOf("productCode" to "SKU-1", "quantity" to "2"))
+
+  @Test
+  fun `confirm yields a positive label`() {
+    val label = ConfirmGate.apply(proposal, Decision.Confirm)
+    assertThat(label).isInstanceOf(FeedbackLabel.Positive::class.java)
+    assertThat((label as FeedbackLabel.Positive).proposal).isEqualTo(proposal)
+  }
+
+  @Test
+  fun `edit yields a correction pair carrying the fixed slots`() {
+    val fixed = mapOf("productCode" to "SKU-1", "quantity" to "5")
+    val label = ConfirmGate.apply(proposal, Decision.Edit(fixed))
+    assertThat(label).isInstanceOf(FeedbackLabel.CorrectionPair::class.java)
+    val pair = label as FeedbackLabel.CorrectionPair
+    assertThat(pair.proposal.slots).containsEntry("quantity", "2")
+    assertThat(pair.correctedSlots).containsEntry("quantity", "5")
+  }
+
+  @Test
+  fun `reject yields a negative label carrying the human's correct graph`() {
+    val label = ConfirmGate.apply(proposal, Decision.Reject(correctGraph = "price"))
+    assertThat(label).isInstanceOf(FeedbackLabel.Negative::class.java)
+    assertThat((label as FeedbackLabel.Negative).correctGraph).isEqualTo("price")
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/feedback/FlywheelClosesLoopTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/feedback/FlywheelClosesLoopTest.kt
@@ -1,0 +1,49 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.feedback
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.eval.EvalCase
+import com.salesforce.revoman.harness.eval.RouterEvaluator
+import com.salesforce.revoman.harness.llm.ScoringLlmClient
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import org.junit.jupiter.api.Test
+
+class FlywheelClosesLoopTest {
+  private val evaluator = RouterEvaluator(ScoringLlmClient())
+  private val seedTools = GraphRegistry.loadToolDefs().map { it.copy(whenNotToUse = emptyList()) }
+
+  @Test
+  fun `a rejected near-miss, mined by the nightly batch, tightens the CI gate`() {
+    // The confirm gate rejected the near-miss turn, stating the correct graph is price.
+    val labels =
+      listOf(
+        FeedbackLabel.Negative(
+          Proposal("quote me a price for this config", "quote", emptyMap()),
+          correctGraph = "price",
+        )
+      )
+    val seedEval = listOf(EvalCase("create a draft quote for prc-2", "quote"))
+
+    val batch = NightlyBatch.run(seedEval, labels)
+    // The batch grew the eval set with the regression case and drafted a clause on 'quote'.
+    assertThat(batch.grownEvalSet).contains(EvalCase("quote me a price for this config", "price"))
+    val drafted = batch.draftedClauses["quote"]!!
+
+    // Apply the drafted clause to the quote tool = the calibrated tools.
+    val calibratedTools =
+      seedTools.map { if (it.graphName == "quote") it.copy(whenNotToUse = drafted) else it }
+
+    val before = evaluator.evaluate(batch.grownEvalSet, seedTools)
+    val after = evaluator.evaluate(batch.grownEvalSet, calibratedTools)
+
+    // The auto-drafted clause strictly improves accuracy on the grown eval set — the flywheel works.
+    assertThat(after.matrix.correct).isGreaterThan(before.matrix.correct)
+    assertThat(after.misses).isEmpty()
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/feedback/NightlyBatchTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/feedback/NightlyBatchTest.kt
@@ -1,0 +1,66 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.feedback
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.eval.EvalCase
+import org.junit.jupiter.api.Test
+
+class NightlyBatchTest {
+  private val seed = listOf(EvalCase("configure 2 units of SKU-1", "configure"))
+
+  @Test
+  fun `confirmed turns append new golden cases to the eval set`() {
+    val labels =
+      listOf(
+        FeedbackLabel.Positive(Proposal("price configuration cfg-1", "price", mapOf("configId" to "cfg-1")))
+      )
+    val out = NightlyBatch.run(seed, labels)
+    assertThat(out.grownEvalSet).hasSize(2)
+    assertThat(out.grownEvalSet).contains(EvalCase("price configuration cfg-1", "price"))
+  }
+
+  @Test
+  fun `a reject with a known correct graph drafts a when_not_to_use clause and a regression case`() {
+    val labels =
+      listOf(
+        FeedbackLabel.Negative(
+          Proposal("quote me a price for this config", "quote", emptyMap()),
+          correctGraph = "price",
+        )
+      )
+    val out = NightlyBatch.run(seed, labels)
+    // A regression eval case pinning the correct answer.
+    assertThat(out.grownEvalSet).contains(EvalCase("quote me a price for this config", "price"))
+    // A drafted clause on the WRONGLY-chosen graph (quote), pointing at the correct one (price).
+    assertThat(out.draftedClauses.keys).contains("quote")
+    assertThat(out.draftedClauses["quote"]!!.single()).contains("price")
+  }
+
+  @Test
+  fun `a slot correction does not change the eval set or clauses`() {
+    val labels =
+      listOf(
+        FeedbackLabel.CorrectionPair(
+          Proposal("configure 2 units of SKU-1", "configure", mapOf("quantity" to "2")),
+          correctedSlots = mapOf("quantity" to "5"),
+        )
+      )
+    val out = NightlyBatch.run(seed, labels)
+    assertThat(out.grownEvalSet).isEqualTo(seed)
+    assertThat(out.draftedClauses).isEmpty()
+  }
+
+  @Test
+  fun `dedupes an already-present utterance`() {
+    val labels =
+      listOf(FeedbackLabel.Positive(Proposal("configure 2 units of SKU-1", "configure", emptyMap())))
+    val out = NightlyBatch.run(seed, labels)
+    assertThat(out.grownEvalSet).hasSize(1)
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/graph/GraphResourcesTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/graph/GraphResourcesTest.kt
@@ -1,0 +1,28 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.graph
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class GraphResourcesTest {
+  @Test
+  fun `each graph directory has a V3 definition on the classpath`() {
+    listOf("configure", "price", "quote").forEach { graph ->
+      val def = javaClass.classLoader.getResource("graphs/$graph/.resources/definition.yaml")
+      assertThat(def).isNotNull()
+    }
+  }
+
+  @Test
+  fun `price request references the configId placeholder threaded from configure`() {
+    val priceReq =
+      javaClass.classLoader.getResource("graphs/price/price-config.request.yaml")!!.readText()
+    assertThat(priceReq).contains("{{configId}}")
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/llm/RouteConfidenceTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/llm/RouteConfidenceTest.kt
@@ -1,0 +1,40 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.llm
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import org.junit.jupiter.api.Test
+
+class RouteConfidenceTest {
+  private val tools = GraphRegistry.loadToolDefs()
+  private val scoring = ScoringLlmClient()
+
+  @Test
+  fun `an unambiguous utterance routes with high margin`() {
+    val decision = scoring.route("configure 2 units of SKU-1", tools)
+    assertThat(decision.graphName).isEqualTo("configure")
+    assertThat(decision.confidence).isGreaterThan(0.0)
+    assertThat(decision.margin).isGreaterThan(0.0)
+  }
+
+  @Test
+  fun `scores exposes a per-graph score map`() {
+    val scores = scoring.scores("configure 2 units of SKU-1", tools)
+    assertThat(scores.keys).containsExactly("configure", "price", "quote")
+    assertThat(scores["configure"]!!).isGreaterThan(0)
+  }
+
+  @Test
+  fun `a no-match utterance has zero confidence and margin`() {
+    val decision = scoring.route("xyzzy plugh", tools)
+    assertThat(decision.graphName).isNull()
+    assertThat(decision.confidence).isEqualTo(0.0)
+    assertThat(decision.margin).isEqualTo(0.0)
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/llm/ScoringLlmClientTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/llm/ScoringLlmClientTest.kt
@@ -1,0 +1,55 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.llm
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.tooldef.GraphMetadataParser
+import com.salesforce.revoman.harness.tooldef.GraphOasLoader
+import com.salesforce.revoman.harness.tooldef.ToolDef
+import com.salesforce.revoman.harness.tooldef.ToolDefGenerator
+import org.junit.jupiter.api.Test
+
+class ScoringLlmClientTest {
+  // Seed tool defs with when_not_to_use STRIPPED — the un-calibrated starting point.
+  private val seedTools: List<ToolDef> =
+    listOf("configure", "price", "quote").map {
+      ToolDefGenerator.generate(GraphMetadataParser.parse(it), GraphOasLoader.load(it))
+        .copy(whenNotToUse = emptyList())
+    }
+  private val scoring = ScoringLlmClient()
+
+  @Test
+  fun `routes an unambiguous configure utterance`() {
+    assertThat(scoring.route("configure 2 units of SKU-1", seedTools).graphName).isEqualTo("configure")
+  }
+
+  @Test
+  fun `the price-phrased-as-quote utterance mis-routes to quote before calibration`() {
+    assertThat(scoring.route("quote me a price for this config", seedTools).graphName).isEqualTo("quote")
+  }
+
+  @Test
+  fun `adding a when_not_to_use clause to quote fixes the mis-route`() {
+    val calibrated =
+      seedTools.map {
+        if (it.graphName == "quote")
+          it.copy(
+            whenNotToUse =
+              listOf("Do not use when the user asks for a price or cost — that is the price graph.")
+          )
+        else it
+      }
+    assertThat(scoring.route("quote me a price for this config", calibrated).graphName)
+      .isEqualTo("price")
+  }
+
+  @Test
+  fun `returns null for an utterance that matches nothing`() {
+    assertThat(scoring.route("xyzzy plugh", seedTools).graphName).isNull()
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/llm/StubLlmClientTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/llm/StubLlmClientTest.kt
@@ -1,0 +1,51 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.llm
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.tooldef.GraphMetadataParser
+import com.salesforce.revoman.harness.tooldef.GraphOasLoader
+import com.salesforce.revoman.harness.tooldef.ToolDef
+import com.salesforce.revoman.harness.tooldef.ToolDefGenerator
+import org.junit.jupiter.api.Test
+
+class StubLlmClientTest {
+  private val tools: List<ToolDef> =
+    listOf("configure", "price", "quote").map {
+      ToolDefGenerator.generate(GraphMetadataParser.parse(it), GraphOasLoader.load(it))
+    }
+  private val stub = StubLlmClient()
+
+  @Test
+  fun `routes configure intent`() {
+    assertThat(stub.route("configure 2 units of SKU-1", tools).graphName).isEqualTo("configure")
+  }
+
+  @Test
+  fun `routes price intent`() {
+    assertThat(stub.route("how much does this configuration cost", tools).graphName).isEqualTo("price")
+  }
+
+  @Test
+  fun `routes quote intent`() {
+    assertThat(stub.route("create a draft quote", tools).graphName).isEqualTo("quote")
+  }
+
+  @Test
+  fun `returns null graph for an unrelated utterance`() {
+    assertThat(stub.route("what is the weather today", tools).graphName).isNull()
+  }
+
+  @Test
+  fun `fills configure slots from the utterance`() {
+    val configure = tools.first { it.graphName == "configure" }
+    val slots = stub.fillSlots("configure 2 units of SKU-1", configure)
+    assertThat(slots).containsEntry("productCode", "SKU-1")
+    assertThat(slots).containsEntry("quantity", "2")
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/mock/MockCpqServerTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/mock/MockCpqServerTest.kt
@@ -1,0 +1,69 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.mock
+
+import com.google.common.truth.Truth.assertThat
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse.BodyHandlers
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class MockCpqServerTest {
+  private lateinit var server: MockCpqServer
+  private var port: Int = 0
+  private val http: HttpClient = HttpClient.newHttpClient()
+
+  @BeforeEach
+  fun setUp() {
+    server = MockCpqServer()
+    port = server.start()
+  }
+
+  @AfterEach fun tearDown() = server.stop()
+
+  private fun post(path: String, json: String): Pair<Int, String> {
+    val resp =
+      http.send(
+        HttpRequest.newBuilder(URI.create("http://127.0.0.1:$port$path"))
+          .header("Content-Type", "application/json")
+          .POST(HttpRequest.BodyPublishers.ofString(json))
+          .build(),
+        BodyHandlers.ofString(),
+      )
+    return resp.statusCode() to resp.body()
+  }
+
+  @Test
+  fun `configure then price then quote chain succeeds`() {
+    val (cfgStatus, cfgBody) = post("/configure", """{"productCode":"SKU-1","quantity":2}""")
+    assertThat(cfgStatus).isEqualTo(200)
+    assertThat(cfgBody).contains("configId")
+
+    val configId = Regex(""""configId"\s*:\s*"([^"]+)"""").find(cfgBody)!!.groupValues[1]
+    val (prcStatus, prcBody) = post("/price", """{"configId":"$configId"}""")
+    assertThat(prcStatus).isEqualTo(200)
+    assertThat(prcBody).contains("priceId")
+    assertThat(prcBody).contains("total")
+
+    val priceId = Regex(""""priceId"\s*:\s*"([^"]+)"""").find(prcBody)!!.groupValues[1]
+    val (qotStatus, qotBody) = post("/quote", """{"priceId":"$priceId"}""")
+    assertThat(qotStatus).isEqualTo(200)
+    assertThat(qotBody).contains("quoteId")
+    assertThat(qotBody).contains("DRAFT")
+  }
+
+  @Test
+  fun `price with unknown configId is rejected`() {
+    val (status, body) = post("/price", """{"configId":"nope"}""")
+    assertThat(status).isEqualTo(400)
+    assertThat(body).contains("error")
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/orchestrator/OrchestratorContractTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/orchestrator/OrchestratorContractTest.kt
@@ -1,0 +1,50 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.orchestrator
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.contract.toJson
+import com.salesforce.revoman.harness.llm.StubLlmClient
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.output.Verbosity
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class OrchestratorContractTest {
+  private lateinit var server: MockCpqServer
+  private lateinit var baseUrl: String
+  private val tools = GraphRegistry.loadToolDefs()
+
+  @BeforeEach
+  fun setUp() {
+    server = MockCpqServer()
+    baseUrl = "http://127.0.0.1:${server.start()}"
+  }
+
+  @AfterEach fun tearDown() = server.stop()
+
+  @Test
+  fun `an executed turn carries a unified GraphContract`() {
+    val result =
+      Orchestrator(baseUrl, tools, StubLlmClient()).orchestrate("configure 2 units of SKU-1")
+    val executed = result as OrchestrationResult.Executed
+
+    assertThat(executed.contract).isNotNull()
+    val contract = executed.contract!!
+    assertThat(contract.descriptor.graphName).isEqualTo("configure")
+    assertThat(contract.invocationSlots).containsEntry("quantity", "2")
+    assertThat(contract.succeeded).isTrue()
+
+    // The unified contract renders both halves + provenance.
+    val json = contract.toJson(Verbosity.STANDARD)
+    assertThat(json).contains("\"whenToUse\"")
+    assertThat(json).contains("\"dataFlow\"")
+    assertThat(json).contains("configId")
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/orchestrator/OrchestratorTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/orchestrator/OrchestratorTest.kt
@@ -42,8 +42,9 @@ class OrchestratorTest {
     assertThat(executed.slots).containsEntry("quantity", "2")
     // The filled quantity (2) overrides the env-file default (1) — proof slots reach ReVoman.
     assertThat(server.db.values).contains("SKU-1 x2")
-    // Rundown context flows back for the LLM.
-    assertThat(executed.context).contains("areAllStepsSuccessful")
+    // Unified GraphContract context flows back for the LLM.
+    assertThat(executed.context).contains("succeeded")
+    assertThat(executed.context).contains("executedStepCount")
   }
 
   @Test

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/orchestrator/OrchestratorTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/orchestrator/OrchestratorTest.kt
@@ -1,0 +1,71 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.orchestrator
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.llm.LlmClient
+import com.salesforce.revoman.harness.llm.RouteDecision
+import com.salesforce.revoman.harness.llm.StubLlmClient
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.tooldef.ToolDef
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class OrchestratorTest {
+  private lateinit var server: MockCpqServer
+  private lateinit var baseUrl: String
+  private val tools: List<ToolDef> = GraphRegistry.loadToolDefs()
+
+  @BeforeEach
+  fun setUp() {
+    server = MockCpqServer()
+    baseUrl = "http://127.0.0.1:${server.start()}"
+  }
+
+  @AfterEach fun tearDown() = server.stop()
+
+  @Test
+  fun `configure intent routes, fills, executes, and records state`() {
+    val result =
+      Orchestrator(baseUrl, tools, StubLlmClient()).orchestrate("configure 2 units of SKU-1")
+
+    assertThat(result).isInstanceOf(OrchestrationResult.Executed::class.java)
+    val executed = result as OrchestrationResult.Executed
+    assertThat(executed.graph).isEqualTo("configure")
+    assertThat(executed.slots).containsEntry("productCode", "SKU-1")
+    assertThat(executed.slots).containsEntry("quantity", "2")
+    // The filled quantity (2) overrides the env-file default (1) — proof slots reach ReVoman.
+    assertThat(server.db.values).contains("SKU-1 x2")
+    // Rundown context flows back for the LLM.
+    assertThat(executed.context).contains("areAllStepsSuccessful")
+  }
+
+  @Test
+  fun `unrelated intent yields NoGraphMatched`() {
+    val result = Orchestrator(baseUrl, tools, StubLlmClient()).orchestrate("what is the weather")
+    assertThat(result).isInstanceOf(OrchestrationResult.NoGraphMatched::class.java)
+  }
+
+  @Test
+  fun `hallucinated slot value is rejected before execution`() {
+    // A fake LLM that routes to configure but fills an out-of-enum productCode.
+    val badLlm =
+      object : LlmClient {
+        override fun route(utterance: String, tools: List<ToolDef>) =
+          RouteDecision("configure", "forced")
+
+        override fun fillSlots(utterance: String, tool: ToolDef) =
+          mapOf("productCode" to "SKU-99", "quantity" to "2")
+      }
+    val result = Orchestrator(baseUrl, tools, badLlm).orchestrate("configure something")
+    assertThat(result).isInstanceOf(OrchestrationResult.SlotsRejected::class.java)
+    // Nothing was executed — the mock DB stays empty.
+    assertThat(server.db).isEmpty()
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/orchestrator/OrchestratorTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/orchestrator/OrchestratorTest.kt
@@ -42,9 +42,8 @@ class OrchestratorTest {
     assertThat(executed.slots).containsEntry("quantity", "2")
     // The filled quantity (2) overrides the env-file default (1) — proof slots reach ReVoman.
     assertThat(server.db.values).contains("SKU-1 x2")
-    // Unified GraphContract context flows back for the LLM.
-    assertThat(executed.context).contains("succeeded")
-    assertThat(executed.context).contains("executedStepCount")
+    // Rundown context flows back for the LLM.
+    assertThat(executed.context).contains("areAllStepsSuccessful")
   }
 
   @Test

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/orchestrator/OrchestratorTracingTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/orchestrator/OrchestratorTracingTest.kt
@@ -1,0 +1,56 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.orchestrator
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.llm.StubLlmClient
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.telemetry.GenAiTracer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class OrchestratorTracingTest {
+  private lateinit var server: MockCpqServer
+  private lateinit var baseUrl: String
+  private val tools = GraphRegistry.loadToolDefs()
+
+  @BeforeEach
+  fun setUp() {
+    server = MockCpqServer()
+    baseUrl = "http://127.0.0.1:${server.start()}"
+  }
+
+  @AfterEach fun tearDown() = server.stop()
+
+  @Test
+  fun `an executed turn emits invoke_agent with nested chat and execute_tool spans`() {
+    val tracer = GenAiTracer(sink = {})
+    Orchestrator(baseUrl, tools, StubLlmClient(), tracer)
+      .orchestrate("configure 2 units of SKU-1")
+
+    val root = tracer.rootSpans.single()
+    assertThat(root.name).isEqualTo("invoke_agent")
+    assertThat(root.attributes).containsEntry("gen_ai.operation.name", "invoke_agent")
+    val childNames = root.children.map { it.name }
+    // Two chat spans (route + slot-fill) then an execute_tool span.
+    assertThat(childNames).containsExactly("chat", "chat", "execute_tool").inOrder()
+    val executeTool = root.children.last()
+    assertThat(executeTool.attributes).containsEntry("gen_ai.tool.name", "configure")
+    assertThat(executeTool.attributes).containsEntry("steps", 1)
+    assertThat(executeTool.attributes.keys).contains("stop_reason")
+  }
+
+  @Test
+  fun `a no-match turn emits invoke_agent with only the routing chat span`() {
+    val tracer = GenAiTracer(sink = {})
+    Orchestrator(baseUrl, tools, StubLlmClient(), tracer).orchestrate("what is the weather")
+    val root = tracer.rootSpans.single()
+    assertThat(root.children.map { it.name }).containsExactly("chat")
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/orchestrator/SlotFillerTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/orchestrator/SlotFillerTest.kt
@@ -1,0 +1,85 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.orchestrator
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.llm.LlmClient
+import com.salesforce.revoman.harness.llm.RouteDecision
+import com.salesforce.revoman.harness.tooldef.SlotSchema
+import com.salesforce.revoman.harness.tooldef.SlotType
+import com.salesforce.revoman.harness.tooldef.ToolDef
+import org.junit.jupiter.api.Test
+
+class SlotFillerTest {
+  private val configureTool =
+    ToolDef(
+      graphName = "configure",
+      whenToUse = "configure a product",
+      whenNotToUse = emptyList(),
+      exampleQueries = emptyList(),
+      inputExamples = emptyList(),
+      slots =
+        mapOf(
+          "productCode" to SlotSchema(SlotType.ENUM, listOf("SKU-1", "SKU-2", "SKU-3")),
+          "quantity" to SlotSchema(SlotType.INT),
+        ),
+    )
+
+  /** A fake LlmClient that returns pre-canned slot values, so validation can be tested in isolation. */
+  private fun fakeLlm(filled: Map<String, String>): LlmClient =
+    object : LlmClient {
+      override fun route(utterance: String, tools: List<ToolDef>) = RouteDecision(null, "")
+
+      override fun fillSlots(utterance: String, tool: ToolDef) = filled
+    }
+
+  @Test
+  fun `accepts valid enum and int slots`() {
+    val result =
+      SlotFiller(fakeLlm(mapOf("productCode" to "SKU-1", "quantity" to "2")))
+        .fill("x", configureTool)
+    assertThat(result).isInstanceOf(FillResult.Valid::class.java)
+    assertThat((result as FillResult.Valid).slots).containsEntry("quantity", "2")
+  }
+
+  @Test
+  fun `rejects a hallucinated enum value`() {
+    val result =
+      SlotFiller(fakeLlm(mapOf("productCode" to "SKU-99", "quantity" to "2")))
+        .fill("x", configureTool)
+    assertThat(result).isInstanceOf(FillResult.Invalid::class.java)
+    assertThat((result as FillResult.Invalid).errors.joinToString()).contains("productCode")
+  }
+
+  @Test
+  fun `rejects a non-integer quantity`() {
+    val result =
+      SlotFiller(fakeLlm(mapOf("productCode" to "SKU-1", "quantity" to "lots")))
+        .fill("x", configureTool)
+    assertThat(result).isInstanceOf(FillResult.Invalid::class.java)
+    assertThat((result as FillResult.Invalid).errors.joinToString()).contains("quantity")
+  }
+
+  @Test
+  fun `rejects a missing required slot`() {
+    val result = SlotFiller(fakeLlm(mapOf("productCode" to "SKU-1"))).fill("x", configureTool)
+    assertThat(result).isInstanceOf(FillResult.Invalid::class.java)
+    assertThat((result as FillResult.Invalid).errors.joinToString()).contains("quantity")
+  }
+
+  @Test
+  fun `rejects a hallucinated slot name`() {
+    val result =
+      SlotFiller(
+          fakeLlm(mapOf("productCode" to "SKU-1", "quantity" to "2", "discountPct" to "50"))
+        )
+        .fill("x", configureTool)
+    assertThat(result).isInstanceOf(FillResult.Invalid::class.java)
+    assertThat((result as FillResult.Invalid).errors.joinToString()).contains("discountPct")
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/reasoning/ConfidencePolicyTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/reasoning/ConfidencePolicyTest.kt
@@ -1,0 +1,33 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.reasoning
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class ConfidencePolicyTest {
+  @Test
+  fun `write graphs default to the financial-services 0-90 band`() {
+    val policy = ConfidencePolicy()
+    assertThat(policy.isWrite("quote")).isTrue()
+    assertThat(policy.threshold("quote")).isEqualTo(0.90)
+  }
+
+  @Test
+  fun `read graphs use the default threshold`() {
+    val policy = ConfidencePolicy()
+    assertThat(policy.isWrite("configure")).isFalse()
+    assertThat(policy.threshold("configure")).isEqualTo(0.60)
+  }
+
+  @Test
+  fun `per-graph override wins over the write default`() {
+    val policy = ConfidencePolicy(perGraphThreshold = mapOf("quote" to 0.50))
+    assertThat(policy.threshold("quote")).isEqualTo(0.50)
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/reasoning/DisambiguationGateTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/reasoning/DisambiguationGateTest.kt
@@ -1,0 +1,62 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.reasoning
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.llm.RouteDecision
+import com.salesforce.revoman.harness.orchestrator.FillResult
+import org.junit.jupiter.api.Test
+
+class DisambiguationGateTest {
+  private val gate = DisambiguationGate()
+
+  @Test
+  fun `no route yields NoMatch`() {
+    val outcome = gate.decide(RouteDecision(null, "none", 0.0, 0.0), null, FillResult.Valid(emptyMap()), listOf("configure"))
+    assertThat(outcome).isInstanceOf(ReasoningOutcome.NoMatch::class.java)
+  }
+
+  @Test
+  fun `low margin asks instead of guessing`() {
+    // Confident-ish confidence but a tiny margin between the top two graphs.
+    val decision = RouteDecision("configure", "close call", confidence = 0.55, margin = 0.10)
+    val outcome =
+      gate.decide(decision, secondBestGraph = "price", FillResult.Valid(mapOf("productCode" to "SKU-1")), listOf("configure"))
+    assertThat(outcome).isInstanceOf(ReasoningOutcome.Clarify::class.java)
+    val clarify = outcome as ReasoningOutcome.Clarify
+    assertThat(clarify.candidates).containsExactly("configure", "price")
+  }
+
+  @Test
+  fun `a confident read proceeds`() {
+    val decision = RouteDecision("configure", "clear", confidence = 0.9, margin = 0.9)
+    val outcome =
+      gate.decide(decision, "price", FillResult.Valid(mapOf("productCode" to "SKU-1", "quantity" to "2")), listOf("configure"))
+    assertThat(outcome).isInstanceOf(ReasoningOutcome.Proceed::class.java)
+  }
+
+  @Test
+  fun `a confident write requires confirmation with a preview, not execution`() {
+    val decision = RouteDecision("quote", "clear", confidence = 0.95, margin = 0.95)
+    val outcome = gate.decide(decision, "price", FillResult.Valid(mapOf("priceId" to "prc-2")), listOf("quote"))
+    assertThat(outcome).isInstanceOf(ReasoningOutcome.ConfirmRequired::class.java)
+    val preview = (outcome as ReasoningOutcome.ConfirmRequired).preview
+    assertThat(preview.graph).isEqualTo("quote")
+    assertThat(preview.isWrite).isTrue()
+    assertThat(preview.slots).containsEntry("priceId", "prc-2")
+  }
+
+  @Test
+  fun `an invalid slot-fill asks for clarification`() {
+    val decision = RouteDecision("configure", "clear", confidence = 0.9, margin = 0.9)
+    val outcome =
+      gate.decide(decision, "price", FillResult.Invalid(listOf("missing required slot 'quantity'")), listOf("configure"))
+    assertThat(outcome).isInstanceOf(ReasoningOutcome.Clarify::class.java)
+    assertThat((outcome as ReasoningOutcome.Clarify).question).contains("quantity")
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/reasoning/ReasoningLayerTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/reasoning/ReasoningLayerTest.kt
@@ -1,0 +1,66 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.reasoning
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ReasoningLayerTest {
+  private lateinit var server: MockCpqServer
+  private lateinit var baseUrl: String
+  private val tools = GraphRegistry.loadToolDefs()
+
+  @BeforeEach
+  fun setUp() {
+    server = MockCpqServer()
+    baseUrl = "http://127.0.0.1:${server.start()}"
+  }
+
+  @AfterEach fun tearDown() = server.stop()
+
+  @Test
+  fun `a confident read proceeds without executing`() {
+    val outcome = ReasoningLayer(tools).handle("configure 2 units of SKU-1")
+    assertThat(outcome).isInstanceOf(ReasoningOutcome.Proceed::class.java)
+    assertThat(server.db).isEmpty() // handle() never executes
+  }
+
+  @Test
+  fun `a write intent requires confirmation and executes only on confirm`() {
+    val layer = ReasoningLayer(tools)
+    // Populate the database with the required price record so the quote can be created
+    server.db["price:prc-2"] = 100.0
+    val outcome = layer.handle("create a draft quote for prc-2")
+    assertThat(outcome).isInstanceOf(ReasoningOutcome.ConfirmRequired::class.java)
+    assertThat(server.db.size).isEqualTo(1) // only the price we added, nothing ran yet
+
+    val preview = (outcome as ReasoningOutcome.ConfirmRequired).preview
+    val rundowns = layer.confirm(preview, baseUrl)
+    assertThat(rundowns).isNotEmpty()
+    assertThat(server.db.values).contains("DRAFT") // now it ran
+  }
+
+  @Test
+  fun `an ambiguous intent asks instead of guessing and never executes`() {
+    // A high write-threshold (0.90) means a low-margin quote intent must ask.
+    val policy = ConfidencePolicy(perGraphThreshold = mapOf("configure" to 0.99))
+    val outcome = ReasoningLayer(tools, policy = policy).handle("configure or price this")
+    assertThat(outcome).isInstanceOf(ReasoningOutcome.Clarify::class.java)
+    assertThat(server.db).isEmpty()
+  }
+
+  @Test
+  fun `an unrelated intent is NoMatch`() {
+    assertThat(ReasoningLayer(tools).handle("what is the weather"))
+      .isInstanceOf(ReasoningOutcome.NoMatch::class.java)
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/reasoning/ReasoningLayerTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/reasoning/ReasoningLayerTest.kt
@@ -50,11 +50,22 @@ class ReasoningLayerTest {
   }
 
   @Test
-  fun `an ambiguous intent asks instead of guessing and never executes`() {
-    // A high write-threshold (0.90) means a low-margin quote intent must ask.
-    val policy = ConfidencePolicy(perGraphThreshold = mapOf("configure" to 0.99))
-    val outcome = ReasoningLayer(tools, policy = policy).handle("configure or price this")
+  fun `a slot-missing intent asks instead of guessing and never executes`() {
+    val outcome = ReasoningLayer(tools).handle("configure or price this")
     assertThat(outcome).isInstanceOf(ReasoningOutcome.Clarify::class.java)
+    assertThat(server.db).isEmpty()
+  }
+
+  @Test
+  fun `a low-margin intent asks which graph, never guessing or executing`() {
+    // Un-calibrated (when_not_to_use stripped) tools score price=2, quote=4 on this intent
+    // -> margin 0.5, below quote's 0.90 write-graph threshold -> the gate asks, never guesses.
+    val stripped = tools.map { it.copy(whenNotToUse = emptyList()) }
+    val outcome = ReasoningLayer(stripped).handle("price configuration or draft quote")
+    assertThat(outcome).isInstanceOf(ReasoningOutcome.Clarify::class.java)
+    val clarify = outcome as ReasoningOutcome.Clarify
+    assertThat(clarify.candidates.size).isAtLeast(2)
+    assertThat(clarify.question).contains("Did you mean")
     assertThat(server.db).isEmpty()
   }
 

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/retrieval/RetrievalPreFilterTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/retrieval/RetrievalPreFilterTest.kt
@@ -1,0 +1,50 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.retrieval
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import com.salesforce.revoman.harness.tooldef.SlotSchema
+import com.salesforce.revoman.harness.tooldef.SlotType
+import com.salesforce.revoman.harness.tooldef.ToolDef
+import org.junit.jupiter.api.Test
+
+class RetrievalPreFilterTest {
+  private val realTools = GraphRegistry.loadToolDefs()
+
+  @Test
+  fun `is a no-op when k is at least the number of tools`() {
+    val out = RetrievalPreFilter.topK("configure a product", realTools, k = 3)
+    assertThat(out).isEqualTo(realTools)
+  }
+
+  @Test
+  fun `narrows a large synthetic tool set to the relevant candidates`() {
+    // 10 synthetic graphs; only these three should surface for a pricing intent.
+    val tools =
+      (1..10).map { i ->
+        val (name, blurb) =
+          when (i) {
+            1 -> "price" to "compute the price and total cost of a configuration"
+            2 -> "discount" to "apply a pricing discount to a cost total"
+            3 -> "tax" to "compute tax on a price total"
+            else -> "graph$i" to "unrelated capability number $i about widgets and gadgets"
+          }
+        ToolDef(name, blurb, emptyList(), listOf(blurb), emptyList(),
+          mapOf("x" to SlotSchema(SlotType.STRING)))
+      }
+    val top3 = RetrievalPreFilter.topK("what is the price and cost total", tools, k = 3)
+    assertThat(top3.map { it.graphName }).containsExactly("price", "discount", "tax")
+  }
+
+  @Test
+  fun `never returns empty for k greater than zero even with no token overlap`() {
+    val out = RetrievalPreFilter.topK("zzzz qqqq", realTools, k = 2)
+    assertThat(out).hasSize(2)
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/telemetry/GenAiTracerTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/telemetry/GenAiTracerTest.kt
@@ -1,0 +1,53 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.telemetry
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class GenAiTracerTest {
+  @Test
+  fun `nests child spans under the parent and records attributes`() {
+    val tracer = GenAiTracer(sink = {})
+    tracer.span("invoke_agent", invokeAgentAttrs("q2c-agent")) { agent ->
+      tracer.span("chat", chatAttrs("stub")) { it.setAttribute("gen_ai.response.text", "configure") }
+      tracer.span("execute_tool", executeToolAttrs("configure")) { it.setAttribute("steps", 1) }
+      agent.setAttribute("turn.ok", true)
+    }
+
+    assertThat(tracer.rootSpans).hasSize(1)
+    val root = tracer.rootSpans.single()
+    assertThat(root.name).isEqualTo("invoke_agent")
+    assertThat(root.attributes).containsEntry("gen_ai.operation.name", "invoke_agent")
+    assertThat(root.attributes).containsEntry("turn.ok", true)
+    assertThat(root.children.map { it.name }).containsExactly("chat", "execute_tool").inOrder()
+    assertThat(root.children[1].attributes).containsEntry("gen_ai.tool.name", "configure")
+  }
+
+  @Test
+  fun `renders a nested indented tree and emits to the sink on root close`() {
+    val emitted = StringBuilder()
+    val tracer = GenAiTracer(sink = { emitted.append(it) })
+    tracer.span("invoke_agent", invokeAgentAttrs("q2c-agent")) {
+      tracer.span("chat", chatAttrs("stub")) {}
+    }
+    val text = emitted.toString()
+    assertThat(text).contains("invoke_agent")
+    assertThat(text).contains("chat")
+    assertThat(text).contains("gen_ai.operation.name=invoke_agent")
+    // The child is indented deeper than the parent.
+    assertThat(text.indexOf("chat")).isGreaterThan(text.indexOf("invoke_agent"))
+  }
+
+  @Test
+  fun `NoopTracer runs the block but records nothing`() {
+    val noop = NoopTracer()
+    val result = noop.span("invoke_agent") { 42 }
+    assertThat(result).isEqualTo(42)
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/tooldef/GraphMetadataParserTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/tooldef/GraphMetadataParserTest.kt
@@ -1,0 +1,38 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.tooldef
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class GraphMetadataParserTest {
+  @Test
+  fun `configure graph exposes productCode and quantity as slots and configId as output`() {
+    val spec = GraphMetadataParser.parse("configure")
+    assertThat(spec.name).isEqualTo("configure")
+    assertThat(spec.description).isNotEmpty()
+    assertThat(spec.slots).containsExactly("productCode", "quantity")
+    assertThat(spec.outputKeys).contains("configId")
+    // Infra placeholders are never slots.
+    assertThat(spec.slots).containsNoneOf("baseUrl", "accessToken")
+  }
+
+  @Test
+  fun `price graph consumes configId as its only slot and emits priceId`() {
+    val spec = GraphMetadataParser.parse("price")
+    assertThat(spec.slots).containsExactly("configId")
+    assertThat(spec.outputKeys).containsAtLeast("priceId", "total")
+  }
+
+  @Test
+  fun `quote graph consumes priceId as its only slot`() {
+    val spec = GraphMetadataParser.parse("quote")
+    assertThat(spec.slots).containsExactly("priceId")
+    assertThat(spec.outputKeys).contains("quoteId")
+  }
+}

--- a/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/tooldef/ToolDefGeneratorTest.kt
+++ b/agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/tooldef/ToolDefGeneratorTest.kt
@@ -1,0 +1,46 @@
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.tooldef
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class ToolDefGeneratorTest {
+  @Test
+  fun `generates the four fields from configure metadata and OAS`() {
+    val spec = GraphMetadataParser.parse("configure")
+    val oas = GraphOasLoader.load("configure")
+    val toolDef = ToolDefGenerator.generate(spec, oas)
+
+    assertThat(toolDef.graphName).isEqualTo("configure")
+    assertThat(toolDef.whenToUse).isEqualTo(spec.description)
+    assertThat(toolDef.whenNotToUse).isNotEmpty()
+    assertThat(toolDef.exampleQueries).hasSize(3)
+    assertThat(toolDef.inputExamples).isNotEmpty()
+    // The slot schema is carried through for the slot-filler/validator.
+    assertThat(toolDef.slots.keys).containsExactly("productCode", "quantity")
+    assertThat(toolDef.slots["productCode"]!!.type).isEqualTo(SlotType.ENUM)
+    assertThat(toolDef.slots["productCode"]!!.values).containsExactly("SKU-1", "SKU-2", "SKU-3")
+    assertThat(toolDef.slots["quantity"]!!.type).isEqualTo(SlotType.INT)
+  }
+
+  @Test
+  fun `rejects an OAS whose declared slots do not match the graph metadata`() {
+    val spec = GraphSpec("configure", "desc", slots = listOf("productCode", "quantity"), outputKeys = listOf("configId"))
+    val badOas =
+      GraphOas(
+        graph = "configure",
+        slots = mapOf("productCode" to SlotSchema(SlotType.ENUM, listOf("SKU-1"))), // missing 'quantity'
+        exampleQueries = listOf("x"),
+        inputExamples = listOf(mapOf("productCode" to "SKU-1")),
+      )
+    val ex = assertThrows<IllegalArgumentException> { ToolDefGenerator.generate(spec, badOas) }
+    assertThat(ex.message).contains("quantity")
+  }
+}

--- a/docs/superpowers/plans/2026-07-31-agentic-harness-stage1.md
+++ b/docs/superpowers/plans/2026-07-31-agentic-harness-stage1.md
@@ -1,0 +1,847 @@
+# Agentic Harness — Stage 1 (Deterministic Spine) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up a new `agentic-harness` Gradle module with a local mock CPQ server and three ReVoman V3 collections (`configure` → `price` → `quote`) that chain via `{{var}}` threading, executed by `ReVoman.revUp`, with a Layer-1 contract test asserting on the `Rundown`.
+
+**Architecture:** A new Gradle subproject depends on `:` (the ReVoman library) and reuses its transitive test deps. A JDK `com.sun.net.httpserver.HttpServer` (the same in-process mock idiom the library's own `ControlFlowE2ETest` uses — zero new dependencies) serves `/configure`, `/price`, `/quote` backed by an in-memory `MutableMap` "DB". Three V3 Postman collections (mirroring the format of `src/integrationTest/resources/pm-templates/v3/core`) point at the mock and thread data through `pm.environment.set(...)` + `{{var}}`. A `GraphRunner` calls `ReVoman.revUp(List<Kick>)` to run the chain and prints `Rundown.toJson(SUMMARY)`.
+
+**Tech Stack:** Kotlin (JVM 21), Gradle (`include(...)` submodule + `buildSrc` conventions), ReVoman library (project dep), JDK HttpServer, JUnit5 + Google Truth (assertions), Moshi (JSON, already transitive via ReVoman's http4k/moshix). No koog, no LLM, no API key in Stage 1.
+
+## Global Constraints
+
+- **JDK 21** runtime and build (`libs.versions.toml`: `jdk = "21"`).
+- **Never modify the ReVoman library** (`build.gradle.kts`, `src/main`, `src/test`, `src/integrationTest`). Only add the new module and one `include(...)` line in `settings.gradle.kts`.
+- **No new external dependencies in Stage 1.** Use the JDK HttpServer and deps already transitively provided by `project(":")` (Moshi, Truth via testImplementation, JUnit5).
+- **Formatting:** ktfmt Google style (spotless runs repo-wide). Run `./gradlew spotlessApply` before every commit or `spotlessCheck` fails the build.
+- **Copyright header:** every Kotlin source file in this repo starts with the standard SFDC Apache-2.0 header block (copy from any existing `src/main/kotlin/**/*.kt`). Apply it to every new `.kt`.
+- **Test convention:** JUnit5 (`@Test`, `org.junit.jupiter.api`) with Google Truth (`com.google.common.truth.Truth.assertThat`) — matches the library's `RestfulAPIDevKtTest`. Kotest bundle is also on the test classpath via `revoman.kt-conventions` if a spec style is preferred, but default to JUnit5+Truth for consistency with ReVoman's own revUp tests.
+- **ReVoman API (verified from source, do not re-derive):**
+  - Entry: `ReVoman.revUp(kick: Kick): Rundown`; overload `revUp(kicks: List<Kick>, postExeHook, dynamicEnvironment): List<Rundown>` threads the mutable env forward from each run into the next.
+  - `Kick.configure().templatePath(String).environmentPath(String)...off()` builds config; V3 templates are passed as a **directory** path resolved off the classpath.
+  - `Rundown` fields/props: `stopReason: StopReason` (`@JvmField`), `firstUnIgnoredUnsuccessfulStepReport: StepReport?`, `areAllStepsSuccessful: Boolean`, `mutableEnv: PostmanEnvironment<Any?>` (read via `getAsString(key)` / `get(key)`).
+  - `StopReason` enum values: `COMPLETED`, `HALTED_ON_FAILURE`, `LOOP_BUDGET_EXCEEDED` (+ a directive-stop). Happy path = `COMPLETED`.
+  - `Rundown.toJson(verbosity: Verbosity = STANDARD): String` is a Kotlin **extension function** in `com.salesforce.revoman.output` (`import com.salesforce.revoman.output.toJson`). `Verbosity.SUMMARY | STANDARD | VERBOSE`.
+- **V3 collection format (verified):** a directory with `.resources/definition.yaml` (`$kind: collection` + bearer auth) and one `*.request.yaml` per API (`$kind: http-request`, `url`/`method`/`headers`/`body`, `scripts` with `type: afterResponse`, and an `order:` int for sequencing). Edges are `pm.environment.set("k", v)` in one step + `{{k}}` referenced later. Env file is `*.environment.yaml` (`name:` + `values: [{key, value}]`). Only `bearer` auth is supported in V3.
+
+---
+
+### Task 1: Create the `agentic-harness` Gradle module skeleton
+
+**Files:**
+- Modify: `settings.gradle.kts` (add one `include("agentic-harness")` line, after `rootProject.name`)
+- Create: `agentic-harness/build.gradle.kts`
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/.gitkeep` (placeholder dir; removed when first source lands)
+- Create: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/ModuleWiringTest.kt`
+
+**Interfaces:**
+- Consumes: nothing (first task).
+- Produces: a buildable module `:agentic-harness` on the classpath of which `com.salesforce.revoman.ReVoman` (from `project(":")`) resolves.
+
+- [ ] **Step 1: Add the module to settings**
+
+In `settings.gradle.kts`, immediately after the line `rootProject.name = "revoman-root"`, add:
+
+```kotlin
+include("agentic-harness")
+```
+
+- [ ] **Step 2: Write the module build file**
+
+Create `agentic-harness/build.gradle.kts`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+plugins { id("revoman.kt-conventions") }
+
+dependencies {
+  // The deterministic execution engine. `project(":")` is the ReVoman library module.
+  implementation(project(":"))
+
+  val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+  // Truth for assertions, matching ReVoman's own revUp tests (RestfulAPIDevKtTest).
+  testImplementation(libs.findLibrary("truth").get())
+}
+```
+
+- [ ] **Step 3: Write a wiring test that proves ReVoman resolves from the module**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/ModuleWiringTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.ReVoman
+import org.junit.jupiter.api.Test
+
+class ModuleWiringTest {
+  @Test
+  fun `ReVoman engine is on the harness module classpath`() {
+    // ReVoman is a Kotlin `object` (singleton); referencing it proves the project dep resolves.
+    assertThat(ReVoman.toString()).isNotEmpty()
+  }
+}
+```
+
+- [ ] **Step 4: Run the wiring test — expect PASS**
+
+Run: `./gradlew :agentic-harness:test --tests "com.salesforce.revoman.harness.ModuleWiringTest"`
+Expected: BUILD SUCCESSFUL, 1 test passed. (If `include` or the project dep is wrong, compilation fails with "unresolved reference: ReVoman".)
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add settings.gradle.kts agentic-harness/build.gradle.kts \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/ModuleWiringTest.kt
+git commit -m "feat(harness): scaffold agentic-harness Gradle module"
+```
+
+(The `.gitkeep` under `src/main` is optional; skip it if the main source dir is created in Task 2.)
+
+---
+
+### Task 2: Mock CPQ server (`MockCpqServer`)
+
+**Files:**
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/mock/MockCpqServer.kt`
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/mock/MockCpqServerTest.kt`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks (uses JDK `com.sun.net.httpserver.HttpServer`).
+- Produces:
+  - `class MockCpqServer` with:
+    - `fun start(): Int` — binds `127.0.0.1:0`, starts, returns the actual bound port.
+    - `fun stop()` — stops the server (delay 0).
+    - `val db: MutableMap<String, Any?>` — the in-memory "DB" (later tasks/Stage 3 assert on it).
+  - Endpoints (all `POST`, JSON in/out):
+    - `POST /configure` body `{ "productCode": String, "quantity": Int }` → 200 `{ "configId": "cfg-<n>" }`; records `db["config:<id>"] = productCode+quantity`.
+    - `POST /price` body `{ "configId": String }` → 200 `{ "priceId": "prc-<n>", "total": <Double> }` when the configId exists in `db`, else 400 `{ "error": "unknown configId" }`.
+    - `POST /quote` body `{ "priceId": String }` → 200 `{ "quoteId": "qot-<n>", "status": "DRAFT" }` when priceId exists, else 400. Records `db["quote:<id>"] = "DRAFT"`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/mock/MockCpqServerTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.mock
+
+import com.google.common.truth.Truth.assertThat
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse.BodyHandlers
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class MockCpqServerTest {
+  private lateinit var server: MockCpqServer
+  private var port: Int = 0
+  private val http: HttpClient = HttpClient.newHttpClient()
+
+  @BeforeEach
+  fun setUp() {
+    server = MockCpqServer()
+    port = server.start()
+  }
+
+  @AfterEach fun tearDown() = server.stop()
+
+  private fun post(path: String, json: String): Pair<Int, String> {
+    val resp =
+      http.send(
+        HttpRequest.newBuilder(URI.create("http://127.0.0.1:$port$path"))
+          .header("Content-Type", "application/json")
+          .POST(HttpRequest.BodyPublishers.ofString(json))
+          .build(),
+        BodyHandlers.ofString(),
+      )
+    return resp.statusCode() to resp.body()
+  }
+
+  @Test
+  fun `configure then price then quote chain succeeds`() {
+    val (cfgStatus, cfgBody) = post("/configure", """{"productCode":"SKU-1","quantity":2}""")
+    assertThat(cfgStatus).isEqualTo(200)
+    assertThat(cfgBody).contains("configId")
+
+    val configId = Regex(""""configId"\s*:\s*"([^"]+)"""").find(cfgBody)!!.groupValues[1]
+    val (prcStatus, prcBody) = post("/price", """{"configId":"$configId"}""")
+    assertThat(prcStatus).isEqualTo(200)
+    assertThat(prcBody).contains("priceId")
+    assertThat(prcBody).contains("total")
+
+    val priceId = Regex(""""priceId"\s*:\s*"([^"]+)"""").find(prcBody)!!.groupValues[1]
+    val (qotStatus, qotBody) = post("/quote", """{"priceId":"$priceId"}""")
+    assertThat(qotStatus).isEqualTo(200)
+    assertThat(qotBody).contains("quoteId")
+    assertThat(qotBody).contains("DRAFT")
+  }
+
+  @Test
+  fun `price with unknown configId is rejected`() {
+    val (status, body) = post("/price", """{"configId":"nope"}""")
+    assertThat(status).isEqualTo(400)
+    assertThat(body).contains("error")
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :agentic-harness:test --tests "*MockCpqServerTest"`
+Expected: FAIL — compilation error "unresolved reference: MockCpqServer".
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/mock/MockCpqServer.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.mock
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * A local, in-process mock of the three Revenue-Cloud CPQ endpoints the harness graphs execute
+ * against — [/configure], [/price], [/quote]. Backed by an in-memory [db] map that stands in for
+ * the org's records (Stage 3's tau-bench-style checks assert on this final state). Uses the JDK
+ * [HttpServer], the same zero-dependency mock idiom ReVoman's own `ControlFlowE2ETest` uses.
+ */
+class MockCpqServer {
+  val db: MutableMap<String, Any?> = LinkedHashMap()
+  private val seq = AtomicInteger(0)
+  private lateinit var server: HttpServer
+
+  fun start(): Int {
+    server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+    server.createContext("/configure") { ex -> handleConfigure(ex) }
+    server.createContext("/price") { ex -> handlePrice(ex) }
+    server.createContext("/quote") { ex -> handleQuote(ex) }
+    server.start()
+    return server.address.port
+  }
+
+  fun stop() = server.stop(0)
+
+  // --- handlers -----------------------------------------------------------------------------
+
+  private fun handleConfigure(ex: HttpExchange) {
+    val body = ex.readBody()
+    val productCode = body.field("productCode") ?: return ex.respond(400, """{"error":"missing productCode"}""")
+    val quantity = body.field("quantity") ?: "1"
+    val configId = "cfg-${seq.incrementAndGet()}"
+    db["config:$configId"] = "$productCode x$quantity"
+    ex.respond(200, """{"configId":"$configId"}""")
+  }
+
+  private fun handlePrice(ex: HttpExchange) {
+    val body = ex.readBody()
+    val configId = body.field("configId")
+    if (configId == null || !db.containsKey("config:$configId")) {
+      return ex.respond(400, """{"error":"unknown configId"}""")
+    }
+    val priceId = "prc-${seq.incrementAndGet()}"
+    val total = 100.0 // deterministic stub price
+    db["price:$priceId"] = total
+    ex.respond(200, """{"priceId":"$priceId","total":$total}""")
+  }
+
+  private fun handleQuote(ex: HttpExchange) {
+    val body = ex.readBody()
+    val priceId = body.field("priceId")
+    if (priceId == null || !db.containsKey("price:$priceId")) {
+      return ex.respond(400, """{"error":"unknown priceId"}""")
+    }
+    val quoteId = "qot-${seq.incrementAndGet()}"
+    db["quote:$quoteId"] = "DRAFT"
+    ex.respond(200, """{"quoteId":"$quoteId","status":"DRAFT"}""")
+  }
+
+  // --- tiny JSON helpers (no dep; naive on purpose — bodies are flat + trusted) --------------
+
+  private fun HttpExchange.readBody(): String = requestBody.readBytes().decodeToString()
+
+  /** Extracts a flat JSON string/number field value by key, or null. */
+  private fun String.field(key: String): String? =
+    Regex(""""$key"\s*:\s*"?([^",}\s]+)"?""").find(this)?.groupValues?.get(1)
+
+  private fun HttpExchange.respond(status: Int, json: String) {
+    val bytes = json.encodeToByteArray()
+    responseHeaders.add("Content-Type", "application/json")
+    sendResponseHeaders(status, bytes.size.toLong())
+    responseBody.use { it.write(bytes) }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./gradlew :agentic-harness:test --tests "*MockCpqServerTest"`
+Expected: BUILD SUCCESSFUL, 2 tests passed.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/mock/MockCpqServer.kt \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/mock/MockCpqServerTest.kt
+git commit -m "feat(harness): in-memory mock CPQ server (configure/price/quote)"
+```
+
+---
+
+### Task 3: Author the three V3 graph collections
+
+**Files (all under `agentic-harness/src/main/resources/graphs/`):**
+- Create: `configure/.resources/definition.yaml`
+- Create: `configure/configure-product.request.yaml`
+- Create: `configure/configure.environment.yaml`
+- Create: `price/.resources/definition.yaml`
+- Create: `price/price-config.request.yaml`
+- Create: `price/price.environment.yaml`
+- Create: `quote/.resources/definition.yaml`
+- Create: `quote/quote-price.request.yaml`
+- Create: `quote/quote.environment.yaml`
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/graph/GraphResourcesTest.kt`
+
+**Interfaces:**
+- Consumes: the mock server's endpoint contracts from Task 2.
+- Produces: three classpath-resolvable V3 collection directories. Env edge keys (later tasks depend on these exact names): `configId` (set by configure), `priceId` (set by price), `quoteId` (set by quote). Each graph reads `{{baseUrl}}` from its environment.
+
+- [ ] **Step 1: Write the failing test (resources exist + parse)**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/graph/GraphResourcesTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.graph
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class GraphResourcesTest {
+  @Test
+  fun `each graph directory has a V3 definition on the classpath`() {
+    listOf("configure", "price", "quote").forEach { graph ->
+      val def = javaClass.classLoader.getResource("graphs/$graph/.resources/definition.yaml")
+      assertThat(def).isNotNull()
+    }
+  }
+
+  @Test
+  fun `price request references the configId placeholder threaded from configure`() {
+    val priceReq =
+      javaClass.classLoader.getResource("graphs/price/price-config.request.yaml")!!.readText()
+    assertThat(priceReq).contains("{{configId}}")
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :agentic-harness:test --tests "*GraphResourcesTest"`
+Expected: FAIL — `def` is null / resource not found.
+
+- [ ] **Step 3: Create the `configure` graph**
+
+`agentic-harness/src/main/resources/graphs/configure/.resources/definition.yaml`:
+
+```yaml
+$kind: collection
+description: "Configure a product: turn a product code + quantity into a saved configuration."
+auth:
+  - id: cfg-auth
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{accessToken}}"
+```
+
+`agentic-harness/src/main/resources/graphs/configure/configure-product.request.yaml`:
+
+```yaml
+$kind: http-request
+url: "{{baseUrl}}/configure"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: text
+  content: |-
+    {"productCode":"{{productCode}}","quantity":{{quantity}}}
+scripts:
+  - type: afterResponse
+    code: |-
+      var res = pm.response.json()
+      pm.environment.set("configId", res.configId)
+    language: text/javascript
+order: 1000
+```
+
+`agentic-harness/src/main/resources/graphs/configure/configure.environment.yaml`:
+
+```yaml
+name: configure
+values:
+  - key: baseUrl
+    value: "http://127.0.0.1:0"
+  - key: accessToken
+    value: "local-dev-token"
+  - key: productCode
+    value: "SKU-1"
+  - key: quantity
+    value: "1"
+```
+
+- [ ] **Step 4: Create the `price` graph**
+
+`agentic-harness/src/main/resources/graphs/price/.resources/definition.yaml`:
+
+```yaml
+$kind: collection
+description: "Price a saved configuration: compute the total for a configId."
+auth:
+  - id: prc-auth
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{accessToken}}"
+```
+
+`agentic-harness/src/main/resources/graphs/price/price-config.request.yaml`:
+
+```yaml
+$kind: http-request
+url: "{{baseUrl}}/price"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: text
+  content: |-
+    {"configId":"{{configId}}"}
+scripts:
+  - type: afterResponse
+    code: |-
+      var res = pm.response.json()
+      pm.environment.set("priceId", res.priceId)
+      pm.environment.set("total", res.total)
+    language: text/javascript
+order: 1000
+```
+
+`agentic-harness/src/main/resources/graphs/price/price.environment.yaml`:
+
+```yaml
+name: price
+values:
+  - key: baseUrl
+    value: "http://127.0.0.1:0"
+  - key: accessToken
+    value: "local-dev-token"
+  - key: configId
+    value: ""
+```
+
+- [ ] **Step 5: Create the `quote` graph**
+
+`agentic-harness/src/main/resources/graphs/quote/.resources/definition.yaml`:
+
+```yaml
+$kind: collection
+description: "Quote a priced configuration: create a draft quote from a priceId."
+auth:
+  - id: qot-auth
+    type: bearer
+    name: bearer auth
+    credentials:
+      token: "{{accessToken}}"
+```
+
+`agentic-harness/src/main/resources/graphs/quote/quote-price.request.yaml`:
+
+```yaml
+$kind: http-request
+url: "{{baseUrl}}/quote"
+method: POST
+headers:
+  Content-Type: application/json
+body:
+  type: text
+  content: |-
+    {"priceId":"{{priceId}}"}
+scripts:
+  - type: afterResponse
+    code: |-
+      var res = pm.response.json()
+      pm.environment.set("quoteId", res.quoteId)
+      pm.environment.set("quoteStatus", res.status)
+    language: text/javascript
+order: 1000
+```
+
+`agentic-harness/src/main/resources/graphs/quote/quote.environment.yaml`:
+
+```yaml
+name: quote
+values:
+  - key: baseUrl
+    value: "http://127.0.0.1:0"
+  - key: accessToken
+    value: "local-dev-token"
+  - key: priceId
+    value: ""
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `./gradlew :agentic-harness:test --tests "*GraphResourcesTest"`
+Expected: BUILD SUCCESSFUL, 2 tests passed.
+
+- [ ] **Step 7: Commit** (no Kotlin changed, so spotless is a no-op but run it anyway)
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/main/resources/graphs \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/graph/GraphResourcesTest.kt
+git commit -m "feat(harness): V3 graph collections configure/price/quote (var-threaded)"
+```
+
+---
+
+### Task 4: `GraphRunner` — run the chain via ReVoman and thread env forward
+
+**Files:**
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/GraphRunner.kt`
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/GraphRunnerTest.kt`
+
+**Interfaces:**
+- Consumes: `MockCpqServer` (Task 2) for the live `baseUrl`; the V3 resources under `graphs/` (Task 3).
+- Produces:
+  - `object GraphRunner` (or `class`) with:
+    - `fun runChain(baseUrl: String, graphs: List<String> = listOf("configure", "price", "quote"), seedEnv: Map<String, Any?> = emptyMap()): List<Rundown>` — builds one `Kick` per graph via `Kick.configure().templatePath("graphs/<g>").environmentPath("graphs/<g>/<g>.environment.yaml").dynamicEnvironment(mapOf("baseUrl" to baseUrl) + seedEnv).off()` and calls `ReVoman.revUp(kicks, ...)` so env threads forward.
+    - `fun runChainAndSummarize(baseUrl: String, ...): String` — runs the chain and returns the concatenated `toJson(Verbosity.SUMMARY)` of each Rundown.
+  - Note: `dynamicEnvironment` overrides the `baseUrl` placeholder (env file ships `http://127.0.0.1:0`, replaced at runtime with the real bound port). The `List<Kick>` overload threads `configId`/`priceId` forward automatically (verified: `revUp(List<Kick>)` folds `mutableEnv.immutableEnv` into the next kick).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/GraphRunnerTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GraphRunnerTest {
+  private lateinit var server: MockCpqServer
+  private var baseUrl: String = ""
+
+  @BeforeEach
+  fun setUp() {
+    server = MockCpqServer()
+    baseUrl = "http://127.0.0.1:${server.start()}"
+  }
+
+  @AfterEach fun tearDown() = server.stop()
+
+  @Test
+  fun `configure-price-quote chain threads ids forward and lands a draft quote`() {
+    val rundowns = GraphRunner.runChain(baseUrl)
+
+    // Three graphs ran, each with no failing step.
+    assertThat(rundowns).hasSize(3)
+    rundowns.forEach { assertThat(it.firstUnIgnoredUnsuccessfulStepReport).isNull() }
+
+    // The final env carries the threaded ids — proof {{var}} edges connected the graphs.
+    val finalEnv = rundowns.last().mutableEnv
+    assertThat(finalEnv.getAsString("configId")).startsWith("cfg-")
+    assertThat(finalEnv.getAsString("priceId")).startsWith("prc-")
+    assertThat(finalEnv.getAsString("quoteId")).startsWith("qot-")
+
+    // The mock "DB" recorded a DRAFT quote (tau-bench-style state proof, previewed here).
+    assertThat(server.db.values).contains("DRAFT")
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :agentic-harness:test --tests "*GraphRunnerTest"`
+Expected: FAIL — "unresolved reference: GraphRunner".
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/GraphRunner.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness
+
+import com.salesforce.revoman.ReVoman
+import com.salesforce.revoman.input.config.Kick
+import com.salesforce.revoman.output.Rundown
+import com.salesforce.revoman.output.Verbosity
+import com.salesforce.revoman.output.toJson
+
+/**
+ * The deterministic worker: runs one or more ReVoman V3 graph collections in order, threading the
+ * mutable environment forward from each graph into the next (this is the {{var}} edge mechanism —
+ * no LLM, no @{ref.id} operator). Wraps `ReVoman.revUp(List<Kick>)`.
+ */
+object GraphRunner {
+  val DEFAULT_CHAIN: List<String> = listOf("configure", "price", "quote")
+
+  fun runChain(
+    baseUrl: String,
+    graphs: List<String> = DEFAULT_CHAIN,
+    seedEnv: Map<String, Any?> = emptyMap(),
+  ): List<Rundown> {
+    val runtimeEnv: Map<String, Any?> = mapOf("baseUrl" to baseUrl) + seedEnv
+    val kicks =
+      graphs.map { graph ->
+        Kick.configure()
+          .templatePath("graphs/$graph")
+          .environmentPath("graphs/$graph/$graph.environment.yaml")
+          .dynamicEnvironment(runtimeEnv)
+          .off()
+      }
+    return ReVoman.revUp(kicks)
+  }
+
+  fun runChainAndSummarize(
+    baseUrl: String,
+    graphs: List<String> = DEFAULT_CHAIN,
+    seedEnv: Map<String, Any?> = emptyMap(),
+  ): String =
+    runChain(baseUrl, graphs, seedEnv).joinToString("\n") { it.toJson(Verbosity.SUMMARY) }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :agentic-harness:test --tests "*GraphRunnerTest"`
+Expected: BUILD SUCCESSFUL, 1 test passed.
+
+If it fails on `dynamicEnvironment` not overriding `baseUrl`: the V3 env file value (`http://127.0.0.1:0`) is a fallback; `dynamicEnvironment(...)` merges at runtime and takes precedence over the environment file. Confirm the env key name is exactly `baseUrl`. If the `{{quantity}}` numeric placeholder produces invalid JSON (quoted), change the configure body to `"quantity":{{quantity}}` (already unquoted above) and ensure the env ships `quantity` as `"1"`.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/GraphRunner.kt \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/GraphRunnerTest.kt
+git commit -m "feat(harness): GraphRunner runs V3 graph chain via ReVoman.revUp"
+```
+
+---
+
+### Task 5: Layer-1 contract test + runnable `main()` demo
+
+**Files:**
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/Stage1Demo.kt`
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/Layer1ContractTest.kt`
+- Modify: `agentic-harness/build.gradle.kts` (add an `application`-style run task for the demo `main`)
+
+**Interfaces:**
+- Consumes: `MockCpqServer` (Task 2), `GraphRunner` (Task 4).
+- Produces:
+  - `fun main()` in `Stage1Demo.kt` — boots the mock, runs the chain, prints each Rundown's SUMMARY json, stops the mock.
+  - A gradle task `:agentic-harness:runStage1Demo` (type `JavaExec`) that runs `Stage1DemoKt`.
+
+- [ ] **Step 1: Write the failing Layer-1 contract test**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/Layer1ContractTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.output.StopReason
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * The design's "evals Layer 1" beat: deterministic API-graph contract tests, no LLM. Runs the
+ * graph chain against the mock and asserts on the Rundown — the exact same engine that will run
+ * graphs at agent runtime.
+ */
+class Layer1ContractTest {
+  private lateinit var server: MockCpqServer
+  private var baseUrl: String = ""
+
+  @BeforeEach
+  fun setUp() {
+    server = MockCpqServer()
+    baseUrl = "http://127.0.0.1:${server.start()}"
+  }
+
+  @AfterEach fun tearDown() = server.stop()
+
+  @Test
+  fun `every graph in the chain completes with no unsuccessful step`() {
+    val rundowns = GraphRunner.runChain(baseUrl)
+    rundowns.forEach { rundown ->
+      assertThat(rundown.areAllStepsSuccessful).isTrue()
+      assertThat(rundown.firstUnIgnoredUnsuccessfulStepReport).isNull()
+      assertThat(rundown.stopReason).isEqualTo(StopReason.COMPLETED)
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :agentic-harness:test --tests "*Layer1ContractTest"`
+Expected: FAIL — compiles (GraphRunner exists) but this is the first run asserting `stopReason`; if any graph mis-chains it fails on `areAllStepsSuccessful`. If it passes immediately because Task 4 already made the chain green, that is acceptable — this task's deliverable is the contract assertion + demo, not new production code. Proceed.
+
+- [ ] **Step 3: Write the demo `main()`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/Stage1Demo.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness
+
+import com.salesforce.revoman.harness.mock.MockCpqServer
+
+/**
+ * Stage 1 runnable demo: boot the mock CPQ server, run the configure->price->quote graph chain
+ * through ReVoman, and print each Rundown summary. This is the deterministic worker, end to end,
+ * with no LLM involved.
+ */
+fun main() {
+  val server = MockCpqServer()
+  val baseUrl = "http://127.0.0.1:${server.start()}"
+  try {
+    println("Mock CPQ server up at $baseUrl")
+    println(GraphRunner.runChainAndSummarize(baseUrl))
+    println("Final mock DB state: ${server.db}")
+  } finally {
+    server.stop()
+  }
+}
+```
+
+- [ ] **Step 4: Add the run task to the module build file**
+
+Append to `agentic-harness/build.gradle.kts`:
+
+```kotlin
+tasks.register<JavaExec>("runStage1Demo") {
+  group = "harness"
+  description = "Boot the mock CPQ server and run the configure->price->quote graph chain"
+  mainClass.set("com.salesforce.revoman.harness.Stage1DemoKt")
+  classpath = sourceSets["main"].runtimeClasspath
+}
+```
+
+- [ ] **Step 5: Run the contract test and the demo**
+
+Run: `./gradlew :agentic-harness:test --tests "*Layer1ContractTest"`
+Expected: BUILD SUCCESSFUL, 1 test passed.
+
+Run: `./gradlew :agentic-harness:runStage1Demo -q`
+Expected output (ids will vary): a line `Mock CPQ server up at http://127.0.0.1:<port>`, three JSON summary blocks each showing success, and `Final mock DB state: {config:cfg-1=SKU-1 x1, price:prc-2=100.0, quote:qot-3=DRAFT}`.
+
+- [ ] **Step 6: Run the whole module suite to confirm Stage 1 is green end to end**
+
+Run: `./gradlew :agentic-harness:test`
+Expected: BUILD SUCCESSFUL — `ModuleWiringTest`, `MockCpqServerTest`, `GraphResourcesTest`, `GraphRunnerTest`, `Layer1ContractTest` all pass.
+
+- [ ] **Step 7: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/Stage1Demo.kt \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/Layer1ContractTest.kt \
+  agentic-harness/build.gradle.kts
+git commit -m "feat(harness): Layer-1 contract test + runnable Stage 1 demo"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (Stage 1 rows of the spec's concept-to-component map):**
+- Deterministic worker (`MockCpqServer` + V3 graphs chaining via `{{var}}`) → Tasks 2, 3. ✓
+- `revUp(Kick): Rundown` (`GraphRunner`) → Task 4. ✓
+- Evals Layer 1 (contract test on `Rundown`) → Task 5. ✓
+- Module isolation (new submodule, library untouched) → Task 1. ✓
+- Runnable proof (`main()` + green suite) → Task 5 Steps 5–6. ✓
+- Stages 2–4 are explicitly out of scope for this plan (each gets its own plan so it stays independently runnable, per the spec's staging).
+
+**Placeholder scan:** No TBD/TODO/"add error handling"/"similar to Task N". Every code step shows complete code. ✓
+
+**Type consistency:** `MockCpqServer.start(): Int`, `.stop()`, `.db` used identically in Tasks 2, 4, 5. `GraphRunner.runChain(baseUrl, graphs, seedEnv): List<Rundown>` and `runChainAndSummarize(...)` used identically in Tasks 4, 5. Env edge keys `configId`/`priceId`/`quoteId` set in Task 3 YAML and asserted in Tasks 4, 5. `StopReason.COMPLETED`, `Rundown.areAllStepsSuccessful`, `firstUnIgnoredUnsuccessfulStepReport`, `mutableEnv.getAsString(...)`, `toJson(Verbosity.SUMMARY)` all match verified library API. ✓
+
+**Known risk flagged in-plan (Task 4 Step 4):** ReVoman `dynamicEnvironment` precedence over the V3 env-file `baseUrl`, and numeric-placeholder JSON validity. Both have inline remedies. If `dynamicEnvironment` does not override an env-file key, the fallback is to omit `baseUrl` from the env YAML entirely so the only source is `dynamicEnvironment` — the implementer should apply that if the Task 4 test fails on a connection error.

--- a/docs/superpowers/plans/2026-07-31-agentic-harness-stage2.md
+++ b/docs/superpowers/plans/2026-07-31-agentic-harness-stage2.md
@@ -1,0 +1,1433 @@
+# Agentic Harness — Stage 2 (Tool-Def Gen + Probabilistic Layer) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the probabilistic layer on top of Stage 1's deterministic spine: auto-generate the 4-field tool definition from graph metadata + a small OAS, put the LLM behind a pluggable `LlmClient` interface (deterministic STUB in `main`/tests; real Claude via koog in an isolated source set), and wire router → slot-filler (schema-validated) → `GraphRunner.revUp` → Rundown-as-context.
+
+**Architecture:** Everything testable and CI-safe lives in `agentic-harness/src/main` with **zero koog and zero coroutines** — the `StubLlmClient` drives all of it deterministically, so `./gradlew :agentic-harness:test` never needs an API key or a network. The real Claude implementation (`ClaudeLlmClient`) is confined to a **separate `claude` source set** (`src/claude/kotlin`) that carries the koog dependency and is compiled only by an opt-in `compileClaudeKotlin` / `claudeDemo` task — the default `test`/`build`/`check` tasks never compile it, so a koog resolution or version problem cannot break Stage 1 or the Stage 2 core.
+
+**Tech Stack:** Kotlin (JVM 21), Gradle multi-module (existing `agentic-harness` module), ReVoman library (`project(":")`), snakeyaml (OAS parsing; already in the repo version catalog), JUnit5 + Google Truth. koog (`ai.koog:koog-agents:1.1.1`) ONLY in the isolated `claude` source set.
+
+## Global Constraints
+
+- **JDK 21** runtime and build.
+- **Never modify the ReVoman library** (`build.gradle.kts`, `src/main`, `src/test`, `src/integrationTest`). All work is inside `agentic-harness/`.
+- **koog is quarantined to the `claude` source set.** No file under `agentic-harness/src/main` or `agentic-harness/src/test` may import anything under `ai.koog.*` or `kotlinx.coroutines.*`. The default `test`/`build`/`check` tasks must never compile the `claude` source set.
+- **Stage 1 must stay green.** After every task, `./gradlew :agentic-harness:test` passes all Stage-1 and Stage-2 test classes.
+- **Dependencies added in Stage 2:** `implementation(libs.snakeyaml)` on the module `main` (already in the repo's version catalog — used for OAS parsing), and `ai.koog:koog-agents:1.1.1` on the `claude` source set only.
+- **Copyright header:** every new `.kt` starts with the standard SFDC Apache-2.0 header block (copy from any existing `agentic-harness/**/*.kt`).
+- **Test convention:** JUnit5 (`org.junit.jupiter.api`) + Google Truth (`com.google.common.truth.Truth.assertThat`). ktfmt Google style — run `./gradlew spotlessApply` before every commit.
+- **Verified facts (do not re-derive):**
+  - Stage 1 delivered: `com.salesforce.revoman.harness.GraphRunner` (`object`) with `runChain(baseUrl: String, graphs: List<String> = DEFAULT_CHAIN, seedEnv: Map<String, Any?> = emptyMap()): List<Rundown>`; `com.salesforce.revoman.harness.mock.MockCpqServer` with `start(): Int`, `stop()`, `db: MutableMap<String,Any?>`; three V3 graphs under `src/main/resources/graphs/{configure,price,quote}`.
+  - `GraphRunner.runChain`'s `seedEnv` is passed to ReVoman as `dynamicEnvironment`, which **overrides** the env-file values (Stage 1 Task 4 verified). So filled slots seeded here replace the graph's env-file defaults.
+  - ReVoman `{{var}}` substitution is string substitution: a slot value of the string `"2"` rendered into `"quantity":{{quantity}}` yields valid JSON `"quantity":2`.
+  - Graph edge facts: `configure` reads `{{productCode}}`,`{{quantity}}` and sets `configId`; `price` reads `{{configId}}` and sets `priceId`,`total`; `quote` reads `{{priceId}}` and sets `quoteId`,`quoteStatus`. Infra placeholders are `{{baseUrl}}`,`{{accessToken}}`.
+  - koog (verified from `~/code-clones/oss/koog`): `ai.koog:koog-agents:1.1.1` umbrella re-exports `prompt-executor-llms-all`, which provides `ai.koog.prompt.executor.llms.all.simpleAnthropicExecutor(apiKey: String): PromptExecutor` (JVM no-factory overload) and `ai.koog.prompt.executor.clients.anthropic.AnthropicModels.Sonnet_4_5: LLModel`. `PromptExecutor.execute(prompt: Prompt, model: LLModel): Message.Assistant` is a `suspend` fun; `Message.Assistant.content: String` holds the text. Build a prompt with `ai.koog.prompt.dsl.prompt("<id>") { system("..."); user("...") }`. koog is compiled against Kotlin 2.3.10.
+
+---
+
+### Task 1: `GraphSpec` + `GraphMetadataParser` — extract graph metadata
+
+**Files:**
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/GraphSpec.kt`
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/GraphMetadataParser.kt`
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/tooldef/GraphMetadataParserTest.kt`
+
+**Interfaces:**
+- Consumes: the three V3 graph resource dirs under `graphs/` (Stage 1).
+- Produces:
+  - `data class GraphSpec(val name: String, val description: String, val slots: List<String>, val outputKeys: List<String>)` — `slots` and `outputKeys` are sorted, distinct.
+  - `object GraphMetadataParser { fun parse(graph: String): GraphSpec }` — reads `graphs/<graph>/` from the classpath: `description` from `.resources/definition.yaml`, `slots` = `{{placeholders}}` referenced across the `*.request.yaml` files minus infra (`baseUrl`,`accessToken`) minus `outputKeys`, `outputKeys` = keys passed to `pm.environment.set(...)`.
+  - Note (documented limitation): resolves the graph resource directory as a filesystem `Path` (dev/test exploded resources). This harness runs via Gradle, never as a packaged jar, so this is sufficient — do not add jar-walking.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/tooldef/GraphMetadataParserTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.tooldef
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class GraphMetadataParserTest {
+  @Test
+  fun `configure graph exposes productCode and quantity as slots and configId as output`() {
+    val spec = GraphMetadataParser.parse("configure")
+    assertThat(spec.name).isEqualTo("configure")
+    assertThat(spec.description).isNotEmpty()
+    assertThat(spec.slots).containsExactly("productCode", "quantity")
+    assertThat(spec.outputKeys).contains("configId")
+    // Infra placeholders are never slots.
+    assertThat(spec.slots).containsNoneOf("baseUrl", "accessToken")
+  }
+
+  @Test
+  fun `price graph consumes configId as its only slot and emits priceId`() {
+    val spec = GraphMetadataParser.parse("price")
+    assertThat(spec.slots).containsExactly("configId")
+    assertThat(spec.outputKeys).containsAtLeast("priceId", "total")
+  }
+
+  @Test
+  fun `quote graph consumes priceId as its only slot`() {
+    val spec = GraphMetadataParser.parse("quote")
+    assertThat(spec.slots).containsExactly("priceId")
+    assertThat(spec.outputKeys).contains("quoteId")
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :agentic-harness:test --tests "*GraphMetadataParserTest"`
+Expected: FAIL — "unresolved reference: GraphMetadataParser".
+
+- [ ] **Step 3: Write `GraphSpec`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/GraphSpec.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.tooldef
+
+/**
+ * Structural metadata distilled from a ReVoman V3 graph collection — the raw material the
+ * [ToolDefGenerator] turns into an LLM-facing tool definition.
+ *
+ * @property slots the input `{{placeholder}}` names the LLM must fill (infra + intra-graph outputs
+ *   excluded — those are threaded deterministically by ReVoman, never by the LLM).
+ * @property outputKeys the `pm.environment.set(...)` keys the graph produces (its internal edges).
+ */
+data class GraphSpec(
+  val name: String,
+  val description: String,
+  val slots: List<String>,
+  val outputKeys: List<String>,
+)
+```
+
+- [ ] **Step 4: Write `GraphMetadataParser`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/GraphMetadataParser.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.tooldef
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.name
+import kotlin.io.path.readText
+
+/**
+ * Parses a V3 graph collection directory (on the classpath) into a [GraphSpec]. Placeholder and
+ * output extraction is done by regex over the raw request-yaml text — more robust for finding
+ * `{{var}}` tokens and `pm.environment.set` keys than parsing the YAML structure and re-scanning
+ * string values.
+ */
+object GraphMetadataParser {
+  private val INFRA_PLACEHOLDERS = setOf("baseUrl", "accessToken")
+  private val PLACEHOLDER = Regex("""\{\{(\w+)}}""")
+  private val ENV_SET = Regex("""pm\.environment\.set\(\s*["'](\w+)["']""")
+  private val DESCRIPTION = Regex("""^description:\s*["']?(.*?)["']?\s*$""", RegexOption.MULTILINE)
+
+  fun parse(graph: String): GraphSpec {
+    val dir = resourceDir("graphs/$graph")
+    val defText = dir.resolve(".resources/definition.yaml").readText()
+    val description = DESCRIPTION.find(defText)?.groupValues?.get(1)?.trim().orEmpty()
+
+    val requestText =
+      Files.list(dir).use { stream ->
+        stream
+          .filter { it.name.endsWith(".request.yaml") }
+          .map { it.readText() }
+          .toList()
+          .joinToString("\n")
+      }
+    val referenced = PLACEHOLDER.findAll(requestText).map { it.groupValues[1] }.toSet()
+    val outputKeys = ENV_SET.findAll(requestText).map { it.groupValues[1] }.toSet()
+    val slots = (referenced - INFRA_PLACEHOLDERS - outputKeys).sorted()
+    return GraphSpec(graph, description, slots, outputKeys.sorted())
+  }
+
+  private fun resourceDir(path: String): Path {
+    val url =
+      javaClass.classLoader.getResource(path)
+        ?: error("Graph resource directory not found on classpath: $path")
+    return Path.of(url.toURI())
+  }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `./gradlew :agentic-harness:test --tests "*GraphMetadataParserTest"`
+Expected: BUILD SUCCESSFUL, 3 tests passed.
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/GraphSpec.kt \
+  agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/GraphMetadataParser.kt \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/tooldef/GraphMetadataParserTest.kt
+git commit -m "feat(harness): GraphMetadataParser extracts slots/outputs from V3 graphs"
+```
+
+---
+
+### Task 2: OAS model + loader + `ToolDefGenerator` (the pure 4-field generator)
+
+**Files:**
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/GraphOas.kt`
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/GraphOasLoader.kt`
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/ToolDef.kt`
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/ToolDefGenerator.kt`
+- Create OAS resources: `agentic-harness/src/main/resources/oas/configure.yaml`, `oas/price.yaml`, `oas/quote.yaml`
+- Modify: `agentic-harness/build.gradle.kts` (add `implementation(libs.snakeyaml)`)
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/tooldef/ToolDefGeneratorTest.kt`
+
+**Interfaces:**
+- Consumes: `GraphSpec` (Task 1).
+- Produces:
+  - `enum class SlotType { STRING, INT, ENUM }`
+  - `data class SlotSchema(val type: SlotType, val values: List<String> = emptyList(), val required: Boolean = true)`
+  - `data class GraphOas(val graph: String, val slots: Map<String, SlotSchema>, val exampleQueries: List<String>, val inputExamples: List<Map<String, String>>, val whenNotToUse: List<String> = emptyList())`
+  - `object GraphOasLoader { fun load(graph: String): GraphOas }` — parses `oas/<graph>.yaml` from the classpath via snakeyaml.
+  - `data class ToolDef(val graphName: String, val whenToUse: String, val whenNotToUse: List<String>, val exampleQueries: List<String>, val inputExamples: List<Map<String, String>>, val slots: Map<String, SlotSchema>)`
+  - `object ToolDefGenerator { fun generate(spec: GraphSpec, oas: GraphOas): ToolDef }` — reconciles: **requires** `oas.slots.keys == spec.slots.toSet()` (every metadata slot has a schema and no extra), else throws `IllegalArgumentException` naming the diff. `whenToUse` = `spec.description`; the other three fields come from `oas`.
+
+- [ ] **Step 1: Add snakeyaml to the module build**
+
+In `agentic-harness/build.gradle.kts`, inside the existing `dependencies { ... }` block, add:
+
+```kotlin
+implementation(libs.snakeyaml)
+```
+
+- [ ] **Step 2: Write the OAS resource files**
+
+`agentic-harness/src/main/resources/oas/configure.yaml`:
+
+```yaml
+graph: configure
+slots:
+  productCode: { type: enum, values: [SKU-1, SKU-2, SKU-3] }
+  quantity: { type: int }
+exampleQueries:
+  - "configure 2 units of SKU-1"
+  - "set up a new product configuration"
+  - "add SKU-2 to a fresh config"
+inputExamples:
+  - { productCode: "SKU-1", quantity: "2" }
+  - { productCode: "SKU-2", quantity: "10" }
+whenNotToUse:
+  - "Do not use to compute a price or total — that is the price graph."
+```
+
+`agentic-harness/src/main/resources/oas/price.yaml`:
+
+```yaml
+graph: price
+slots:
+  configId: { type: string }
+exampleQueries:
+  - "price configuration cfg-1"
+  - "what does this configuration cost"
+  - "compute the total for my config"
+inputExamples:
+  - { configId: "cfg-1" }
+whenNotToUse:
+  - "Do not use to build a configuration from a product — that is the configure graph."
+  - "Do not use to create a draft quote — that is the quote graph."
+```
+
+`agentic-harness/src/main/resources/oas/quote.yaml`:
+
+```yaml
+graph: quote
+slots:
+  priceId: { type: string }
+exampleQueries:
+  - "create a draft quote for prc-2"
+  - "turn this price into a quote"
+  - "draft a quote"
+inputExamples:
+  - { priceId: "prc-2" }
+whenNotToUse:
+  - "Do not use to price a configuration — that is the price graph."
+```
+
+- [ ] **Step 3: Write the failing test**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/tooldef/ToolDefGeneratorTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.tooldef
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class ToolDefGeneratorTest {
+  @Test
+  fun `generates the four fields from configure metadata and OAS`() {
+    val spec = GraphMetadataParser.parse("configure")
+    val oas = GraphOasLoader.load("configure")
+    val toolDef = ToolDefGenerator.generate(spec, oas)
+
+    assertThat(toolDef.graphName).isEqualTo("configure")
+    assertThat(toolDef.whenToUse).isEqualTo(spec.description)
+    assertThat(toolDef.whenNotToUse).isNotEmpty()
+    assertThat(toolDef.exampleQueries).hasSize(3)
+    assertThat(toolDef.inputExamples).isNotEmpty()
+    // The slot schema is carried through for the slot-filler/validator.
+    assertThat(toolDef.slots.keys).containsExactly("productCode", "quantity")
+    assertThat(toolDef.slots["productCode"]!!.type).isEqualTo(SlotType.ENUM)
+    assertThat(toolDef.slots["productCode"]!!.values).containsExactly("SKU-1", "SKU-2", "SKU-3")
+    assertThat(toolDef.slots["quantity"]!!.type).isEqualTo(SlotType.INT)
+  }
+
+  @Test
+  fun `rejects an OAS whose declared slots do not match the graph metadata`() {
+    val spec = GraphSpec("configure", "desc", slots = listOf("productCode", "quantity"), outputKeys = listOf("configId"))
+    val badOas =
+      GraphOas(
+        graph = "configure",
+        slots = mapOf("productCode" to SlotSchema(SlotType.ENUM, listOf("SKU-1"))), // missing 'quantity'
+        exampleQueries = listOf("x"),
+        inputExamples = listOf(mapOf("productCode" to "SKU-1")),
+      )
+    val ex = assertThrows<IllegalArgumentException> { ToolDefGenerator.generate(spec, badOas) }
+    assertThat(ex.message).contains("quantity")
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it fails**
+
+Run: `./gradlew :agentic-harness:test --tests "*ToolDefGeneratorTest"`
+Expected: FAIL — unresolved references (`GraphOas`, `GraphOasLoader`, `ToolDef`, `ToolDefGenerator`, `SlotType`, `SlotSchema`).
+
+- [ ] **Step 5: Write the OAS model, loader, ToolDef, and generator**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/GraphOas.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.tooldef
+
+/** The type of a graph input slot, used to validate LLM-filled arguments before execution. */
+enum class SlotType {
+  STRING,
+  INT,
+  ENUM,
+}
+
+/** Schema for one input slot: its type, allowed values (for [SlotType.ENUM]), and whether required. */
+data class SlotSchema(
+  val type: SlotType,
+  val values: List<String> = emptyList(),
+  val required: Boolean = true,
+)
+
+/**
+ * A small, hand-authored OpenAPI-style spec for one graph. The [ToolDefGenerator] distils it — plus
+ * the graph metadata — into the four LLM-facing tool-def fields. Never dumped raw into a prompt.
+ */
+data class GraphOas(
+  val graph: String,
+  val slots: Map<String, SlotSchema>,
+  val exampleQueries: List<String>,
+  val inputExamples: List<Map<String, String>>,
+  val whenNotToUse: List<String> = emptyList(),
+)
+```
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/GraphOasLoader.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.tooldef
+
+import org.yaml.snakeyaml.Yaml
+
+/** Loads a graph's OAS from `oas/<graph>.yaml` on the classpath. */
+object GraphOasLoader {
+  fun load(graph: String): GraphOas {
+    val text =
+      javaClass.classLoader.getResourceAsStream("oas/$graph.yaml")?.bufferedReader()?.readText()
+        ?: error("OAS not found on classpath: oas/$graph.yaml")
+    @Suppress("UNCHECKED_CAST") val root = Yaml().load<Map<String, Any?>>(text)
+
+    @Suppress("UNCHECKED_CAST") val slotsRaw = (root["slots"] as? Map<String, Any?>).orEmpty()
+    val slots =
+      slotsRaw.mapValues { (_, v) ->
+        @Suppress("UNCHECKED_CAST") val s = v as Map<String, Any?>
+        val type = SlotType.valueOf((s["type"] as String).uppercase())
+        @Suppress("UNCHECKED_CAST") val values = (s["values"] as? List<Any?>).orEmpty().map { it.toString() }
+        val required = (s["required"] as? Boolean) ?: true
+        SlotSchema(type, values, required)
+      }
+
+    @Suppress("UNCHECKED_CAST")
+    val exampleQueries = (root["exampleQueries"] as? List<Any?>).orEmpty().map { it.toString() }
+    @Suppress("UNCHECKED_CAST")
+    val inputExamples =
+      (root["inputExamples"] as? List<Map<String, Any?>>).orEmpty().map { ex ->
+        ex.mapValues { it.value.toString() }
+      }
+    @Suppress("UNCHECKED_CAST")
+    val whenNotToUse = (root["whenNotToUse"] as? List<Any?>).orEmpty().map { it.toString() }
+
+    return GraphOas(root["graph"] as String, slots, exampleQueries, inputExamples, whenNotToUse)
+  }
+}
+```
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/ToolDef.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.tooldef
+
+/**
+ * The LLM-facing definition of one graph tool: the four calibration fields from the design
+ * (`when_to_use`, `when_not_to_use`, `example_queries`, `input_examples`) plus the slot schema the
+ * slot-filler validates against before execution.
+ */
+data class ToolDef(
+  val graphName: String,
+  val whenToUse: String,
+  val whenNotToUse: List<String>,
+  val exampleQueries: List<String>,
+  val inputExamples: List<Map<String, String>>,
+  val slots: Map<String, SlotSchema>,
+)
+```
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/ToolDefGenerator.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.tooldef
+
+/**
+ * Pure function: distils graph metadata + a small OAS into the four-field [ToolDef]. Reconciles the
+ * two sources — the OAS must declare a schema for exactly the graph's input slots (no more, no
+ * less) — so a graph and its spec cannot silently drift apart.
+ */
+object ToolDefGenerator {
+  fun generate(spec: GraphSpec, oas: GraphOas): ToolDef {
+    val metadataSlots = spec.slots.toSet()
+    val oasSlots = oas.slots.keys
+    require(metadataSlots == oasSlots) {
+      val missing = metadataSlots - oasSlots
+      val extra = oasSlots - metadataSlots
+      "OAS for '${spec.name}' does not match graph slots. missing schema for=$missing, unknown slots=$extra"
+    }
+    return ToolDef(
+      graphName = spec.name,
+      whenToUse = spec.description,
+      whenNotToUse = oas.whenNotToUse,
+      exampleQueries = oas.exampleQueries,
+      inputExamples = oas.inputExamples,
+      slots = oas.slots,
+    )
+  }
+}
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `./gradlew :agentic-harness:test --tests "*ToolDefGeneratorTest"`
+Expected: BUILD SUCCESSFUL, 2 tests passed.
+
+- [ ] **Step 7: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/GraphOas.kt \
+  agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/GraphOasLoader.kt \
+  agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/ToolDef.kt \
+  agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/tooldef/ToolDefGenerator.kt \
+  agentic-harness/src/main/resources/oas \
+  agentic-harness/build.gradle.kts \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/tooldef/ToolDefGeneratorTest.kt
+git commit -m "feat(harness): auto-generate 4-field tool defs from graph metadata + OAS"
+```
+
+---
+
+### Task 3: `LlmClient` interface + `StubLlmClient`
+
+**Files:**
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/llm/LlmClient.kt`
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/llm/StubLlmClient.kt`
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/llm/StubLlmClientTest.kt`
+
+**Interfaces:**
+- Consumes: `ToolDef`, `SlotSchema` (Task 2).
+- Produces:
+  - `data class RouteDecision(val graphName: String?, val rationale: String)` — `graphName == null` means no confident match.
+  - `interface LlmClient { fun route(utterance: String, tools: List<ToolDef>): RouteDecision; fun fillSlots(utterance: String, tool: ToolDef): Map<String, String> }` — synchronous (no coroutines in `main`).
+  - `class StubLlmClient : LlmClient` — deterministic. `route`: keyword match against each tool's `graphName` + `exampleQueries` keywords (configure ← "configure","product","set up","add"; price ← "price","cost","total","how much"; quote ← "quote","draft"); returns the first match, else `null`. `fillSlots`: extracts `SKU-\d+` for a `productCode` slot, the first integer for a `quantity`/`int` slot, and `cfg-\w+`/`prc-\w+` for `configId`/`priceId`; only returns keys the tool actually declares.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/llm/StubLlmClientTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.llm
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.tooldef.GraphMetadataParser
+import com.salesforce.revoman.harness.tooldef.GraphOasLoader
+import com.salesforce.revoman.harness.tooldef.ToolDef
+import com.salesforce.revoman.harness.tooldef.ToolDefGenerator
+import org.junit.jupiter.api.Test
+
+class StubLlmClientTest {
+  private val tools: List<ToolDef> =
+    listOf("configure", "price", "quote").map {
+      ToolDefGenerator.generate(GraphMetadataParser.parse(it), GraphOasLoader.load(it))
+    }
+  private val stub = StubLlmClient()
+
+  @Test
+  fun `routes configure intent`() {
+    assertThat(stub.route("configure 2 units of SKU-1", tools).graphName).isEqualTo("configure")
+  }
+
+  @Test
+  fun `routes price intent`() {
+    assertThat(stub.route("how much does this configuration cost", tools).graphName).isEqualTo("price")
+  }
+
+  @Test
+  fun `routes quote intent`() {
+    assertThat(stub.route("create a draft quote", tools).graphName).isEqualTo("quote")
+  }
+
+  @Test
+  fun `returns null graph for an unrelated utterance`() {
+    assertThat(stub.route("what is the weather today", tools).graphName).isNull()
+  }
+
+  @Test
+  fun `fills configure slots from the utterance`() {
+    val configure = tools.first { it.graphName == "configure" }
+    val slots = stub.fillSlots("configure 2 units of SKU-1", configure)
+    assertThat(slots).containsEntry("productCode", "SKU-1")
+    assertThat(slots).containsEntry("quantity", "2")
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :agentic-harness:test --tests "*StubLlmClientTest"`
+Expected: FAIL — unresolved references `StubLlmClient`, `RouteDecision`.
+
+- [ ] **Step 3: Write `LlmClient`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/llm/LlmClient.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.llm
+
+import com.salesforce.revoman.harness.tooldef.ToolDef
+
+/** The router's output: the chosen graph (or null when nothing matched) and a short rationale. */
+data class RouteDecision(val graphName: String?, val rationale: String)
+
+/**
+ * The only probabilistic surface in the harness. Two jobs, exactly as the design specifies: pick a
+ * graph, and fill that graph's input slots. Synchronous by contract so the deterministic stub and
+ * the whole orchestrator core stay coroutine-free; the real Claude implementation lives in a
+ * separate source set and bridges its suspend calls internally.
+ */
+interface LlmClient {
+  fun route(utterance: String, tools: List<ToolDef>): RouteDecision
+
+  fun fillSlots(utterance: String, tool: ToolDef): Map<String, String>
+}
+```
+
+- [ ] **Step 4: Write `StubLlmClient`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/llm/StubLlmClient.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.llm
+
+import com.salesforce.revoman.harness.tooldef.SlotType
+import com.salesforce.revoman.harness.tooldef.ToolDef
+
+/**
+ * A deterministic, network-free [LlmClient] for tests, CI, and the no-key demo. Routing is keyword
+ * matching; slot-filling is regex extraction. It stands in for a real model everywhere the key is
+ * absent, so the entire orchestrator is exercisable without an LLM.
+ */
+class StubLlmClient : LlmClient {
+  private val routingKeywords: Map<String, List<String>> =
+    mapOf(
+      "configure" to listOf("configure", "product", "set up", "add "),
+      "price" to listOf("price", "cost", "total", "how much"),
+      "quote" to listOf("quote", "draft"),
+    )
+  private val skuRegex = Regex("""SKU-\d+""")
+  private val configIdRegex = Regex("""cfg-\w+""")
+  private val priceIdRegex = Regex("""prc-\w+""")
+  private val intRegex = Regex("""\b(\d+)\b""")
+
+  override fun route(utterance: String, tools: List<ToolDef>): RouteDecision {
+    val lower = utterance.lowercase()
+    val match =
+      tools.firstOrNull { tool ->
+        routingKeywords[tool.graphName].orEmpty().any { lower.contains(it) }
+      }
+    return match?.let { RouteDecision(it.graphName, "keyword match on '${it.graphName}'") }
+      ?: RouteDecision(null, "no keyword matched any graph")
+  }
+
+  override fun fillSlots(utterance: String, tool: ToolDef): Map<String, String> =
+    tool.slots.keys
+      .mapNotNull { slot -> extract(slot, tool.slots[slot]!!.type, utterance)?.let { slot to it } }
+      .toMap()
+
+  private fun extract(slot: String, type: SlotType, utterance: String): String? =
+    when {
+      slot == "productCode" -> skuRegex.find(utterance)?.value
+      slot == "configId" -> configIdRegex.find(utterance)?.value
+      slot == "priceId" -> priceIdRegex.find(utterance)?.value
+      type == SlotType.INT -> intRegex.find(utterance)?.groupValues?.get(1)
+      else -> null
+    }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `./gradlew :agentic-harness:test --tests "*StubLlmClientTest"`
+Expected: BUILD SUCCESSFUL, 5 tests passed.
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/llm/LlmClient.kt \
+  agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/llm/StubLlmClient.kt \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/llm/StubLlmClientTest.kt
+git commit -m "feat(harness): LlmClient interface + deterministic StubLlmClient"
+```
+
+---
+
+### Task 4: `Router` + `SlotFiller` (schema validation / hallucination rejection)
+
+**Files:**
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/Router.kt`
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/SlotFiller.kt`
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/orchestrator/SlotFillerTest.kt`
+
+**Interfaces:**
+- Consumes: `LlmClient`, `RouteDecision` (Task 3); `ToolDef`, `SlotType`, `SlotSchema` (Task 2).
+- Produces:
+  - `class Router(private val llm: LlmClient, private val tools: List<ToolDef>) { fun route(utterance: String): RouteDecision }`.
+  - `sealed interface FillResult { data class Valid(val slots: Map<String, String>) : FillResult; data class Invalid(val errors: List<String>) : FillResult }`.
+  - `class SlotFiller(private val llm: LlmClient) { fun fill(utterance: String, tool: ToolDef): FillResult }` — calls `llm.fillSlots`, then validates each filled value against the tool's `SlotSchema` **before** returning: missing required slot → error; unknown slot key (not in schema) → error (rejects hallucinated param names); `INT` value that is not an integer → error; `ENUM` value not in `values` → error (rejects hallucinated arguments). Empty error list → `Valid`, else `Invalid`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/orchestrator/SlotFillerTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.orchestrator
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.llm.LlmClient
+import com.salesforce.revoman.harness.llm.RouteDecision
+import com.salesforce.revoman.harness.tooldef.SlotSchema
+import com.salesforce.revoman.harness.tooldef.SlotType
+import com.salesforce.revoman.harness.tooldef.ToolDef
+import org.junit.jupiter.api.Test
+
+class SlotFillerTest {
+  private val configureTool =
+    ToolDef(
+      graphName = "configure",
+      whenToUse = "configure a product",
+      whenNotToUse = emptyList(),
+      exampleQueries = emptyList(),
+      inputExamples = emptyList(),
+      slots =
+        mapOf(
+          "productCode" to SlotSchema(SlotType.ENUM, listOf("SKU-1", "SKU-2", "SKU-3")),
+          "quantity" to SlotSchema(SlotType.INT),
+        ),
+    )
+
+  /** A fake LlmClient that returns pre-canned slot values, so validation can be tested in isolation. */
+  private fun fakeLlm(filled: Map<String, String>): LlmClient =
+    object : LlmClient {
+      override fun route(utterance: String, tools: List<ToolDef>) = RouteDecision(null, "")
+
+      override fun fillSlots(utterance: String, tool: ToolDef) = filled
+    }
+
+  @Test
+  fun `accepts valid enum and int slots`() {
+    val result =
+      SlotFiller(fakeLlm(mapOf("productCode" to "SKU-1", "quantity" to "2")))
+        .fill("x", configureTool)
+    assertThat(result).isInstanceOf(FillResult.Valid::class.java)
+    assertThat((result as FillResult.Valid).slots).containsEntry("quantity", "2")
+  }
+
+  @Test
+  fun `rejects a hallucinated enum value`() {
+    val result =
+      SlotFiller(fakeLlm(mapOf("productCode" to "SKU-99", "quantity" to "2")))
+        .fill("x", configureTool)
+    assertThat(result).isInstanceOf(FillResult.Invalid::class.java)
+    assertThat((result as FillResult.Invalid).errors.joinToString()).contains("productCode")
+  }
+
+  @Test
+  fun `rejects a non-integer quantity`() {
+    val result =
+      SlotFiller(fakeLlm(mapOf("productCode" to "SKU-1", "quantity" to "lots")))
+        .fill("x", configureTool)
+    assertThat(result).isInstanceOf(FillResult.Invalid::class.java)
+    assertThat((result as FillResult.Invalid).errors.joinToString()).contains("quantity")
+  }
+
+  @Test
+  fun `rejects a missing required slot`() {
+    val result = SlotFiller(fakeLlm(mapOf("productCode" to "SKU-1"))).fill("x", configureTool)
+    assertThat(result).isInstanceOf(FillResult.Invalid::class.java)
+    assertThat((result as FillResult.Invalid).errors.joinToString()).contains("quantity")
+  }
+
+  @Test
+  fun `rejects a hallucinated slot name`() {
+    val result =
+      SlotFiller(
+          fakeLlm(mapOf("productCode" to "SKU-1", "quantity" to "2", "discountPct" to "50"))
+        )
+        .fill("x", configureTool)
+    assertThat(result).isInstanceOf(FillResult.Invalid::class.java)
+    assertThat((result as FillResult.Invalid).errors.joinToString()).contains("discountPct")
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :agentic-harness:test --tests "*SlotFillerTest"`
+Expected: FAIL — unresolved references `SlotFiller`, `FillResult`.
+
+- [ ] **Step 3: Write `Router`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/Router.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.orchestrator
+
+import com.salesforce.revoman.harness.llm.LlmClient
+import com.salesforce.revoman.harness.llm.RouteDecision
+import com.salesforce.revoman.harness.tooldef.ToolDef
+
+/** Prompt A: turns an intent into a graph choice by delegating to the pluggable [LlmClient]. */
+class Router(private val llm: LlmClient, private val tools: List<ToolDef>) {
+  fun route(utterance: String): RouteDecision = llm.route(utterance, tools)
+}
+```
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/SlotFiller.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.orchestrator
+
+import com.salesforce.revoman.harness.llm.LlmClient
+import com.salesforce.revoman.harness.tooldef.SlotType
+import com.salesforce.revoman.harness.tooldef.ToolDef
+
+/** The result of slot-filling: validated arguments, or the list of validation failures. */
+sealed interface FillResult {
+  data class Valid(val slots: Map<String, String>) : FillResult
+
+  data class Invalid(val errors: List<String>) : FillResult
+}
+
+/**
+ * Prompt B: fills a graph's input placeholders via the [LlmClient], then validates every argument
+ * against the graph's typed schema BEFORE it can reach ReVoman. Hallucinated argument names,
+ * out-of-enum values, non-integer numbers, and missing required slots are all rejected at the door.
+ */
+class SlotFiller(private val llm: LlmClient) {
+  fun fill(utterance: String, tool: ToolDef): FillResult {
+    val filled = llm.fillSlots(utterance, tool)
+    val errors = buildList {
+      // Reject hallucinated slot names not declared by the graph.
+      (filled.keys - tool.slots.keys).forEach { add("unknown slot '$it' (not declared by graph '${tool.graphName}')") }
+      // Validate each declared slot.
+      tool.slots.forEach { (name, schema) ->
+        val value = filled[name]
+        when {
+          value == null -> if (schema.required) add("missing required slot '$name'")
+          schema.type == SlotType.INT && value.toIntOrNull() == null ->
+            add("slot '$name' expects an integer but got '$value'")
+          schema.type == SlotType.ENUM && value !in schema.values ->
+            add("slot '$name' value '$value' is not one of ${schema.values}")
+        }
+      }
+    }
+    return if (errors.isEmpty()) FillResult.Valid(filled) else FillResult.Invalid(errors)
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :agentic-harness:test --tests "*SlotFillerTest"`
+Expected: BUILD SUCCESSFUL, 5 tests passed.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/Router.kt \
+  agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/SlotFiller.kt \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/orchestrator/SlotFillerTest.kt
+git commit -m "feat(harness): Router + SlotFiller with pre-execution schema validation"
+```
+
+---
+
+### Task 5: `GraphRegistry` + `Orchestrator` + runnable Stage 2 demo
+
+**Files:**
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/GraphRegistry.kt`
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/Orchestrator.kt`
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/Stage2Demo.kt`
+- Modify: `agentic-harness/build.gradle.kts` (add a `runStage2Demo` JavaExec task)
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/orchestrator/OrchestratorTest.kt`
+
+**Interfaces:**
+- Consumes: `GraphMetadataParser`, `GraphOasLoader`, `ToolDefGenerator`, `ToolDef` (Tasks 1–2); `LlmClient`, `StubLlmClient` (Task 3); `Router`, `SlotFiller`, `FillResult` (Task 4); `GraphRunner` (Stage 1); ReVoman `Rundown`, `Verbosity`, `toJson`.
+- Produces:
+  - `object GraphRegistry { val GRAPHS: List<String>; fun loadToolDefs(): List<ToolDef> }` — assembles the three tool defs (parser + OAS loader + generator).
+  - `sealed interface OrchestrationResult { data class NoGraphMatched(val utterance: String); data class SlotsRejected(val graph: String, val errors: List<String>); data class Executed(val graph: String, val slots: Map<String, String>, val rundowns: List<Rundown>, val context: String) }`.
+  - `class Orchestrator(private val baseUrl: String, private val tools: List<ToolDef>, private val llm: LlmClient) { fun orchestrate(utterance: String): OrchestrationResult }` — route → (null ⇒ `NoGraphMatched`); slot-fill+validate → (`Invalid` ⇒ `SlotsRejected`); else `GraphRunner.runChain(baseUrl, listOf(graph), seedEnv = slots)` and return `Executed` with `context` = each Rundown's `toJson(Verbosity.SUMMARY)` joined by newlines.
+  - `fun main()` in `Stage2Demo.kt` and a `runStage2Demo` JavaExec task (mainClass `com.salesforce.revoman.harness.Stage2DemoKt`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/orchestrator/OrchestratorTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.orchestrator
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.llm.LlmClient
+import com.salesforce.revoman.harness.llm.RouteDecision
+import com.salesforce.revoman.harness.llm.StubLlmClient
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.tooldef.ToolDef
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class OrchestratorTest {
+  private lateinit var server: MockCpqServer
+  private lateinit var baseUrl: String
+  private val tools: List<ToolDef> = GraphRegistry.loadToolDefs()
+
+  @BeforeEach
+  fun setUp() {
+    server = MockCpqServer()
+    baseUrl = "http://127.0.0.1:${server.start()}"
+  }
+
+  @AfterEach fun tearDown() = server.stop()
+
+  @Test
+  fun `configure intent routes, fills, executes, and records state`() {
+    val result =
+      Orchestrator(baseUrl, tools, StubLlmClient()).orchestrate("configure 2 units of SKU-1")
+
+    assertThat(result).isInstanceOf(OrchestrationResult.Executed::class.java)
+    val executed = result as OrchestrationResult.Executed
+    assertThat(executed.graph).isEqualTo("configure")
+    assertThat(executed.slots).containsEntry("productCode", "SKU-1")
+    assertThat(executed.slots).containsEntry("quantity", "2")
+    // The filled quantity (2) overrides the env-file default (1) — proof slots reach ReVoman.
+    assertThat(server.db.values).contains("SKU-1 x2")
+    // Rundown context flows back for the LLM.
+    assertThat(executed.context).contains("areAllStepsSuccessful")
+  }
+
+  @Test
+  fun `unrelated intent yields NoGraphMatched`() {
+    val result = Orchestrator(baseUrl, tools, StubLlmClient()).orchestrate("what is the weather")
+    assertThat(result).isInstanceOf(OrchestrationResult.NoGraphMatched::class.java)
+  }
+
+  @Test
+  fun `hallucinated slot value is rejected before execution`() {
+    // A fake LLM that routes to configure but fills an out-of-enum productCode.
+    val badLlm =
+      object : LlmClient {
+        override fun route(utterance: String, tools: List<ToolDef>) =
+          RouteDecision("configure", "forced")
+
+        override fun fillSlots(utterance: String, tool: ToolDef) =
+          mapOf("productCode" to "SKU-99", "quantity" to "2")
+      }
+    val result = Orchestrator(baseUrl, tools, badLlm).orchestrate("configure something")
+    assertThat(result).isInstanceOf(OrchestrationResult.SlotsRejected::class.java)
+    // Nothing was executed — the mock DB stays empty.
+    assertThat(server.db).isEmpty()
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :agentic-harness:test --tests "*OrchestratorTest"`
+Expected: FAIL — unresolved references `GraphRegistry`, `Orchestrator`, `OrchestrationResult`.
+
+- [ ] **Step 3: Write `GraphRegistry`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/GraphRegistry.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.orchestrator
+
+import com.salesforce.revoman.harness.tooldef.GraphMetadataParser
+import com.salesforce.revoman.harness.tooldef.GraphOasLoader
+import com.salesforce.revoman.harness.tooldef.ToolDef
+import com.salesforce.revoman.harness.tooldef.ToolDefGenerator
+
+/**
+ * The static graph registry (design decision: static tool list at v1). Assembles the LLM-facing
+ * tool definitions for every graph from its metadata + OAS. Retrieval-based selection drops in here
+ * later without changing consumers.
+ */
+object GraphRegistry {
+  val GRAPHS: List<String> = listOf("configure", "price", "quote")
+
+  fun loadToolDefs(): List<ToolDef> =
+    GRAPHS.map { ToolDefGenerator.generate(GraphMetadataParser.parse(it), GraphOasLoader.load(it)) }
+}
+```
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/Orchestrator.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.orchestrator
+
+import com.salesforce.revoman.harness.GraphRunner
+import com.salesforce.revoman.harness.llm.LlmClient
+import com.salesforce.revoman.harness.tooldef.ToolDef
+import com.salesforce.revoman.output.Rundown
+import com.salesforce.revoman.output.Verbosity
+import com.salesforce.revoman.output.toJson
+
+/** The outcome of one orchestration turn. */
+sealed interface OrchestrationResult {
+  data class NoGraphMatched(val utterance: String) : OrchestrationResult
+
+  data class SlotsRejected(val graph: String, val errors: List<String>) : OrchestrationResult
+
+  data class Executed(
+    val graph: String,
+    val slots: Map<String, String>,
+    val rundowns: List<Rundown>,
+    val context: String,
+  ) : OrchestrationResult
+}
+
+/**
+ * The orchestrator-workers loop, made literal: the probabilistic layer (route + slot-fill) selects
+ * and parameterises a graph; the deterministic worker ([GraphRunner] → ReVoman) executes it; the
+ * `Rundown` flows back as context. The LLM never touches API sequencing or intra-graph threading.
+ */
+class Orchestrator(
+  private val baseUrl: String,
+  private val tools: List<ToolDef>,
+  private val llm: LlmClient,
+) {
+  private val router = Router(llm, tools)
+  private val slotFiller = SlotFiller(llm)
+
+  fun orchestrate(utterance: String): OrchestrationResult {
+    val graphName =
+      router.route(utterance).graphName ?: return OrchestrationResult.NoGraphMatched(utterance)
+    val tool = tools.first { it.graphName == graphName }
+    val slots =
+      when (val fill = slotFiller.fill(utterance, tool)) {
+        is FillResult.Valid -> fill.slots
+        is FillResult.Invalid -> return OrchestrationResult.SlotsRejected(graphName, fill.errors)
+      }
+    val rundowns = GraphRunner.runChain(baseUrl, listOf(graphName), seedEnv = slots)
+    val context = rundowns.joinToString("\n") { it.toJson(Verbosity.SUMMARY) }
+    return OrchestrationResult.Executed(graphName, slots, rundowns, context)
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :agentic-harness:test --tests "*OrchestratorTest"`
+Expected: BUILD SUCCESSFUL, 3 tests passed.
+
+- [ ] **Step 5: Write the demo `main()`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/Stage2Demo.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness
+
+import com.salesforce.revoman.harness.llm.StubLlmClient
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import com.salesforce.revoman.harness.orchestrator.Orchestrator
+import com.salesforce.revoman.harness.orchestrator.OrchestrationResult
+
+/**
+ * Stage 2 runnable demo: the orchestrator-workers loop end to end with the deterministic stub LLM
+ * (no API key needed). Routes a handful of utterances, fills+validates slots, executes the chosen
+ * graph via ReVoman, and prints the outcome + the Rundown context that would flow back to the LLM.
+ */
+fun main() {
+  val server = MockCpqServer()
+  val baseUrl = "http://127.0.0.1:${server.start()}"
+  val tools = GraphRegistry.loadToolDefs()
+  val orchestrator = Orchestrator(baseUrl, tools, StubLlmClient())
+  val utterances =
+    listOf(
+      "configure 2 units of SKU-1",
+      "what is the weather today",
+    )
+  try {
+    println("Mock CPQ server up at $baseUrl")
+    utterances.forEach { utterance ->
+      println("\n>>> $utterance")
+      when (val result = orchestrator.orchestrate(utterance)) {
+        is OrchestrationResult.NoGraphMatched -> println("No graph matched.")
+        is OrchestrationResult.SlotsRejected ->
+          println("Slots rejected for '${result.graph}': ${result.errors}")
+        is OrchestrationResult.Executed -> {
+          println("Routed to '${result.graph}', slots=${result.slots}")
+          println(result.context)
+        }
+      }
+    }
+    println("\nFinal mock DB state: ${server.db}")
+  } finally {
+    server.stop()
+  }
+}
+```
+
+- [ ] **Step 6: Add the run task to the module build file**
+
+Append to `agentic-harness/build.gradle.kts`:
+
+```kotlin
+tasks.register<JavaExec>("runStage2Demo") {
+  group = "harness"
+  description = "Run the orchestrator-workers loop (route -> slot-fill -> revUp) with the stub LLM"
+  mainClass.set("com.salesforce.revoman.harness.Stage2DemoKt")
+  classpath = sourceSets["main"].runtimeClasspath
+}
+```
+
+- [ ] **Step 7: Run the demo and the full module suite**
+
+Run: `./gradlew :agentic-harness:runStage2Demo -q`
+Expected: `Mock CPQ server up at ...`, a `>>> configure 2 units of SKU-1` block routed to `configure` with `slots={productCode=SKU-1, quantity=2}` and a JSON summary showing success, a `>>> what is the weather today` block printing `No graph matched.`, and `Final mock DB state: {config:cfg-1=SKU-1 x2}`.
+
+Run: `./gradlew :agentic-harness:test`
+Expected: BUILD SUCCESSFUL — all Stage-1 and Stage-2 test classes pass.
+
+- [ ] **Step 8: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/GraphRegistry.kt \
+  agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/Orchestrator.kt \
+  agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/Stage2Demo.kt \
+  agentic-harness/build.gradle.kts \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/orchestrator/OrchestratorTest.kt
+git commit -m "feat(harness): Orchestrator wires route -> slot-fill -> revUp -> Rundown context"
+```
+
+---
+
+### Task 6: `ClaudeLlmClient` in an isolated `claude` source set (koog, key-gated)
+
+**Files:**
+- Modify: `agentic-harness/build.gradle.kts` (create the `claude` source set + its koog dependency + a `claudeDemo` JavaExec task)
+- Create: `agentic-harness/src/claude/kotlin/com/salesforce/revoman/harness/llm/claude/ClaudeLlmClient.kt`
+- Create: `agentic-harness/src/claude/kotlin/com/salesforce/revoman/harness/ClaudeDemo.kt`
+
+**Interfaces:**
+- Consumes: `LlmClient`, `RouteDecision`, `ToolDef` (from `main`, on the source set's compile classpath); `GraphRegistry`, `Orchestrator`, `OrchestrationResult`, `MockCpqServer` for the demo. koog (`ai.koog:koog-agents:1.1.1`).
+- Produces:
+  - A `claude` source set whose `compileClasspath`/`runtimeClasspath` include `main`'s output; it is NOT wired into `test`/`build`/`check`.
+  - `class ClaudeLlmClient(private val apiKey: String) : LlmClient` in package `...harness.llm.claude` — builds a prompt embedding the tool defs' four fields, calls koog's `simpleAnthropicExecutor(apiKey).execute(prompt, AnthropicModels.Sonnet_4_5)`, and parses the assistant text into a `RouteDecision` (route) or a `Map<String,String>` (slot-fill). Bridges koog's `suspend` API with `kotlinx.coroutines.runBlocking` internally, so it still satisfies the synchronous `LlmClient`. A companion `fromEnv(): LlmClient?` returns an instance when `ANTHROPIC_API_KEY` is set, else `null`.
+  - `fun main()` in `ClaudeDemo.kt`: if `ClaudeLlmClient.fromEnv()` is null, print a skip message and return; else run the `Orchestrator` (against a booted `MockCpqServer`) with the real client on a couple of utterances.
+- **Scope note:** this task's deliverable is that the `claude` source set **compiles** against koog (`./gradlew :agentic-harness:compileClaudeKotlin`) and that `./gradlew :agentic-harness:test` remains green and never compiles this source set. A live Claude call is a manual, key-gated demo — NOT part of any automated test. If koog fails to resolve or compile against Kotlin 2.4.20-Beta1, report the exact error as `DONE_WITH_CONCERNS` (core Stage 2 is already complete and green) — do NOT change the `main`/`test` code to accommodate koog.
+
+- [ ] **Step 1: Add the isolated `claude` source set + koog dependency + demo task**
+
+In `agentic-harness/build.gradle.kts`, after the existing `dependencies { ... }` block, add:
+
+```kotlin
+// --- Isolated `claude` source set: the ONLY place koog lives -------------------------------------
+// Quarantines koog (a large Kotlin-multiplatform dependency built against a different Kotlin
+// version) so a resolution/compat problem can never break the default `test`/`build`/`check`
+// tasks, which never compile this source set. `compileClaudeKotlin` / `claudeDemo` are opt-in.
+val claude: SourceSet by sourceSets.creating {
+  compileClasspath += sourceSets["main"].output
+  runtimeClasspath += sourceSets["main"].output
+}
+
+dependencies { "claudeImplementation"("ai.koog:koog-agents:1.1.1") }
+
+tasks.register<JavaExec>("claudeDemo") {
+  group = "harness"
+  description = "Run the orchestrator with the REAL Claude LLM (requires ANTHROPIC_API_KEY)"
+  mainClass.set("com.salesforce.revoman.harness.ClaudeDemoKt")
+  classpath = claude.runtimeClasspath
+}
+```
+
+- [ ] **Step 2: Verify the source set exists and the default suite ignores it**
+
+Run: `./gradlew :agentic-harness:tasks --all | grep -i claude`
+Expected: `compileClaudeKotlin`, `claudeDemo` listed.
+
+Run: `./gradlew :agentic-harness:test`
+Expected: BUILD SUCCESSFUL, still green — and the build log shows NO `compileClaudeKotlin` task executed.
+
+- [ ] **Step 3: Write `ClaudeLlmClient`**
+
+Create `agentic-harness/src/claude/kotlin/com/salesforce/revoman/harness/llm/claude/ClaudeLlmClient.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.llm.claude
+
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.executor.clients.anthropic.AnthropicModels
+import ai.koog.prompt.executor.llms.all.simpleAnthropicExecutor
+import com.salesforce.revoman.harness.llm.LlmClient
+import com.salesforce.revoman.harness.llm.RouteDecision
+import com.salesforce.revoman.harness.tooldef.ToolDef
+import kotlinx.coroutines.runBlocking
+
+/**
+ * The REAL [LlmClient] backed by Claude via koog. Confined to the isolated `claude` source set so
+ * koog never touches the CI-tested core. Bridges koog's suspend API with [runBlocking] to satisfy
+ * the synchronous [LlmClient] contract. Never required to run tests — gated on [fromEnv].
+ */
+class ClaudeLlmClient(apiKey: String) : LlmClient {
+  private val executor = simpleAnthropicExecutor(apiKey)
+  private val model = AnthropicModels.Sonnet_4_5
+
+  override fun route(utterance: String, tools: List<ToolDef>): RouteDecision {
+    val toolBlock =
+      tools.joinToString("\n\n") { t ->
+        buildString {
+          appendLine("graph: ${t.graphName}")
+          appendLine("when_to_use: ${t.whenToUse}")
+          appendLine("when_not_to_use: ${t.whenNotToUse.joinToString("; ")}")
+          appendLine("example_queries: ${t.exampleQueries.joinToString("; ")}")
+        }
+      }
+    val text =
+      runBlocking {
+        executor
+          .execute(
+            prompt("route") {
+              system(
+                "You are a router. Choose exactly ONE graph name for the user's request, or the " +
+                  "literal word NONE if no graph fits. Reply with ONLY the graph name or NONE.\n\n" +
+                  toolBlock
+              )
+              user(utterance)
+            },
+            model,
+          )
+          .content
+          .trim()
+      }
+    val chosen = tools.firstOrNull { it.graphName.equals(text, ignoreCase = true) }?.graphName
+    return RouteDecision(chosen, "claude replied: $text")
+  }
+
+  override fun fillSlots(utterance: String, tool: ToolDef): Map<String, String> {
+    val schema =
+      tool.slots.entries.joinToString("\n") { (name, s) ->
+        "- $name: type=${s.type}${if (s.values.isNotEmpty()) ", allowed=${s.values}" else ""}"
+      }
+    val examples = tool.inputExamples.joinToString("\n") { it.toString() }
+    val text =
+      runBlocking {
+        executor
+          .execute(
+            prompt("slot-fill") {
+              system(
+                "Extract the input slots for the '${tool.graphName}' graph from the user request. " +
+                  "Reply with ONLY compact JSON of slot->string-value. Use only these slots:\n" +
+                  "$schema\n\nExamples:\n$examples"
+              )
+              user(utterance)
+            },
+            model,
+          )
+          .content
+          .trim()
+      }
+    return parseFlatJson(text)
+  }
+
+  /** Minimal flat-JSON parser for `{"k":"v",...}` — the slot-fill reply shape. */
+  private fun parseFlatJson(json: String): Map<String, String> =
+    Regex(""""(\w+)"\s*:\s*"?([^",}]+)"?""")
+      .findAll(json)
+      .associate { it.groupValues[1] to it.groupValues[2].trim() }
+
+  companion object {
+    fun fromEnv(): LlmClient? = System.getenv("ANTHROPIC_API_KEY")?.let(::ClaudeLlmClient)
+  }
+}
+```
+
+- [ ] **Step 4: Write the Claude demo `main()`**
+
+Create `agentic-harness/src/claude/kotlin/com/salesforce/revoman/harness/ClaudeDemo.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness
+
+import com.salesforce.revoman.harness.llm.claude.ClaudeLlmClient
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import com.salesforce.revoman.harness.orchestrator.Orchestrator
+import com.salesforce.revoman.harness.orchestrator.OrchestrationResult
+
+/** Live demo of the orchestrator with the REAL Claude LLM. No-ops (skips) when the key is absent. */
+fun main() {
+  val llm = ClaudeLlmClient.fromEnv()
+  if (llm == null) {
+    println("ANTHROPIC_API_KEY not set — skipping the live Claude demo.")
+    return
+  }
+  val server = MockCpqServer()
+  val baseUrl = "http://127.0.0.1:${server.start()}"
+  val orchestrator = Orchestrator(baseUrl, GraphRegistry.loadToolDefs(), llm)
+  try {
+    println("Live Claude demo, mock CPQ at $baseUrl")
+    listOf("I want to configure ten of SKU-2", "how much will this cost").forEach { utterance ->
+      println("\n>>> $utterance")
+      when (val r = orchestrator.orchestrate(utterance)) {
+        is OrchestrationResult.NoGraphMatched -> println("No graph matched.")
+        is OrchestrationResult.SlotsRejected -> println("Slots rejected for '${r.graph}': ${r.errors}")
+        is OrchestrationResult.Executed -> println("Routed to '${r.graph}', slots=${r.slots}\n${r.context}")
+      }
+    }
+    println("\nFinal mock DB state: ${server.db}")
+  } finally {
+    server.stop()
+  }
+}
+```
+
+- [ ] **Step 5: Compile the isolated source set (koog resolution gate)**
+
+Run: `./gradlew :agentic-harness:compileClaudeKotlin`
+Expected: BUILD SUCCESSFUL — koog resolves from Maven Central and the source set compiles.
+
+If it FAILS to resolve or compile (e.g. Kotlin metadata version mismatch): capture the exact error, report `DONE_WITH_CONCERNS`, and STOP. Do not modify any `main`/`test` file. The core Stage 2 is already delivered and green; the real-Claude path is an isolated, opt-in extra.
+
+- [ ] **Step 6: Confirm the default suite is still green and koog-free**
+
+Run: `./gradlew :agentic-harness:test`
+Expected: BUILD SUCCESSFUL — all Stage-1 + Stage-2 tests pass; `compileClaudeKotlin` does NOT run as part of this.
+
+- [ ] **Step 7 (optional, key-gated): run the live demo**
+
+Only if `ANTHROPIC_API_KEY` is exported: `./gradlew :agentic-harness:claudeDemo -q`
+Expected: real routing/slot-fill decisions from Claude, executed against the mock, ending with a `Final mock DB state:` line. Without the key it prints the skip message and exits 0.
+
+- [ ] **Step 8: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/build.gradle.kts \
+  agentic-harness/src/claude/kotlin/com/salesforce/revoman/harness/llm/claude/ClaudeLlmClient.kt \
+  agentic-harness/src/claude/kotlin/com/salesforce/revoman/harness/ClaudeDemo.kt
+git commit -m "feat(harness): real ClaudeLlmClient in isolated koog source set (key-gated)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (Stage 2 rows of the design's concept-to-component map):**
+- Tool-def auto-generation (4 fields) from graph metadata + OAS, pure + unit-tested → Tasks 1–2. ✓
+- Router (intent → graph) → Tasks 3 (stub), 4 (Router), 6 (Claude). ✓
+- Slot-filler, schema-validated before execution, rejects hallucinated args → Task 4. ✓
+- `LlmClient` interface with deterministic STUB (CI, no key) + REAL Claude (koog, key-gated) → Tasks 3, 6. ✓
+- Orchestrator-workers loop: route → slot-fill → revUp → Rundown-as-context → Task 5. ✓
+- koog isolation so tests never need a key / never break on koog → Task 6 source-set design + Global Constraints. ✓
+- Runnable proof: `runStage2Demo` (stub, no key) + `claudeDemo` (real, gated) → Tasks 5, 6. ✓
+- Stages 3–4 are out of scope for this plan (own plans).
+
+**Placeholder scan:** No TBD/TODO/"add error handling"/"similar to Task N". Every code step shows complete code. ✓
+
+**Type consistency:** `GraphSpec(name, description, slots, outputKeys)` (Task 1) consumed unchanged in Tasks 2, 5. `ToolDef(graphName, whenToUse, whenNotToUse, exampleQueries, inputExamples, slots)` (Task 2) used unchanged in Tasks 3, 4, 5, 6. `SlotSchema(type, values, required)` + `SlotType` (Task 2) used in Tasks 3, 4. `LlmClient.route(utterance, tools): RouteDecision` / `fillSlots(utterance, tool): Map<String,String>` (Task 3) implemented by `StubLlmClient` (3), `ClaudeLlmClient` (6), the inline fakes (4, 5). `FillResult.Valid/Invalid` (Task 4) matched in Task 5's `when`. `OrchestrationResult.{NoGraphMatched,SlotsRejected,Executed}` (Task 5) matched in the demos (5, 6). `GraphRunner.runChain(baseUrl, graphs, seedEnv)` and `MockCpqServer.{start,stop,db}` reused from Stage 1 with their verified signatures. koog symbols (`simpleAnthropicExecutor`, `AnthropicModels.Sonnet_4_5`, `prompt{}`, `execute(...).content`) confined to Task 6, verified against the koog source. ✓
+
+**Known risks flagged in-plan:**
+- Task 1: classpath-dir-as-Path resolution is dev/test-only (documented; harness runs via Gradle, never as a jar).
+- Task 6: koog may not resolve/compile against Kotlin 2.4.20-Beta1 → isolated source set means the core stays green; the task reports `DONE_WITH_CONCERNS` rather than touching `main`/`test`.

--- a/docs/superpowers/plans/2026-07-31-agentic-harness-stage3.md
+++ b/docs/superpowers/plans/2026-07-31-agentic-harness-stage3.md
@@ -1,0 +1,1121 @@
+# Agentic Harness — Stage 3 (Evals + Calibration) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the evals + calibration layer: a labeled eval set, a confusion matrix over router graph-selection, a live calibration loop (off-diagonal miss → add a `when_not_to_use` clause → re-run → accuracy moves), a BFCL-style slot-fill check, a tau-bench-style final-DB-state check, and a bounded LLM-as-judge alongside a deterministic ground-truth check.
+
+**Architecture:** Everything is deterministic, koog-free, and CI-safe — driven by the Stage 2 `StubLlmClient` plus a new calibration-aware `ScoringLlmClient` whose routing genuinely changes when a `when_not_to_use` clause is added (that is what makes the calibration demo real, not staged). All new code lives in `agentic-harness/src/main` and `src/test`; nothing touches koog or the `claude` source set.
+
+**Tech Stack:** Kotlin (JVM 21), the `agentic-harness` module, ReVoman (`project(":")`), snakeyaml (eval/gold resource parsing; already a Stage 2 dep), JUnit5 + Google Truth. No koog.
+
+## Global Constraints
+
+- **JDK 21**; never modify the ReVoman library; all work inside `agentic-harness/`.
+- **No koog / kotlinx.coroutines** in any `src/main` or `src/test` file. The default `test`/`build`/`check` must stay green and must never compile the `claude` source set.
+- **Stage 1 and Stage 2 must stay green** after every task: `./gradlew :agentic-harness:test` passes all prior + new test classes.
+- **Copyright header** (SFDC Apache-2.0) on every new `.kt`; JUnit5 + Google Truth; ktfmt Google style (`./gradlew spotlessApply` before every commit).
+- **Verified facts (do not re-derive):**
+  - Stage 2 delivered, in package `com.salesforce.revoman.harness`:
+    - `tooldef.ToolDef(graphName: String, whenToUse: String, whenNotToUse: List<String>, exampleQueries: List<String>, inputExamples: List<Map<String,String>>, slots: Map<String, SlotSchema>)` — a `data class` (so `.copy(...)` is available).
+    - `tooldef.GraphMetadataParser.parse(graph)`, `tooldef.GraphOasLoader.load(graph)`, `tooldef.ToolDefGenerator.generate(spec, oas)`.
+    - `orchestrator.GraphRegistry.GRAPHS: List<String>` = `[configure, price, quote]` and `GraphRegistry.loadToolDefs(): List<ToolDef>`.
+    - `orchestrator.Orchestrator(baseUrl, tools, llm)` with `orchestrate(utterance): OrchestrationResult` (`NoGraphMatched` | `SlotsRejected` | `Executed(graph, slots, rundowns, context)`).
+    - `orchestrator.Router(llm, tools).route(utterance): RouteDecision`, `orchestrator.SlotFiller(llm).fill(utterance, tool): FillResult` (`Valid(slots)` | `Invalid(errors)`).
+    - `llm.LlmClient { route(utterance, tools): RouteDecision; fillSlots(utterance, tool): Map<String,String> }`; `llm.RouteDecision(graphName: String?, rationale)`; `llm.StubLlmClient`.
+    - `mock.MockCpqServer` (`start(): Int`, `stop()`, `db: MutableMap<String,Any?>`).
+  - The mock DB after a configure with `productCode=SKU-1, quantity=2` contains the value `"SKU-1 x2"` under key `config:cfg-1`; after price, `price:prc-2 = 100.0`; after quote, `quote:qot-3 = "DRAFT"`. (Stage 1/2 verified.)
+  - snakeyaml import is `org.yaml.snakeyaml.Yaml`; `Yaml().load<Map<String,Any?>>(text)`.
+
+---
+
+### Task 1: `EvalSet` (labeled resource + loader) + `ConfusionMatrix`
+
+**Files:**
+- Create resource: `agentic-harness/src/main/resources/evals/router-eval.yaml`
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/EvalCase.kt`
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/EvalSet.kt`
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/ConfusionMatrix.kt`
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/EvalSetTest.kt`
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/ConfusionMatrixTest.kt`
+
+**Interfaces:**
+- Produces:
+  - `data class EvalCase(val utterance: String, val expected: String)`.
+  - `object EvalSet { fun load(resource: String = "evals/router-eval.yaml"): List<EvalCase> }` — parses the YAML `cases:` list via snakeyaml.
+  - `data class ConfusionMatrix(val rowLabels: List<String>, val colLabels: List<String>, val counts: Map<String, Map<String, Int>>)` with `val total: Int`, `val correct: Int`, `val accuracy: Double`, and `fun render(): String`.
+  - `object ConfusionMatrices { fun from(pairs: List<Pair<String, String?>>): ConfusionMatrix }` — `pairs` is `(expected, predicted)`; a `null` predicted becomes the column label `"none"`.
+
+- [ ] **Step 1: Write the eval resource**
+
+Create `agentic-harness/src/main/resources/evals/router-eval.yaml`:
+
+```yaml
+# Labeled utterance -> expected graph. The single deliberate near-miss is the last case:
+# "quote me a price for this config" is really a PRICE request, but the word "quote" lures a
+# naive router to the quote graph. Stage 3's calibration loop fixes exactly this with a
+# when_not_to_use clause. Keep this file human-editable — Stage 4's flywheel appends to it.
+cases:
+  - { utterance: "configure 2 units of SKU-1", expected: configure }
+  - { utterance: "set up a new product configuration", expected: configure }
+  - { utterance: "what does this configuration cost", expected: price }
+  - { utterance: "compute the total for my config", expected: price }
+  - { utterance: "create a draft quote for prc-2", expected: quote }
+  - { utterance: "draft a quote from prc-2", expected: quote }
+  - { utterance: "quote me a price for this config", expected: price }
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/EvalSetTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.eval
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class EvalSetTest {
+  @Test
+  fun `loads the labeled router eval set`() {
+    val cases = EvalSet.load()
+    assertThat(cases).hasSize(7)
+    assertThat(cases.first()).isEqualTo(EvalCase("configure 2 units of SKU-1", "configure"))
+    assertThat(cases.map { it.expected }.toSet()).containsExactly("configure", "price", "quote")
+    // The deliberate near-miss: a price intent phrased with the word "quote".
+    assertThat(cases.last()).isEqualTo(EvalCase("quote me a price for this config", "price"))
+  }
+}
+```
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/ConfusionMatrixTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.eval
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class ConfusionMatrixTest {
+  @Test
+  fun `counts correct and off-diagonal predictions`() {
+    val pairs =
+      listOf(
+        "configure" to "configure",
+        "price" to "price",
+        "price" to "quote", // one off-diagonal miss
+        "quote" to "quote",
+      )
+    val m = ConfusionMatrices.from(pairs)
+    assertThat(m.total).isEqualTo(4)
+    assertThat(m.correct).isEqualTo(3)
+    assertThat(m.accuracy).isWithin(1e-9).of(0.75)
+    assertThat(m.counts["price"]!!["quote"]).isEqualTo(1)
+    assertThat(m.counts["price"]!!["price"]).isEqualTo(1)
+  }
+
+  @Test
+  fun `renders a labeled grid and treats a null prediction as none`() {
+    val m = ConfusionMatrices.from(listOf("configure" to null, "price" to "price"))
+    val text = m.render()
+    assertThat(text).contains("price")
+    assertThat(text).contains("none")
+  }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `./gradlew :agentic-harness:test --tests "*EvalSetTest" --tests "*ConfusionMatrixTest"`
+Expected: FAIL — unresolved references `EvalSet`, `EvalCase`, `ConfusionMatrices`, `ConfusionMatrix`.
+
+- [ ] **Step 4: Write `EvalCase` + `EvalSet`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/EvalCase.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.eval
+
+/** One labeled router eval: a user utterance and the graph it should route to. */
+data class EvalCase(val utterance: String, val expected: String)
+```
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/EvalSet.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.eval
+
+import org.yaml.snakeyaml.Yaml
+
+/** Loads the labeled router eval set from a classpath YAML resource. */
+object EvalSet {
+  fun load(resource: String = "evals/router-eval.yaml"): List<EvalCase> {
+    val text =
+      javaClass.classLoader.getResourceAsStream(resource)?.bufferedReader()?.readText()
+        ?: error("Eval set not found on classpath: $resource")
+    @Suppress("UNCHECKED_CAST") val root = Yaml().load<Map<String, Any?>>(text)
+    @Suppress("UNCHECKED_CAST")
+    val cases = (root["cases"] as? List<Map<String, Any?>>).orEmpty()
+    return cases.map { EvalCase(it["utterance"].toString(), it["expected"].toString()) }
+  }
+}
+```
+
+- [ ] **Step 5: Write `ConfusionMatrix`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/ConfusionMatrix.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.eval
+
+/**
+ * A graph-selection confusion matrix: `counts[expected][predicted]` tallies how often the router
+ * predicted each graph for each gold label. The diagonal is correct; every off-diagonal cell is a
+ * confusion that Stage 3's calibration loop turns into a `when_not_to_use` clause.
+ */
+data class ConfusionMatrix(
+  val rowLabels: List<String>,
+  val colLabels: List<String>,
+  val counts: Map<String, Map<String, Int>>,
+) {
+  val total: Int
+    get() = counts.values.sumOf { row -> row.values.sum() }
+
+  val correct: Int
+    get() = rowLabels.sumOf { label -> counts[label]?.get(label) ?: 0 }
+
+  val accuracy: Double
+    get() = if (total == 0) 0.0 else correct.toDouble() / total
+
+  /** Renders an aligned text grid: rows are gold labels, columns are predictions. */
+  fun render(): String {
+    val width = (colLabels + rowLabels).maxOf { it.length } + 2
+    val header = "gold\\pred".padEnd(width) + colLabels.joinToString("") { it.padStart(width) }
+    val rows =
+      rowLabels.joinToString("\n") { row ->
+        row.padEnd(width) +
+          colLabels.joinToString("") { col -> (counts[row]?.get(col) ?: 0).toString().padStart(width) }
+      }
+    return "$header\n$rows\naccuracy: $correct/$total"
+  }
+}
+
+/** Builds a [ConfusionMatrix] from `(expected, predicted)` pairs; a null prediction becomes "none". */
+object ConfusionMatrices {
+  private const val NONE = "none"
+
+  fun from(pairs: List<Pair<String, String?>>): ConfusionMatrix {
+    val rowLabels = pairs.map { it.first }.distinct().sorted()
+    val predicted = pairs.map { it.second ?: NONE }.distinct()
+    val colLabels = (rowLabels + predicted).distinct()
+    val counts =
+      rowLabels.associateWith { row ->
+        colLabels.associateWith { col ->
+          pairs.count { it.first == row && (it.second ?: NONE) == col }
+        }
+      }
+    return ConfusionMatrix(rowLabels, colLabels, counts)
+  }
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `./gradlew :agentic-harness:test --tests "*EvalSetTest" --tests "*ConfusionMatrixTest"`
+Expected: BUILD SUCCESSFUL, 3 tests passed.
+
+- [ ] **Step 7: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/main/resources/evals/router-eval.yaml \
+  agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/EvalCase.kt \
+  agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/EvalSet.kt \
+  agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/ConfusionMatrix.kt \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/EvalSetTest.kt \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/ConfusionMatrixTest.kt
+git commit -m "feat(harness): labeled eval set + confusion matrix"
+```
+
+---
+
+### Task 2: `ScoringLlmClient` — calibration-aware deterministic router
+
+**Files:**
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/llm/ScoringLlmClient.kt`
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/llm/ScoringLlmClientTest.kt`
+
+**Interfaces:**
+- Consumes: `LlmClient`, `RouteDecision`, `StubLlmClient` (Stage 2/3); `ToolDef` (Stage 2).
+- Produces:
+  - `class ScoringLlmClient(private val slotDelegate: LlmClient = StubLlmClient()) : LlmClient`.
+  - `route`: scores each tool = (# distinct utterance tokens found as substrings in the tool's `graphName + whenToUse + exampleQueries`) minus `5 ×` (# of the tool's `whenNotToUse` clauses whose trigger words appear in the utterance). Highest score wins; `null` if the best score `<= 0`. **This is the key property: routing changes when a `whenNotToUse` clause is added.**
+  - `fillSlots`: delegates to `slotDelegate` (calibration is about routing, not extraction).
+  - Tokenizer: lowercase, split on `[^a-z0-9]+`, keep tokens of length `>= 3` minus a small stopword set. Trigger words of a clause: its tokens of length `>= 4`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/llm/ScoringLlmClientTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.llm
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.tooldef.GraphMetadataParser
+import com.salesforce.revoman.harness.tooldef.GraphOasLoader
+import com.salesforce.revoman.harness.tooldef.ToolDef
+import com.salesforce.revoman.harness.tooldef.ToolDefGenerator
+import org.junit.jupiter.api.Test
+
+class ScoringLlmClientTest {
+  // Seed tool defs with when_not_to_use STRIPPED — the un-calibrated starting point.
+  private val seedTools: List<ToolDef> =
+    listOf("configure", "price", "quote").map {
+      ToolDefGenerator.generate(GraphMetadataParser.parse(it), GraphOasLoader.load(it))
+        .copy(whenNotToUse = emptyList())
+    }
+  private val scoring = ScoringLlmClient()
+
+  @Test
+  fun `routes an unambiguous configure utterance`() {
+    assertThat(scoring.route("configure 2 units of SKU-1", seedTools).graphName).isEqualTo("configure")
+  }
+
+  @Test
+  fun `the price-phrased-as-quote utterance mis-routes to quote before calibration`() {
+    assertThat(scoring.route("quote me a price for this config", seedTools).graphName).isEqualTo("quote")
+  }
+
+  @Test
+  fun `adding a when_not_to_use clause to quote fixes the mis-route`() {
+    val calibrated =
+      seedTools.map {
+        if (it.graphName == "quote")
+          it.copy(
+            whenNotToUse =
+              listOf("Do not use when the user asks for a price or cost — that is the price graph.")
+          )
+        else it
+      }
+    assertThat(scoring.route("quote me a price for this config", calibrated).graphName)
+      .isEqualTo("price")
+  }
+
+  @Test
+  fun `returns null for an utterance that matches nothing`() {
+    assertThat(scoring.route("xyzzy plugh", seedTools).graphName).isNull()
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :agentic-harness:test --tests "*ScoringLlmClientTest"`
+Expected: FAIL — unresolved reference `ScoringLlmClient`.
+
+- [ ] **Step 3: Write `ScoringLlmClient`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/llm/ScoringLlmClient.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.llm
+
+import com.salesforce.revoman.harness.tooldef.ToolDef
+
+/**
+ * A deterministic, calibration-aware router. Scores each tool by keyword overlap between the
+ * utterance and the tool's `when_to_use` + `example_queries`, then subtracts a penalty for every
+ * `when_not_to_use` clause whose trigger words appear in the utterance. Unlike [StubLlmClient]'s
+ * fixed keyword map, this client's routing genuinely CHANGES when a `when_not_to_use` clause is
+ * added — which is what makes Stage 3's confusion-matrix calibration loop a real experiment, not a
+ * staged one. Slot-filling is delegated (calibration is about selection, not extraction).
+ */
+class ScoringLlmClient(private val slotDelegate: LlmClient = StubLlmClient()) : LlmClient {
+  private val stopwords =
+    setOf(
+      "the", "for", "this", "that", "with", "into", "from", "and", "you", "your", "does", "what",
+      "are", "our", "its", "new", "saved",
+    )
+  private val penaltyPerClause = 5
+
+  override fun route(utterance: String, tools: List<ToolDef>): RouteDecision {
+    val tokens = tokenize(utterance)
+    val best = tools.map { it to score(tokens, it) }.maxByOrNull { it.second }
+    return if (best == null || best.second <= 0) {
+      RouteDecision(null, "no graph scored above zero for: $utterance")
+    } else {
+      RouteDecision(best.first.graphName, "score=${best.second} for '${best.first.graphName}'")
+    }
+  }
+
+  override fun fillSlots(utterance: String, tool: ToolDef): Map<String, String> =
+    slotDelegate.fillSlots(utterance, tool)
+
+  private fun score(tokens: List<String>, tool: ToolDef): Int {
+    val haystack =
+      (tool.graphName + " " + tool.whenToUse + " " + tool.exampleQueries.joinToString(" "))
+        .lowercase()
+    val positive = tokens.count { token -> haystack.contains(token) }
+    val penalty =
+      tool.whenNotToUse.count { clause ->
+        val triggers = tokenize(clause).filter { it.length >= 4 }
+        triggers.any { trigger -> tokens.any { it.contains(trigger) } }
+      } * penaltyPerClause
+    return positive - penalty
+  }
+
+  private fun tokenize(text: String): List<String> =
+    text.lowercase().split(Regex("[^a-z0-9]+")).filter { it.length >= 3 && it !in stopwords }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :agentic-harness:test --tests "*ScoringLlmClientTest"`
+Expected: BUILD SUCCESSFUL, 4 tests passed. (If the calibration test fails, the penalty is not dominating — confirm `penaltyPerClause = 5` and that the clause's trigger `price` matches the utterance token `price`.)
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/llm/ScoringLlmClient.kt \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/llm/ScoringLlmClientTest.kt
+git commit -m "feat(harness): calibration-aware ScoringLlmClient (when_not_to_use changes routing)"
+```
+
+---
+
+### Task 3: `RouterEvaluator` + the live calibration loop
+
+**Files:**
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/RouterEvaluator.kt`
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/RouterEvaluatorTest.kt`
+
+**Interfaces:**
+- Consumes: `EvalCase`, `ConfusionMatrix`, `ConfusionMatrices` (Task 1); `ScoringLlmClient` (Task 2); `LlmClient`, `Router`, `ToolDef`, `GraphRegistry`.
+- Produces:
+  - `data class Miss(val utterance: String, val expected: String, val predicted: String?)`.
+  - `data class EvalReport(val matrix: ConfusionMatrix, val misses: List<Miss>)` with `val accuracy: Double get() = matrix.accuracy`.
+  - `class RouterEvaluator(private val llm: LlmClient) { fun evaluate(cases: List<EvalCase>, tools: List<ToolDef>): EvalReport }` — routes each case via a `Router`, tallies `(expected, predicted)` into a `ConfusionMatrix`, and collects the mismatches as `Miss`es.
+
+- [ ] **Step 1: Write the failing test (this is the headline calibration test)**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/RouterEvaluatorTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.eval
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.llm.ScoringLlmClient
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import com.salesforce.revoman.harness.tooldef.ToolDef
+import org.junit.jupiter.api.Test
+
+class RouterEvaluatorTest {
+  private val cases = EvalSet.load()
+  private val evaluator = RouterEvaluator(ScoringLlmClient())
+
+  // Seed = the four fields as generated, but with when_not_to_use STRIPPED (un-calibrated start).
+  private val seedTools: List<ToolDef> =
+    GraphRegistry.loadToolDefs().map { it.copy(whenNotToUse = emptyList()) }
+
+  // Calibrated = add the disambiguating clause to the quote graph (mined from the off-diagonal).
+  private val calibratedTools: List<ToolDef> =
+    seedTools.map {
+      if (it.graphName == "quote")
+        it.copy(
+          whenNotToUse =
+            listOf("Do not use when the user asks for a price or cost — that is the price graph.")
+        )
+      else it
+    }
+
+  @Test
+  fun `seed router confuses the price-phrased-as-quote utterance`() {
+    val report = evaluator.evaluate(cases, seedTools)
+    assertThat(report.matrix.correct).isEqualTo(6)
+    assertThat(report.matrix.total).isEqualTo(7)
+    // The single off-diagonal: a price intent predicted as quote.
+    assertThat(report.matrix.counts["price"]!!["quote"]).isEqualTo(1)
+    assertThat(report.misses)
+      .contains(Miss("quote me a price for this config", "price", "quote"))
+  }
+
+  @Test
+  fun `adding the when_not_to_use clause moves accuracy to 100 percent`() {
+    val report = evaluator.evaluate(cases, calibratedTools)
+    assertThat(report.matrix.correct).isEqualTo(7)
+    assertThat(report.matrix.total).isEqualTo(7)
+    assertThat(report.misses).isEmpty()
+    assertThat(report.matrix.counts["price"]!!["quote"]).isEqualTo(0)
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :agentic-harness:test --tests "*RouterEvaluatorTest"`
+Expected: FAIL — unresolved references `RouterEvaluator`, `EvalReport`, `Miss`.
+
+- [ ] **Step 3: Write `RouterEvaluator`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/RouterEvaluator.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.eval
+
+import com.salesforce.revoman.harness.llm.LlmClient
+import com.salesforce.revoman.harness.orchestrator.Router
+import com.salesforce.revoman.harness.tooldef.ToolDef
+
+/** A single graph-selection mismatch from an eval run. */
+data class Miss(val utterance: String, val expected: String, val predicted: String?)
+
+/** The outcome of running the router over an eval set: the confusion matrix plus its misses. */
+data class EvalReport(val matrix: ConfusionMatrix, val misses: List<Miss>) {
+  val accuracy: Double
+    get() = matrix.accuracy
+}
+
+/**
+ * Runs the router over a labeled eval set and produces a confusion matrix + the list of misses.
+ * This is the design's Layer-2 graph-selection eval: run against gold, read the matrix, and turn
+ * each off-diagonal cell into a `when_not_to_use` clause. Re-running with the calibrated tool defs
+ * moves the number — the calibration loop, made measurable.
+ */
+class RouterEvaluator(private val llm: LlmClient) {
+  fun evaluate(cases: List<EvalCase>, tools: List<ToolDef>): EvalReport {
+    val router = Router(llm, tools)
+    val results = cases.map { it to router.route(it.utterance).graphName }
+    val matrix = ConfusionMatrices.from(results.map { (case, predicted) -> case.expected to predicted })
+    val misses =
+      results
+        .filter { (case, predicted) -> case.expected != predicted }
+        .map { (case, predicted) -> Miss(case.utterance, case.expected, predicted) }
+    return EvalReport(matrix, misses)
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :agentic-harness:test --tests "*RouterEvaluatorTest"`
+Expected: BUILD SUCCESSFUL, 2 tests passed.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/RouterEvaluator.kt \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/RouterEvaluatorTest.kt
+git commit -m "feat(harness): RouterEvaluator + confusion-matrix calibration loop (6/7 -> 7/7)"
+```
+
+---
+
+### Task 4: `BfclCheck` (slot-fill vs gold) + `TauBenchCheck` (final DB state)
+
+**Files:**
+- Create resource: `agentic-harness/src/main/resources/evals/slotfill-gold.yaml`
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/BfclCheck.kt`
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/TauBenchCheck.kt`
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/BfclCheckTest.kt`
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/TauBenchCheckTest.kt`
+
+**Interfaces:**
+- Consumes: `LlmClient`, `StubLlmClient`, `Router`, `SlotFiller`, `FillResult`, `ToolDef`, `GraphRegistry`, `Orchestrator`, `OrchestrationResult`, `MockCpqServer`.
+- Produces:
+  - `data class SlotFillGold(val utterance: String, val graph: String, val slots: Map<String, String>)` and `object SlotFillGoldSet { fun load(resource: String = "evals/slotfill-gold.yaml"): List<SlotFillGold> }`.
+  - `data class BfclResult(val gold: SlotFillGold, val predictedGraph: String?, val predictedSlots: Map<String, String>, val graphMatch: Boolean, val slotsMatch: Boolean) { val pass: Boolean get() = graphMatch && slotsMatch }`.
+  - `class BfclCheck(private val llm: LlmClient, private val tools: List<ToolDef>) { fun check(gold: SlotFillGold): BfclResult }` — routes + slot-fills the utterance and AST-compares (value equality of graph + slot map) against gold. A `SlotFiller.Invalid` yields empty predicted slots (a fail).
+  - `data class TaskCase(val utterance: String, val expectedDbValues: List<String>)`.
+  - `class TauBenchCheck(private val baseUrl: String, private val tools: List<ToolDef>, private val llm: LlmClient) { fun check(server: MockCpqServer, case: TaskCase): Boolean }` — orchestrates the utterance and asserts the mock DB's values contain all `expectedDbValues` (final-state comparison, not transcript).
+
+- [ ] **Step 1: Write the gold resource**
+
+Create `agentic-harness/src/main/resources/evals/slotfill-gold.yaml`:
+
+```yaml
+# BFCL-style gold: the exact graph + filled slots each utterance should produce.
+cases:
+  - utterance: "configure 2 units of SKU-1"
+    graph: configure
+    slots: { productCode: "SKU-1", quantity: "2" }
+  - utterance: "price configuration cfg-1"
+    graph: price
+    slots: { configId: "cfg-1" }
+  - utterance: "create a draft quote for prc-2"
+    graph: quote
+    slots: { priceId: "prc-2" }
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/BfclCheckTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.eval
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.llm.StubLlmClient
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import org.junit.jupiter.api.Test
+
+class BfclCheckTest {
+  private val tools = GraphRegistry.loadToolDefs()
+  private val bfcl = BfclCheck(StubLlmClient(), tools)
+
+  @Test
+  fun `loads the slot-fill gold set`() {
+    assertThat(SlotFillGoldSet.load()).hasSize(3)
+  }
+
+  @Test
+  fun `predicted call matches gold for a configure utterance`() {
+    val gold = SlotFillGold("configure 2 units of SKU-1", "configure", mapOf("productCode" to "SKU-1", "quantity" to "2"))
+    val result = bfcl.check(gold)
+    assertThat(result.graphMatch).isTrue()
+    assertThat(result.slotsMatch).isTrue()
+    assertThat(result.pass).isTrue()
+  }
+
+  @Test
+  fun `every gold case passes with the stub client`() {
+    val results = SlotFillGoldSet.load().map { bfcl.check(it) }
+    assertThat(results.all { it.pass }).isTrue()
+  }
+}
+```
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/TauBenchCheckTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.eval
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.llm.StubLlmClient
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class TauBenchCheckTest {
+  private lateinit var server: MockCpqServer
+  private lateinit var baseUrl: String
+  private val tools = GraphRegistry.loadToolDefs()
+
+  @BeforeEach
+  fun setUp() {
+    server = MockCpqServer()
+    baseUrl = "http://127.0.0.1:${server.start()}"
+  }
+
+  @AfterEach fun tearDown() = server.stop()
+
+  @Test
+  fun `configure task reaches the expected final DB state`() {
+    val check = TauBenchCheck(baseUrl, tools, StubLlmClient())
+    val passed = check.check(server, TaskCase("configure 2 units of SKU-1", listOf("SKU-1 x2")))
+    assertThat(passed).isTrue()
+  }
+
+  @Test
+  fun `an unmet final state fails the task`() {
+    val check = TauBenchCheck(baseUrl, tools, StubLlmClient())
+    val passed = check.check(server, TaskCase("configure 2 units of SKU-1", listOf("SKU-9 x99")))
+    assertThat(passed).isFalse()
+  }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `./gradlew :agentic-harness:test --tests "*BfclCheckTest" --tests "*TauBenchCheckTest"`
+Expected: FAIL — unresolved references `BfclCheck`, `SlotFillGold`, `SlotFillGoldSet`, `BfclResult`, `TauBenchCheck`, `TaskCase`.
+
+- [ ] **Step 4: Write `BfclCheck`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/BfclCheck.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.eval
+
+import com.salesforce.revoman.harness.llm.LlmClient
+import com.salesforce.revoman.harness.orchestrator.FillResult
+import com.salesforce.revoman.harness.orchestrator.Router
+import com.salesforce.revoman.harness.orchestrator.SlotFiller
+import com.salesforce.revoman.harness.tooldef.ToolDef
+import org.yaml.snakeyaml.Yaml
+
+/** BFCL-style gold: the exact graph + slot values an utterance should produce. */
+data class SlotFillGold(val utterance: String, val graph: String, val slots: Map<String, String>)
+
+/** Loads the BFCL gold set from a classpath YAML resource. */
+object SlotFillGoldSet {
+  fun load(resource: String = "evals/slotfill-gold.yaml"): List<SlotFillGold> {
+    val text =
+      javaClass.classLoader.getResourceAsStream(resource)?.bufferedReader()?.readText()
+        ?: error("Slot-fill gold not found on classpath: $resource")
+    @Suppress("UNCHECKED_CAST") val root = Yaml().load<Map<String, Any?>>(text)
+    @Suppress("UNCHECKED_CAST") val cases = (root["cases"] as? List<Map<String, Any?>>).orEmpty()
+    return cases.map { c ->
+      @Suppress("UNCHECKED_CAST") val slots = (c["slots"] as? Map<String, Any?>).orEmpty()
+      SlotFillGold(c["utterance"].toString(), c["graph"].toString(), slots.mapValues { it.value.toString() })
+    }
+  }
+}
+
+/** The outcome of one BFCL comparison: predicted call vs gold, by value equality. */
+data class BfclResult(
+  val gold: SlotFillGold,
+  val predictedGraph: String?,
+  val predictedSlots: Map<String, String>,
+  val graphMatch: Boolean,
+  val slotsMatch: Boolean,
+) {
+  val pass: Boolean
+    get() = graphMatch && slotsMatch
+}
+
+/**
+ * BFCL-style check: run the router + slot-filler over an utterance and AST-compare the predicted
+ * call (graph name + filled slots) against gold by value equality. Rejected (invalid) slot-fills
+ * predict no slots — a clean fail, never a silent partial pass.
+ */
+class BfclCheck(private val llm: LlmClient, private val tools: List<ToolDef>) {
+  private val router = Router(llm, tools)
+  private val slotFiller = SlotFiller(llm)
+
+  fun check(gold: SlotFillGold): BfclResult {
+    val predictedGraph = router.route(gold.utterance).graphName
+    val tool = tools.firstOrNull { it.graphName == predictedGraph }
+    val predictedSlots =
+      if (tool == null) emptyMap()
+      else
+        when (val fill = slotFiller.fill(gold.utterance, tool)) {
+          is FillResult.Valid -> fill.slots
+          is FillResult.Invalid -> emptyMap()
+        }
+    val graphMatch = predictedGraph == gold.graph
+    val slotsMatch = predictedSlots == gold.slots
+    return BfclResult(gold, predictedGraph, predictedSlots, graphMatch, slotsMatch)
+  }
+}
+```
+
+- [ ] **Step 5: Write `TauBenchCheck`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/TauBenchCheck.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.eval
+
+import com.salesforce.revoman.harness.llm.LlmClient
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.orchestrator.Orchestrator
+import com.salesforce.revoman.harness.tooldef.ToolDef
+
+/** A task-success case: an utterance and the final DB values it should produce. */
+data class TaskCase(val utterance: String, val expectedDbValues: List<String>)
+
+/**
+ * tau-bench-style check: grade the final database STATE, not the chat transcript. Orchestrates the
+ * utterance end to end and asserts the mock CPQ DB's values contain every expected value.
+ */
+class TauBenchCheck(
+  private val baseUrl: String,
+  private val tools: List<ToolDef>,
+  private val llm: LlmClient,
+) {
+  fun check(server: MockCpqServer, case: TaskCase): Boolean {
+    Orchestrator(baseUrl, tools, llm).orchestrate(case.utterance)
+    val actual = server.db.values.map { it.toString() }
+    return case.expectedDbValues.all { expected -> actual.contains(expected) }
+  }
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `./gradlew :agentic-harness:test --tests "*BfclCheckTest" --tests "*TauBenchCheckTest"`
+Expected: BUILD SUCCESSFUL, 5 tests passed.
+
+- [ ] **Step 7: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/main/resources/evals/slotfill-gold.yaml \
+  agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/BfclCheck.kt \
+  agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/TauBenchCheck.kt \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/BfclCheckTest.kt \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/TauBenchCheckTest.kt
+git commit -m "feat(harness): BFCL slot-fill check + tau-bench final-DB-state check"
+```
+
+---
+
+### Task 5: `LlmJudge` (bounded) + `Stage3Demo`
+
+**Files:**
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/LlmJudge.kt`
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/Stage3Demo.kt`
+- Modify: `agentic-harness/build.gradle.kts` (add a `runStage3Demo` JavaExec task)
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/LlmJudgeTest.kt`
+
+**Interfaces:**
+- Consumes: everything above; `Orchestrator`, `OrchestrationResult`, `MockCpqServer`, `GraphRegistry`, `StubLlmClient`, `ScoringLlmClient`, `Rundown`.
+- Produces:
+  - `data class Judgment(val pass: Boolean, val reason: String)`.
+  - `interface LlmJudge { fun judge(utterance: String, responseContext: String): Judgment }`.
+  - `class StubJudge : LlmJudge` — deterministic: passes when the response context indicates success (`"unsuccessfulStepCount": 0` present and `"areAllStepsSuccessful": true` present). This is the *screening* judge.
+  - `object GroundTruth { fun allStepsSucceeded(rundowns: List<Rundown>): Boolean }` — the deterministic *gate* (never drifts): `rundowns.isNotEmpty() && rundowns.all { it.areAllStepsSuccessful }`.
+  - `fun main()` in `Stage3Demo.kt` + a `runStage3Demo` JavaExec task (mainClass `com.salesforce.revoman.harness.Stage3DemoKt`) that runs: (1) the confusion matrix before/after calibration, printing both matrices and the accuracy move; (2) the BFCL check over the gold set; (3) the tau-bench check; (4) the judge alongside the deterministic ground-truth, noting the judge only screens.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/LlmJudgeTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.eval
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.llm.StubLlmClient
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import com.salesforce.revoman.harness.orchestrator.Orchestrator
+import com.salesforce.revoman.harness.orchestrator.OrchestrationResult
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class LlmJudgeTest {
+  private lateinit var server: MockCpqServer
+  private lateinit var baseUrl: String
+  private val tools = GraphRegistry.loadToolDefs()
+
+  @BeforeEach
+  fun setUp() {
+    server = MockCpqServer()
+    baseUrl = "http://127.0.0.1:${server.start()}"
+  }
+
+  @AfterEach fun tearDown() = server.stop()
+
+  @Test
+  fun `judge screens a successful turn and ground truth confirms it`() {
+    val result =
+      Orchestrator(baseUrl, tools, StubLlmClient()).orchestrate("configure 2 units of SKU-1")
+    val executed = result as OrchestrationResult.Executed
+
+    val judgment = StubJudge().judge("configure 2 units of SKU-1", executed.context)
+    assertThat(judgment.pass).isTrue()
+
+    // The deterministic gate agrees — the judge is only a screen, not the source of truth.
+    assertThat(GroundTruth.allStepsSucceeded(executed.rundowns)).isTrue()
+  }
+
+  @Test
+  fun `judge fails an empty or unsuccessful context`() {
+    assertThat(StubJudge().judge("x", "no useful context here").pass).isFalse()
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :agentic-harness:test --tests "*LlmJudgeTest"`
+Expected: FAIL — unresolved references `StubJudge`, `Judgment`, `GroundTruth`.
+
+- [ ] **Step 3: Write `LlmJudge`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/LlmJudge.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.eval
+
+import com.salesforce.revoman.output.Rundown
+
+/** A judge's verdict on a fuzzy metric — advisory, used only to screen. */
+data class Judgment(val pass: Boolean, val reason: String)
+
+/**
+ * LLM-as-judge for fuzzy metrics (response helpfulness / trajectory quality). Bounded on purpose:
+ * it only SCREENS. The gate is always the deterministic [GroundTruth]. A real implementation would
+ * call Claude here; the [StubJudge] is the deterministic stand-in for CI.
+ */
+interface LlmJudge {
+  fun judge(utterance: String, responseContext: String): Judgment
+}
+
+/** Deterministic screening judge: "helpful" iff the response context reports a clean run. */
+class StubJudge : LlmJudge {
+  override fun judge(utterance: String, responseContext: String): Judgment {
+    val clean =
+      responseContext.contains("\"unsuccessfulStepCount\": 0") &&
+        responseContext.contains("\"areAllStepsSuccessful\": true")
+    return if (clean) Judgment(true, "context reports all steps successful")
+    else Judgment(false, "context does not report a clean, successful run")
+  }
+}
+
+/**
+ * The deterministic ground-truth gate that never drifts. Prefer this over the judge wherever a
+ * deterministic check exists; the judge only covers what this cannot.
+ */
+object GroundTruth {
+  fun allStepsSucceeded(rundowns: List<Rundown>): Boolean =
+    rundowns.isNotEmpty() && rundowns.all { it.areAllStepsSuccessful }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :agentic-harness:test --tests "*LlmJudgeTest"`
+Expected: BUILD SUCCESSFUL, 2 tests passed.
+
+- [ ] **Step 5: Write `Stage3Demo`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/Stage3Demo.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness
+
+import com.salesforce.revoman.harness.eval.BfclCheck
+import com.salesforce.revoman.harness.eval.EvalSet
+import com.salesforce.revoman.harness.eval.GroundTruth
+import com.salesforce.revoman.harness.eval.RouterEvaluator
+import com.salesforce.revoman.harness.eval.SlotFillGoldSet
+import com.salesforce.revoman.harness.eval.StubJudge
+import com.salesforce.revoman.harness.eval.TaskCase
+import com.salesforce.revoman.harness.eval.TauBenchCheck
+import com.salesforce.revoman.harness.llm.ScoringLlmClient
+import com.salesforce.revoman.harness.llm.StubLlmClient
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import com.salesforce.revoman.harness.orchestrator.Orchestrator
+import com.salesforce.revoman.harness.orchestrator.OrchestrationResult
+
+/**
+ * Stage 3 runnable demo: evals + calibration in action, entirely deterministic (no API key). Shows
+ * (1) the confusion matrix before/after adding a `when_not_to_use` clause and the accuracy move,
+ * (2) BFCL slot-fill checks vs gold, (3) a tau-bench final-DB-state check, (4) an LLM-as-judge
+ * screening a fuzzy metric alongside the deterministic ground-truth gate.
+ */
+fun main() {
+  val cases = EvalSet.load()
+  val evaluator = RouterEvaluator(ScoringLlmClient())
+  val seedTools = GraphRegistry.loadToolDefs().map { it.copy(whenNotToUse = emptyList()) }
+  val clause = "Do not use when the user asks for a price or cost — that is the price graph."
+  val calibratedTools =
+    seedTools.map { if (it.graphName == "quote") it.copy(whenNotToUse = listOf(clause)) else it }
+
+  println("=== 1. Graph-selection confusion matrix (SEED, un-calibrated) ===")
+  val seed = evaluator.evaluate(cases, seedTools)
+  println(seed.matrix.render())
+  println("misses: ${seed.misses}")
+
+  println("\n=== 2. Calibration: add when_not_to_use to 'quote' ===")
+  println("  + $clause")
+  val calibrated = evaluator.evaluate(cases, calibratedTools)
+  println(calibrated.matrix.render())
+  println(
+    "accuracy moved: ${seed.matrix.correct}/${seed.matrix.total} -> " +
+      "${calibrated.matrix.correct}/${calibrated.matrix.total}"
+  )
+
+  println("\n=== 3. BFCL-style slot-fill check (predicted call vs gold) ===")
+  val tools = GraphRegistry.loadToolDefs()
+  val bfcl = BfclCheck(StubLlmClient(), tools)
+  SlotFillGoldSet.load().forEach { gold ->
+    val r = bfcl.check(gold)
+    println("  ${if (r.pass) "PASS" else "FAIL"}  '${gold.utterance}' -> ${r.predictedGraph} ${r.predictedSlots}")
+  }
+
+  val server = MockCpqServer()
+  val baseUrl = "http://127.0.0.1:${server.start()}"
+  try {
+    println("\n=== 4. tau-bench-style task success (final DB state) ===")
+    val tau = TauBenchCheck(baseUrl, tools, StubLlmClient())
+    val taskCase = TaskCase("configure 2 units of SKU-1", listOf("SKU-1 x2"))
+    println("  ${if (tau.check(server, taskCase)) "PASS" else "FAIL"}  final DB = ${server.db}")
+
+    println("\n=== 5. LLM-as-judge (screen) alongside deterministic ground-truth (gate) ===")
+    when (val result = Orchestrator(baseUrl, tools, StubLlmClient()).orchestrate("configure 2 units of SKU-1")) {
+      is OrchestrationResult.Executed -> {
+        val judgment = StubJudge().judge("configure 2 units of SKU-1", result.context)
+        println("  judge (advisory screen): pass=${judgment.pass} — ${judgment.reason}")
+        println("  ground-truth (gate):     pass=${GroundTruth.allStepsSucceeded(result.rundowns)}")
+      }
+      else -> println("  (unexpected: $result)")
+    }
+  } finally {
+    server.stop()
+  }
+}
+```
+
+- [ ] **Step 6: Add the run task to the module build file**
+
+Append to `agentic-harness/build.gradle.kts`:
+
+```kotlin
+tasks.register<JavaExec>("runStage3Demo") {
+  group = "harness"
+  description = "Run the evals + calibration demo (confusion matrix, BFCL, tau-bench, LLM-judge)"
+  mainClass.set("com.salesforce.revoman.harness.Stage3DemoKt")
+  classpath = sourceSets["main"].runtimeClasspath
+}
+```
+
+- [ ] **Step 7: Run the demo and the full module suite**
+
+Run: `./gradlew :agentic-harness:runStage3Demo -q`
+Expected: section 1 prints a 3×3 matrix with `accuracy: 6/7` and a miss `Miss(utterance=quote me a price for this config, expected=price, predicted=quote)`; section 2 prints a matrix with `accuracy: 7/7` and `accuracy moved: 6/7 -> 7/7`; section 3 prints three `PASS` BFCL lines; section 4 prints `PASS  final DB = {config:cfg-1=SKU-1 x2}`; section 5 prints `judge ... pass=true` and `ground-truth ... pass=true`.
+
+Run: `./gradlew :agentic-harness:test`
+Expected: BUILD SUCCESSFUL — all Stage 1, 2, and 3 test classes pass.
+
+- [ ] **Step 8: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/eval/LlmJudge.kt \
+  agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/Stage3Demo.kt \
+  agentic-harness/build.gradle.kts \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/eval/LlmJudgeTest.kt
+git commit -m "feat(harness): LLM-as-judge (bounded) + Stage 3 evals/calibration demo"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (Stage 3 rows of the design's concept-to-component map):**
+- Labeled eval set (utterance → expected graph) → Task 1 (`EvalSet` + resource). ✓
+- Confusion matrix, graph-selection accuracy → Task 1 (`ConfusionMatrix`) + Task 3 (`RouterEvaluator`). ✓
+- Live calibration: off-diagonal miss → add `when_not_to_use` → re-run → number moves → Task 2 (`ScoringLlmClient` makes routing sensitive to `when_not_to_use`) + Task 3 (6/7 → 7/7 test + demo). ✓
+- BFCL-style predicted-call-vs-gold for slot-fill → Task 4 (`BfclCheck`). ✓
+- tau-bench-style final-DB-state for task success → Task 4 (`TauBenchCheck`). ✓
+- LLM-as-judge on a fuzzy metric, bounded, with a deterministic ground-truth alongside → Task 5 (`StubJudge` + `GroundTruth`). ✓
+- Runnable proof: `runStage3Demo` (no key) → Task 5. ✓
+- Stage 4 (OTel + flywheel) is out of scope for this plan.
+
+**Placeholder scan:** No TBD/TODO/"add error handling"/"similar to Task N". Every code step shows complete code. ✓
+
+**Type consistency:** `EvalCase(utterance, expected)` (Task 1) used in Tasks 3, 5. `ConfusionMatrix`/`ConfusionMatrices.from(pairs)` (Task 1) used in Task 3. `ScoringLlmClient(slotDelegate = StubLlmClient())` (Task 2) implements the Stage 2 `LlmClient` and is used in Tasks 3, 5. `EvalReport(matrix, misses)` + `Miss(utterance, expected, predicted)` (Task 3) used in Task 5. `SlotFillGold`/`SlotFillGoldSet`/`BfclResult`/`BfclCheck` and `TaskCase`/`TauBenchCheck` (Task 4) used in Task 5. `Judgment`/`LlmJudge`/`StubJudge`/`GroundTruth` (Task 5). All reuse verified Stage 1/2 APIs (`GraphRegistry.loadToolDefs`, `Router`, `SlotFiller`/`FillResult`, `Orchestrator`/`OrchestrationResult`, `MockCpqServer`, `ToolDef.copy`, `Rundown.areAllStepsSuccessful`). ✓
+
+**Calibration correctness (hand-verified):** with `when_not_to_use` stripped, the `ScoringLlmClient` scores `quote`=3 vs `price`=2 on "quote me a price for this config" (gold=price) → mis-routes to quote → seed accuracy 6/7 with the single off-diagonal `[price→quote]`. Adding the clause (trigger word `price` matches the utterance token `price`) applies a `-5` penalty to quote → quote 3−5=−2 < price 2 → routes to price → 7/7. The other six cases are unaffected (their utterances contain none of the clause's trigger words in a way that changes the winner). ✓
+
+**Known risks flagged in-plan:** Task 2 Step 4 notes the penalty must dominate; Task 4/5 reuse the mock DB value formats verified in Stages 1–2 (`"SKU-1 x2"`, `config:cfg-1`).

--- a/docs/superpowers/plans/2026-07-31-agentic-harness-stage4.md
+++ b/docs/superpowers/plans/2026-07-31-agentic-harness-stage4.md
@@ -1,0 +1,979 @@
+# Agentic Harness — Stage 4 (Observability + Feedback Flywheel) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the observability + feedback layer: OpenTelemetry GenAI-convention spans (`invoke_agent` / `chat` / `execute_tool`) emitted to the console for each orchestration turn, a simulated HITL confirm gate (confirm / edit / reject → positive / correction-pair / negative labels), and a nightly-batch function that appends confirmed turns to the eval set and drafts `when_not_to_use` clauses from confusion pairs — closing the loop by showing the CI gate tighten (accuracy rises when the drafted clause is applied).
+
+**Architecture:** Everything is deterministic, koog-free, dependency-free, and CI-safe. Tracing is a self-contained `GenAiTracer` that models the OpenTelemetry GenAI semantic conventions (span names + `gen_ai.*` attributes) and renders the span tree to a sink (console by default; captured in tests). It is NOT the OpenTelemetry OTLP SDK — no new dependency — but it is faithful to the convention's span shape, which is what the design demonstrates ("OTel GenAI-style spans to console or a local collector"). The `Orchestrator` gains one optional constructor parameter (a tracer, defaulting to a no-op) so every prior-stage test stays green unchanged. All new code lives in `agentic-harness/src/main` and `src/test`.
+
+**Tech Stack:** Kotlin (JVM 21), the `agentic-harness` module, ReVoman (`project(":")`), snakeyaml (already a dep), JUnit5 + Google Truth. No koog, no OpenTelemetry SDK.
+
+## Global Constraints
+
+- **JDK 21**; never modify the ReVoman library; all work inside `agentic-harness/`.
+- **No koog / kotlinx.coroutines / OpenTelemetry-SDK** dependency in any `src/main` or `src/test` file. The default `test`/`build`/`check` stays green and never compiles the `claude` source set.
+- **Stages 1–3 must stay green** after every task: `./gradlew :agentic-harness:test` passes all prior + new test classes. The one modification to existing code (`Orchestrator` gains an optional tracer param with a no-op default) must not change any existing test's behavior.
+- **Copyright header** (SFDC Apache-2.0) on every new `.kt`; JUnit5 + Google Truth; ktfmt Google style (`./gradlew spotlessApply` before every commit).
+- **Verified facts (do not re-derive):**
+  - `orchestrator.Orchestrator(baseUrl, tools, llm)` currently has `orchestrate(utterance): OrchestrationResult` (`NoGraphMatched(utterance)` | `SlotsRejected(graph, errors)` | `Executed(graph, slots, rundowns, context)`). It composes `Router(llm, tools)` and `SlotFiller(llm)`, then `GraphRunner.runChain(baseUrl, listOf(graphName), seedEnv = slots)`, then joins `Rundown.toJson(Verbosity.SUMMARY)`.
+  - `output.Rundown` exposes `stopReason: StopReason`, `executedStepCount: Int`, `unsuccessfulStepCount: Int`, `areAllStepsSuccessful: Boolean`.
+  - Stage 3 delivered in `eval`: `EvalCase(utterance, expected)`, `EvalSet.load(...)`, `ConfusionMatrix`/`ConfusionMatrices.from(pairs)`, `RouterEvaluator(llm).evaluate(cases, tools): EvalReport(matrix, misses)`, `Miss(utterance, expected, predicted)`, `Scoring­LlmClient`.
+  - Stage 2 delivered: `tooldef.ToolDef` (data class; `.copy(...)` available; has `whenNotToUse: List<String>`), `orchestrator.GraphRegistry.loadToolDefs()`, `llm.StubLlmClient`, `mock.MockCpqServer`.
+  - The design's GenAI span conventions: an `invoke_agent` span per turn; nested `chat` spans per LLM call (with `gen_ai.request.model`); nested `execute_tool` spans per graph run (nesting Rundown stats: step count, stopReason, failures). Attribute keys follow `gen_ai.*` (e.g. `gen_ai.operation.name`, `gen_ai.agent.name`, `gen_ai.tool.name`).
+
+---
+
+### Task 1: `GenAiTracer` — OTel GenAI-convention span model + console renderer
+
+**Files:**
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/telemetry/Span.kt`
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/telemetry/GenAiTracer.kt`
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/telemetry/GenAiTracerTest.kt`
+
+**Interfaces:**
+- Produces:
+  - `data class Span(val name: String, val attributes: Map<String, Any?>, val children: List<Span>)` with `fun render(indent: Int = 0): String` (a nested, indented text tree).
+  - `interface Tracer { fun <T> span(name: String, attributes: Map<String, Any?> = emptyMap(), block: (SpanScope) -> T): T }` and `interface SpanScope { fun setAttribute(key: String, value: Any?) }` — spans nest via the block; a child `span(...)` called inside a parent's block becomes that parent's child.
+  - `class NoopTracer : Tracer` — runs the block, records nothing (the default for tests that don't assert on spans).
+  - `class GenAiTracer(private val sink: (String) -> Unit = ::println) : Tracer` — builds the span tree; when the outermost span closes, emits `root.render()` to `sink`. Exposes `val rootSpans: List<Span>` (completed top-level spans) for assertions.
+  - Convention helpers (top-level funs in `GenAiTracer.kt`): `fun invokeAgentAttrs(agentName: String): Map<String, Any?>` = `{"gen_ai.operation.name":"invoke_agent","gen_ai.agent.name":agentName}`; `fun chatAttrs(model: String): Map<String, Any?>` = `{"gen_ai.operation.name":"chat","gen_ai.request.model":model}`; `fun executeToolAttrs(toolName: String): Map<String, Any?>` = `{"gen_ai.operation.name":"execute_tool","gen_ai.tool.name":toolName}`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/telemetry/GenAiTracerTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.telemetry
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class GenAiTracerTest {
+  @Test
+  fun `nests child spans under the parent and records attributes`() {
+    val tracer = GenAiTracer(sink = {})
+    tracer.span("invoke_agent", invokeAgentAttrs("q2c-agent")) { agent ->
+      tracer.span("chat", chatAttrs("stub")) { it.setAttribute("gen_ai.response.text", "configure") }
+      tracer.span("execute_tool", executeToolAttrs("configure")) { it.setAttribute("steps", 1) }
+      agent.setAttribute("turn.ok", true)
+    }
+
+    assertThat(tracer.rootSpans).hasSize(1)
+    val root = tracer.rootSpans.single()
+    assertThat(root.name).isEqualTo("invoke_agent")
+    assertThat(root.attributes).containsEntry("gen_ai.operation.name", "invoke_agent")
+    assertThat(root.attributes).containsEntry("turn.ok", true)
+    assertThat(root.children.map { it.name }).containsExactly("chat", "execute_tool").inOrder()
+    assertThat(root.children[1].attributes).containsEntry("gen_ai.tool.name", "configure")
+  }
+
+  @Test
+  fun `renders a nested indented tree and emits to the sink on root close`() {
+    val emitted = StringBuilder()
+    val tracer = GenAiTracer(sink = { emitted.append(it) })
+    tracer.span("invoke_agent", invokeAgentAttrs("q2c-agent")) {
+      tracer.span("chat", chatAttrs("stub")) {}
+    }
+    val text = emitted.toString()
+    assertThat(text).contains("invoke_agent")
+    assertThat(text).contains("chat")
+    assertThat(text).contains("gen_ai.operation.name=invoke_agent")
+    // The child is indented deeper than the parent.
+    assertThat(text.indexOf("chat")).isGreaterThan(text.indexOf("invoke_agent"))
+  }
+
+  @Test
+  fun `NoopTracer runs the block but records nothing`() {
+    val noop = NoopTracer()
+    val result = noop.span("invoke_agent") { 42 }
+    assertThat(result).isEqualTo(42)
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :agentic-harness:test --tests "*GenAiTracerTest"`
+Expected: FAIL — unresolved references `GenAiTracer`, `NoopTracer`, `Span`, `invokeAgentAttrs`, etc.
+
+- [ ] **Step 3: Write `Span`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/telemetry/Span.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.telemetry
+
+/**
+ * One completed span in the OpenTelemetry GenAI-convention shape: a name, `gen_ai.*` attributes,
+ * and nested child spans. This is a faithful model of the convention's span tree rendered to a
+ * console sink — not the OTLP wire SDK (no dependency), which is what the local demo needs.
+ */
+data class Span(val name: String, val attributes: Map<String, Any?>, val children: List<Span>) {
+  fun render(indent: Int = 0): String {
+    val pad = "  ".repeat(indent)
+    val attrs = attributes.entries.joinToString(", ") { "${it.key}=${it.value}" }
+    val head = "$pad• $name" + if (attrs.isEmpty()) "" else "  [$attrs]"
+    val kids = children.joinToString("") { "\n" + it.render(indent + 1) }
+    return head + kids
+  }
+}
+```
+
+- [ ] **Step 4: Write `GenAiTracer`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/telemetry/GenAiTracer.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.telemetry
+
+/** A scope for adding attributes to the currently-open span. */
+interface SpanScope {
+  fun setAttribute(key: String, value: Any?)
+}
+
+/** Opens spans that nest via the block: a `span(...)` called inside another's block is its child. */
+interface Tracer {
+  fun <T> span(name: String, attributes: Map<String, Any?> = emptyMap(), block: (SpanScope) -> T): T
+}
+
+/** A tracer that runs blocks but records nothing — the default when tracing isn't wanted. */
+class NoopTracer : Tracer {
+  override fun <T> span(name: String, attributes: Map<String, Any?>, block: (SpanScope) -> T): T =
+    block(
+      object : SpanScope {
+        override fun setAttribute(key: String, value: Any?) {}
+      }
+    )
+}
+
+/**
+ * Records the OpenTelemetry GenAI-convention span tree and renders it to [sink] when each top-level
+ * span closes. Single-threaded by design (the harness confines a turn to one thread, exactly like
+ * ReVoman's `revUp`). Not the OTLP SDK — a dependency-free, faithful console rendering of the
+ * `invoke_agent` / `chat` / `execute_tool` span shape.
+ */
+class GenAiTracer(private val sink: (String) -> Unit = ::println) : Tracer {
+  private class Building(val name: String, val attributes: MutableMap<String, Any?>) : SpanScope {
+    val children: MutableList<Span> = mutableListOf()
+
+    override fun setAttribute(key: String, value: Any?) {
+      attributes[key] = value
+    }
+
+    fun toSpan(): Span = Span(name, attributes.toMap(), children.toList())
+  }
+
+  private val stack: ArrayDeque<Building> = ArrayDeque()
+  private val _rootSpans: MutableList<Span> = mutableListOf()
+
+  val rootSpans: List<Span>
+    get() = _rootSpans.toList()
+
+  override fun <T> span(name: String, attributes: Map<String, Any?>, block: (SpanScope) -> T): T {
+    val building = Building(name, attributes.toMutableMap())
+    stack.addLast(building)
+    try {
+      return block(building)
+    } finally {
+      stack.removeLast()
+      val span = building.toSpan()
+      val parent = stack.lastOrNull()
+      if (parent == null) {
+        _rootSpans.add(span)
+        sink(span.render())
+      } else {
+        parent.children.add(span)
+      }
+    }
+  }
+}
+
+/** GenAI-convention attributes for an agent-invocation (turn) span. */
+fun invokeAgentAttrs(agentName: String): Map<String, Any?> =
+  mapOf("gen_ai.operation.name" to "invoke_agent", "gen_ai.agent.name" to agentName)
+
+/** GenAI-convention attributes for an LLM chat span. */
+fun chatAttrs(model: String): Map<String, Any?> =
+  mapOf("gen_ai.operation.name" to "chat", "gen_ai.request.model" to model)
+
+/** GenAI-convention attributes for a tool-execution (graph run) span. */
+fun executeToolAttrs(toolName: String): Map<String, Any?> =
+  mapOf("gen_ai.operation.name" to "execute_tool", "gen_ai.tool.name" to toolName)
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `./gradlew :agentic-harness:test --tests "*GenAiTracerTest"`
+Expected: BUILD SUCCESSFUL, 3 tests passed.
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/telemetry/Span.kt \
+  agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/telemetry/GenAiTracer.kt \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/telemetry/GenAiTracerTest.kt
+git commit -m "feat(harness): OTel GenAI-convention tracer (invoke_agent/chat/execute_tool)"
+```
+
+---
+
+### Task 2: Instrument `Orchestrator` with GenAI spans (additive, no-op default)
+
+**Files:**
+- Modify: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/Orchestrator.kt`
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/orchestrator/OrchestratorTracingTest.kt`
+
+**Interfaces:**
+- Consumes: `Tracer`, `NoopTracer`, `GenAiTracer`, `invokeAgentAttrs`/`chatAttrs`/`executeToolAttrs` (Task 1).
+- Produces:
+  - `Orchestrator` gains a 4th constructor param: `private val tracer: Tracer = NoopTracer()`. Existing 3-arg construction is unchanged (default no-op), so all prior tests compile and pass untouched.
+  - `orchestrate` wraps the turn in an `invoke_agent` span; emits a `chat` span for routing (attribute `gen_ai.response.text` = the chosen graph or "none"), a `chat` span for slot-filling (attribute `slots.filled` = the filled map's size or the rejection), and — on execution — an `execute_tool` span whose attributes carry the Rundown stats (`gen_ai.tool.name`, `steps` = `executedStepCount`, `stop_reason` = `stopReason`, `unsuccessful_steps` = `unsuccessfulStepCount`). Behavior/return value is unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/orchestrator/OrchestratorTracingTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.orchestrator
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.llm.StubLlmClient
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.telemetry.GenAiTracer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class OrchestratorTracingTest {
+  private lateinit var server: MockCpqServer
+  private lateinit var baseUrl: String
+  private val tools = GraphRegistry.loadToolDefs()
+
+  @BeforeEach
+  fun setUp() {
+    server = MockCpqServer()
+    baseUrl = "http://127.0.0.1:${server.start()}"
+  }
+
+  @AfterEach fun tearDown() = server.stop()
+
+  @Test
+  fun `an executed turn emits invoke_agent with nested chat and execute_tool spans`() {
+    val tracer = GenAiTracer(sink = {})
+    Orchestrator(baseUrl, tools, StubLlmClient(), tracer)
+      .orchestrate("configure 2 units of SKU-1")
+
+    val root = tracer.rootSpans.single()
+    assertThat(root.name).isEqualTo("invoke_agent")
+    assertThat(root.attributes).containsEntry("gen_ai.operation.name", "invoke_agent")
+    val childNames = root.children.map { it.name }
+    // Two chat spans (route + slot-fill) then an execute_tool span.
+    assertThat(childNames).containsExactly("chat", "chat", "execute_tool").inOrder()
+    val executeTool = root.children.last()
+    assertThat(executeTool.attributes).containsEntry("gen_ai.tool.name", "configure")
+    assertThat(executeTool.attributes).containsEntry("steps", 1)
+    assertThat(executeTool.attributes.keys).contains("stop_reason")
+  }
+
+  @Test
+  fun `a no-match turn emits invoke_agent with only the routing chat span`() {
+    val tracer = GenAiTracer(sink = {})
+    Orchestrator(baseUrl, tools, StubLlmClient(), tracer).orchestrate("what is the weather")
+    val root = tracer.rootSpans.single()
+    assertThat(root.children.map { it.name }).containsExactly("chat")
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :agentic-harness:test --tests "*OrchestratorTracingTest"`
+Expected: FAIL — the 4-arg `Orchestrator(...)` constructor does not yet exist (unresolved), or spans are absent.
+
+- [ ] **Step 3: Modify `Orchestrator` to emit spans**
+
+Replace the body of `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/Orchestrator.kt` with (keep the `OrchestrationResult` sealed interface exactly as-is at the top of the file; only the class changes):
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.orchestrator
+
+import com.salesforce.revoman.harness.GraphRunner
+import com.salesforce.revoman.harness.llm.LlmClient
+import com.salesforce.revoman.harness.telemetry.NoopTracer
+import com.salesforce.revoman.harness.telemetry.Tracer
+import com.salesforce.revoman.harness.telemetry.chatAttrs
+import com.salesforce.revoman.harness.telemetry.executeToolAttrs
+import com.salesforce.revoman.harness.telemetry.invokeAgentAttrs
+import com.salesforce.revoman.harness.tooldef.ToolDef
+import com.salesforce.revoman.output.Rundown
+import com.salesforce.revoman.output.Verbosity
+import com.salesforce.revoman.output.toJson
+
+/** The outcome of one orchestration turn. */
+sealed interface OrchestrationResult {
+  data class NoGraphMatched(val utterance: String) : OrchestrationResult
+
+  data class SlotsRejected(val graph: String, val errors: List<String>) : OrchestrationResult
+
+  data class Executed(
+    val graph: String,
+    val slots: Map<String, String>,
+    val rundowns: List<Rundown>,
+    val context: String,
+  ) : OrchestrationResult
+}
+
+/**
+ * The orchestrator-workers loop, made literal: the probabilistic layer (route + slot-fill) selects
+ * and parameterises a graph; the deterministic worker ([GraphRunner] → ReVoman) executes it; the
+ * `Rundown` flows back as context. The LLM never touches API sequencing or intra-graph threading.
+ *
+ * Each turn is traced with OpenTelemetry GenAI-convention spans via [tracer] (a no-op by default,
+ * so callers that don't want tracing are unaffected): an `invoke_agent` span for the turn, nested
+ * `chat` spans for the two LLM jobs, and an `execute_tool` span carrying the Rundown stats.
+ */
+class Orchestrator(
+  private val baseUrl: String,
+  private val tools: List<ToolDef>,
+  private val llm: LlmClient,
+  private val tracer: Tracer = NoopTracer(),
+) {
+  private val router = Router(llm, tools)
+  private val slotFiller = SlotFiller(llm)
+
+  fun orchestrate(utterance: String): OrchestrationResult =
+    tracer.span("invoke_agent", invokeAgentAttrs("q2c-agent")) { agent ->
+      agent.setAttribute("gen_ai.prompt", utterance)
+
+      val graphName =
+        tracer.span("chat", chatAttrs("router")) { chat ->
+          val decision = router.route(utterance)
+          chat.setAttribute("gen_ai.response.text", decision.graphName ?: "none")
+          decision.graphName
+        }
+      if (graphName == null) {
+        agent.setAttribute("turn.outcome", "no_graph_matched")
+        return@span OrchestrationResult.NoGraphMatched(utterance)
+      }
+      val tool =
+        tools.firstOrNull { it.graphName == graphName }
+          ?: run {
+            agent.setAttribute("turn.outcome", "no_graph_matched")
+            return@span OrchestrationResult.NoGraphMatched(utterance)
+          }
+
+      val fill =
+        tracer.span("chat", chatAttrs("slot-filler")) { chat ->
+          val result = slotFiller.fill(utterance, tool)
+          chat.setAttribute(
+            "gen_ai.response.text",
+            when (result) {
+              is FillResult.Valid -> result.slots.toString()
+              is FillResult.Invalid -> "rejected: ${result.errors}"
+            },
+          )
+          result
+        }
+      val slots =
+        when (fill) {
+          is FillResult.Valid -> fill.slots
+          is FillResult.Invalid -> {
+            agent.setAttribute("turn.outcome", "slots_rejected")
+            return@span OrchestrationResult.SlotsRejected(graphName, fill.errors)
+          }
+        }
+
+      tracer.span("execute_tool", executeToolAttrs(graphName)) { exec ->
+        val rundowns = GraphRunner.runChain(baseUrl, listOf(graphName), seedEnv = slots)
+        val last = rundowns.lastOrNull()
+        exec.setAttribute("steps", rundowns.sumOf { it.executedStepCount })
+        exec.setAttribute("stop_reason", last?.stopReason?.toString() ?: "NONE")
+        exec.setAttribute("unsuccessful_steps", rundowns.sumOf { it.unsuccessfulStepCount })
+        agent.setAttribute("turn.outcome", "executed")
+        val context = rundowns.joinToString("\n") { it.toJson(Verbosity.SUMMARY) }
+        OrchestrationResult.Executed(graphName, slots, rundowns, context)
+      }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tracing test AND the whole suite (existing tests must stay green)**
+
+Run: `./gradlew :agentic-harness:test --tests "*OrchestratorTracingTest"`
+Expected: BUILD SUCCESSFUL, 2 tests passed.
+
+Run: `./gradlew :agentic-harness:test`
+Expected: BUILD SUCCESSFUL — every Stage 1/2/3 test class still passes (the no-op default preserves prior behavior; `OrchestratorTest`, `TauBenchCheckTest`, `LlmJudgeTest` all construct `Orchestrator` with 3 args and are unaffected).
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/Orchestrator.kt \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/orchestrator/OrchestratorTracingTest.kt
+git commit -m "feat(harness): trace orchestrator turns with GenAI spans (no-op default)"
+```
+
+---
+
+### Task 3: `ConfirmGate` — HITL confirm / edit / reject → labels
+
+**Files:**
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/feedback/ConfirmGate.kt`
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/feedback/ConfirmGateTest.kt`
+
+**Interfaces:**
+- Consumes: nothing from prior tasks (pure feedback modeling).
+- Produces:
+  - `data class Proposal(val utterance: String, val graph: String, val slots: Map<String, String>)` — the write the agent proposes at the gate.
+  - `sealed interface Decision { object Confirm : Decision; data class Edit(val correctedSlots: Map<String, String>) : Decision; data class Reject(val correctGraph: String? = null) : Decision }`.
+  - `sealed interface FeedbackLabel { data class Positive(val proposal: Proposal) : FeedbackLabel; data class CorrectionPair(val proposal: Proposal, val correctedSlots: Map<String, String>) : FeedbackLabel; data class Negative(val proposal: Proposal, val correctGraph: String?) : FeedbackLabel }`.
+  - `object ConfirmGate { fun apply(proposal: Proposal, decision: Decision): FeedbackLabel }` — `Confirm` → `Positive`; `Edit` → `CorrectionPair` (proposal vs corrected slots); `Reject` → `Negative` (carrying the human's correct graph if given). This is the design's "free labeling machine": the confirm step *is* the feedback signal.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/feedback/ConfirmGateTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.feedback
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class ConfirmGateTest {
+  private val proposal =
+    Proposal("configure 2 units of SKU-1", "configure", mapOf("productCode" to "SKU-1", "quantity" to "2"))
+
+  @Test
+  fun `confirm yields a positive label`() {
+    val label = ConfirmGate.apply(proposal, Decision.Confirm)
+    assertThat(label).isInstanceOf(FeedbackLabel.Positive::class.java)
+    assertThat((label as FeedbackLabel.Positive).proposal).isEqualTo(proposal)
+  }
+
+  @Test
+  fun `edit yields a correction pair carrying the fixed slots`() {
+    val fixed = mapOf("productCode" to "SKU-1", "quantity" to "5")
+    val label = ConfirmGate.apply(proposal, Decision.Edit(fixed))
+    assertThat(label).isInstanceOf(FeedbackLabel.CorrectionPair::class.java)
+    val pair = label as FeedbackLabel.CorrectionPair
+    assertThat(pair.proposal.slots).containsEntry("quantity", "2")
+    assertThat(pair.correctedSlots).containsEntry("quantity", "5")
+  }
+
+  @Test
+  fun `reject yields a negative label carrying the human's correct graph`() {
+    val label = ConfirmGate.apply(proposal, Decision.Reject(correctGraph = "price"))
+    assertThat(label).isInstanceOf(FeedbackLabel.Negative::class.java)
+    assertThat((label as FeedbackLabel.Negative).correctGraph).isEqualTo("price")
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :agentic-harness:test --tests "*ConfirmGateTest"`
+Expected: FAIL — unresolved references `Proposal`, `Decision`, `FeedbackLabel`, `ConfirmGate`.
+
+- [ ] **Step 3: Write `ConfirmGate`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/feedback/ConfirmGate.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.feedback
+
+/** The write the agent proposes at the human confirm gate. */
+data class Proposal(val utterance: String, val graph: String, val slots: Map<String, String>)
+
+/** What the human does at the gate. */
+sealed interface Decision {
+  /** Approve the proposal as-is. */
+  object Confirm : Decision
+
+  /** Approve after fixing the slots. */
+  data class Edit(val correctedSlots: Map<String, String>) : Decision
+
+  /** Reject; optionally state the graph that should have been chosen. */
+  data class Reject(val correctGraph: String? = null) : Decision
+}
+
+/** The training signal the gate emits — the design's "free labeling machine". */
+sealed interface FeedbackLabel {
+  data class Positive(val proposal: Proposal) : FeedbackLabel
+
+  data class CorrectionPair(val proposal: Proposal, val correctedSlots: Map<String, String>) :
+    FeedbackLabel
+
+  data class Negative(val proposal: Proposal, val correctGraph: String?) : FeedbackLabel
+}
+
+/**
+ * The human-in-the-loop confirm gate on every write. Because a human confirms every mutation, the
+ * gate is the highest-value labeling signal available at no extra cost: confirm → positive, edit →
+ * a correction pair (proposed vs fixed), reject → a negative (mined for `when_not_to_use`).
+ */
+object ConfirmGate {
+  fun apply(proposal: Proposal, decision: Decision): FeedbackLabel =
+    when (decision) {
+      is Decision.Confirm -> FeedbackLabel.Positive(proposal)
+      is Decision.Edit -> FeedbackLabel.CorrectionPair(proposal, decision.correctedSlots)
+      is Decision.Reject -> FeedbackLabel.Negative(proposal, decision.correctGraph)
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :agentic-harness:test --tests "*ConfirmGateTest"`
+Expected: BUILD SUCCESSFUL, 3 tests passed.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/feedback/ConfirmGate.kt \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/feedback/ConfirmGateTest.kt
+git commit -m "feat(harness): HITL confirm gate maps confirm/edit/reject to feedback labels"
+```
+
+---
+
+### Task 4: `NightlyBatch` — grow the eval set + draft `when_not_to_use` from confusion pairs
+
+**Files:**
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/feedback/NightlyBatch.kt`
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/feedback/NightlyBatchTest.kt`
+
+**Interfaces:**
+- Consumes: `FeedbackLabel`, `Proposal` (Task 3); `eval.EvalCase` (Stage 3).
+- Produces:
+  - `data class BatchOutput(val grownEvalSet: List<EvalCase>, val draftedClauses: Map<String, List<String>>)` — `draftedClauses` maps a graph name → the `when_not_to_use` clauses drafted for it.
+  - `object NightlyBatch { fun run(seedEvalSet: List<EvalCase>, labels: List<FeedbackLabel>): BatchOutput }`:
+    - Confirmed turns (`Positive`) become new `EvalCase(utterance, proposal.graph)` appended to the eval set (deduped against existing utterances).
+    - `Negative` turns with a known `correctGraph` become both a new `EvalCase(utterance, correctGraph)` (a regression test so that exact miss never returns) AND a drafted `when_not_to_use` clause on the *wrongly-chosen* graph: `"Do not use for requests like \"<utterance>\" — that is the <correctGraph> graph."`.
+    - `CorrectionPair` (slot edit) does not change graph selection, so it grows neither the eval set nor the clauses here (it is slot-fill training data; recorded but not used for router calibration).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/feedback/NightlyBatchTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.feedback
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.eval.EvalCase
+import org.junit.jupiter.api.Test
+
+class NightlyBatchTest {
+  private val seed = listOf(EvalCase("configure 2 units of SKU-1", "configure"))
+
+  @Test
+  fun `confirmed turns append new golden cases to the eval set`() {
+    val labels =
+      listOf(
+        FeedbackLabel.Positive(Proposal("price configuration cfg-1", "price", mapOf("configId" to "cfg-1")))
+      )
+    val out = NightlyBatch.run(seed, labels)
+    assertThat(out.grownEvalSet).hasSize(2)
+    assertThat(out.grownEvalSet).contains(EvalCase("price configuration cfg-1", "price"))
+  }
+
+  @Test
+  fun `a reject with a known correct graph drafts a when_not_to_use clause and a regression case`() {
+    val labels =
+      listOf(
+        FeedbackLabel.Negative(
+          Proposal("quote me a price for this config", "quote", emptyMap()),
+          correctGraph = "price",
+        )
+      )
+    val out = NightlyBatch.run(seed, labels)
+    // A regression eval case pinning the correct answer.
+    assertThat(out.grownEvalSet).contains(EvalCase("quote me a price for this config", "price"))
+    // A drafted clause on the WRONGLY-chosen graph (quote), pointing at the correct one (price).
+    assertThat(out.draftedClauses.keys).contains("quote")
+    assertThat(out.draftedClauses["quote"]!!.single()).contains("price")
+  }
+
+  @Test
+  fun `a slot correction does not change the eval set or clauses`() {
+    val labels =
+      listOf(
+        FeedbackLabel.CorrectionPair(
+          Proposal("configure 2 units of SKU-1", "configure", mapOf("quantity" to "2")),
+          correctedSlots = mapOf("quantity" to "5"),
+        )
+      )
+    val out = NightlyBatch.run(seed, labels)
+    assertThat(out.grownEvalSet).isEqualTo(seed)
+    assertThat(out.draftedClauses).isEmpty()
+  }
+
+  @Test
+  fun `dedupes an already-present utterance`() {
+    val labels =
+      listOf(FeedbackLabel.Positive(Proposal("configure 2 units of SKU-1", "configure", emptyMap())))
+    val out = NightlyBatch.run(seed, labels)
+    assertThat(out.grownEvalSet).hasSize(1)
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :agentic-harness:test --tests "*NightlyBatchTest"`
+Expected: FAIL — unresolved references `NightlyBatch`, `BatchOutput`.
+
+- [ ] **Step 3: Write `NightlyBatch`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/feedback/NightlyBatch.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.feedback
+
+import com.salesforce.revoman.harness.eval.EvalCase
+
+/** What a nightly batch produces: the grown eval set and clauses drafted per wrongly-chosen graph. */
+data class BatchOutput(
+  val grownEvalSet: List<EvalCase>,
+  val draftedClauses: Map<String, List<String>>,
+)
+
+/**
+ * The nightly feedback batch: turns the confirm-gate labels into a bigger eval set and drafted
+ * `when_not_to_use` clauses — the flywheel that makes the CI gate tighten itself over time.
+ * Confirmed turns become positive golden cases; rejects with a known-right graph become both a
+ * regression case (so that exact miss never returns) and a drafted clause on the graph that was
+ * wrongly chosen. Slot corrections are slot-fill training data and do not affect router selection.
+ */
+object NightlyBatch {
+  fun run(seedEvalSet: List<EvalCase>, labels: List<FeedbackLabel>): BatchOutput {
+    val seenUtterances = seedEvalSet.map { it.utterance }.toMutableSet()
+    val grown = seedEvalSet.toMutableList()
+    val clauses = mutableMapOf<String, MutableList<String>>()
+
+    labels.forEach { label ->
+      when (label) {
+        is FeedbackLabel.Positive ->
+          addCase(grown, seenUtterances, label.proposal.utterance, label.proposal.graph)
+        is FeedbackLabel.Negative -> {
+          val correct = label.correctGraph ?: return@forEach
+          addCase(grown, seenUtterances, label.proposal.utterance, correct)
+          val clause =
+            "Do not use for requests like \"${label.proposal.utterance}\" — " +
+              "that is the $correct graph."
+          clauses.getOrPut(label.proposal.graph) { mutableListOf() }.add(clause)
+        }
+        is FeedbackLabel.CorrectionPair -> Unit // slot-fill signal; not a router-selection change
+      }
+    }
+    return BatchOutput(grown.toList(), clauses.mapValues { it.value.toList() })
+  }
+
+  private fun addCase(
+    into: MutableList<EvalCase>,
+    seen: MutableSet<String>,
+    utterance: String,
+    graph: String,
+  ) {
+    if (seen.add(utterance)) into.add(EvalCase(utterance, graph))
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :agentic-harness:test --tests "*NightlyBatchTest"`
+Expected: BUILD SUCCESSFUL, 4 tests passed.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/feedback/NightlyBatch.kt \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/feedback/NightlyBatchTest.kt
+git commit -m "feat(harness): nightly batch grows eval set + drafts when_not_to_use from rejects"
+```
+
+---
+
+### Task 5: `Stage4Demo` — the full flywheel, runnable; + close the loop with a re-eval
+
+**Files:**
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/Stage4Demo.kt`
+- Modify: `agentic-harness/build.gradle.kts` (add a `runStage4Demo` JavaExec task)
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/feedback/FlywheelClosesLoopTest.kt`
+
+**Interfaces:**
+- Consumes: everything above; `GenAiTracer` (Task 1), instrumented `Orchestrator` (Task 2), `ConfirmGate`/`Proposal`/`Decision`/`FeedbackLabel` (Task 3), `NightlyBatch`/`BatchOutput` (Task 4); `RouterEvaluator`/`EvalSet`/`ScoringLlmClient` (Stage 3); `GraphRegistry`, `StubLlmClient`, `MockCpqServer`.
+- Produces:
+  - `fun main()` in `Stage4Demo.kt` + a `runStage4Demo` JavaExec task (mainClass `com.salesforce.revoman.harness.Stage4DemoKt`) that: (1) runs a couple of turns through the instrumented `Orchestrator` with a `GenAiTracer` printing spans to console; (2) sends each executed turn's proposal through the `ConfirmGate` with a scripted mix (confirm, and a reject of the near-miss utterance with `correctGraph = "price"`); (3) runs `NightlyBatch` and prints the grown eval-set size + the drafted `when_not_to_use` clause; (4) closes the loop: evaluate the router on the grown eval set with seed tools vs tools calibrated with the drafted clause, printing the accuracy move ("CI gate tightened").
+  - The `FlywheelClosesLoopTest` proves the loop end-to-end deterministically: a rejected near-miss turn → nightly batch drafts a clause + adds the regression case → applying the drafted clause makes the `RouterEvaluator` score the grown set with strictly higher accuracy than the un-calibrated seed tools do.
+
+- [ ] **Step 1: Write the failing loop-closing test**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/feedback/FlywheelClosesLoopTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.feedback
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.eval.EvalCase
+import com.salesforce.revoman.harness.eval.RouterEvaluator
+import com.salesforce.revoman.harness.llm.ScoringLlmClient
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import org.junit.jupiter.api.Test
+
+class FlywheelClosesLoopTest {
+  private val evaluator = RouterEvaluator(ScoringLlmClient())
+  private val seedTools = GraphRegistry.loadToolDefs().map { it.copy(whenNotToUse = emptyList()) }
+
+  @Test
+  fun `a rejected near-miss, mined by the nightly batch, tightens the CI gate`() {
+    // The confirm gate rejected the near-miss turn, stating the correct graph is price.
+    val labels =
+      listOf(
+        FeedbackLabel.Negative(
+          Proposal("quote me a price for this config", "quote", emptyMap()),
+          correctGraph = "price",
+        )
+      )
+    val seedEval = listOf(EvalCase("create a draft quote for prc-2", "quote"))
+
+    val batch = NightlyBatch.run(seedEval, labels)
+    // The batch grew the eval set with the regression case and drafted a clause on 'quote'.
+    assertThat(batch.grownEvalSet).contains(EvalCase("quote me a price for this config", "price"))
+    val drafted = batch.draftedClauses["quote"]!!
+
+    // Apply the drafted clause to the quote tool = the calibrated tools.
+    val calibratedTools =
+      seedTools.map { if (it.graphName == "quote") it.copy(whenNotToUse = drafted) else it }
+
+    val before = evaluator.evaluate(batch.grownEvalSet, seedTools)
+    val after = evaluator.evaluate(batch.grownEvalSet, calibratedTools)
+
+    // The auto-drafted clause strictly improves accuracy on the grown eval set — the flywheel works.
+    assertThat(after.matrix.correct).isGreaterThan(before.matrix.correct)
+    assertThat(after.misses).isEmpty()
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :agentic-harness:test --tests "*FlywheelClosesLoopTest"`
+Expected: FAIL — it will not compile until `Stage4Demo` exists only if the test referenced it; here the test uses existing classes, so it should compile and FAIL only if the drafted clause does not improve accuracy. If it fails on the assertion, the drafted-clause wording's trigger tokens (`price`, and the near-miss words) must overlap the utterance — confirm `NightlyBatch`'s clause contains the word `price` and the utterance. (If it passes immediately, that is fine — the loop-closing behavior is the deliverable; proceed to the demo.)
+
+- [ ] **Step 3: Write `Stage4Demo`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/Stage4Demo.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness
+
+import com.salesforce.revoman.harness.eval.RouterEvaluator
+import com.salesforce.revoman.harness.eval.EvalSet
+import com.salesforce.revoman.harness.feedback.ConfirmGate
+import com.salesforce.revoman.harness.feedback.Decision
+import com.salesforce.revoman.harness.feedback.FeedbackLabel
+import com.salesforce.revoman.harness.feedback.NightlyBatch
+import com.salesforce.revoman.harness.feedback.Proposal
+import com.salesforce.revoman.harness.llm.ScoringLlmClient
+import com.salesforce.revoman.harness.llm.StubLlmClient
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import com.salesforce.revoman.harness.orchestrator.Orchestrator
+import com.salesforce.revoman.harness.orchestrator.OrchestrationResult
+import com.salesforce.revoman.harness.telemetry.GenAiTracer
+
+/**
+ * Stage 4 runnable demo: observability + the feedback flywheel, all deterministic (no API key).
+ * (1) Traces turns with OpenTelemetry GenAI-convention spans printed to console. (2) Runs each
+ * executed proposal through the HITL confirm gate (a scripted confirm + a reject of the near-miss).
+ * (3) Runs the nightly batch to grow the eval set and draft a `when_not_to_use` clause. (4) Closes
+ * the loop: re-evaluates the router on the grown set, showing the CI gate tighten.
+ */
+fun main() {
+  val tools = GraphRegistry.loadToolDefs()
+  val server = MockCpqServer()
+  val baseUrl = "http://127.0.0.1:${server.start()}"
+  val tracer = GenAiTracer()
+  val orchestrator = Orchestrator(baseUrl, tools, StubLlmClient(), tracer)
+
+  try {
+    println("=== 1. Traced orchestration turns (OTel GenAI spans to console) ===")
+    val executed = orchestrator.orchestrate("configure 2 units of SKU-1")
+
+    println("\n=== 2. HITL confirm gate ===")
+    val labels = mutableListOf<FeedbackLabel>()
+    if (executed is OrchestrationResult.Executed) {
+      val proposal = Proposal("configure 2 units of SKU-1", executed.graph, executed.slots)
+      val label = ConfirmGate.apply(proposal, Decision.Confirm)
+      labels.add(label)
+      println("  confirm -> $label")
+    }
+    // A human rejects the near-miss the router would get wrong, stating the correct graph.
+    val rejectProposal = Proposal("quote me a price for this config", "quote", emptyMap())
+    val rejectLabel = ConfirmGate.apply(rejectProposal, Decision.Reject(correctGraph = "price"))
+    labels.add(rejectLabel)
+    println("  reject  -> $rejectLabel")
+
+    println("\n=== 3. Nightly batch (mine labels -> grow eval set + draft when_not_to_use) ===")
+    val seedEval = EvalSet.load()
+    val batch = NightlyBatch.run(seedEval, labels)
+    println("  eval set grew: ${seedEval.size} -> ${batch.grownEvalSet.size} cases")
+    batch.draftedClauses.forEach { (graph, clauses) ->
+      clauses.forEach { println("  drafted when_not_to_use for '$graph': $it") }
+    }
+
+    println("\n=== 4. Close the loop: re-eval shows the CI gate tighten ===")
+    val evaluator = RouterEvaluator(ScoringLlmClient())
+    val seedTools = tools.map { it.copy(whenNotToUse = emptyList()) }
+    val calibratedTools =
+      seedTools.map {
+        if (batch.draftedClauses.containsKey(it.graphName))
+          it.copy(whenNotToUse = batch.draftedClauses[it.graphName]!!)
+        else it
+      }
+    val before = evaluator.evaluate(batch.grownEvalSet, seedTools)
+    val after = evaluator.evaluate(batch.grownEvalSet, calibratedTools)
+    println("  accuracy on grown eval set: ${before.matrix.correct}/${before.matrix.total} -> " +
+      "${after.matrix.correct}/${after.matrix.total}  (auto-drafted from a rejected turn)")
+  } finally {
+    server.stop()
+  }
+}
+```
+
+- [ ] **Step 4: Add the run task to the module build file**
+
+Append to `agentic-harness/build.gradle.kts`:
+
+```kotlin
+tasks.register<JavaExec>("runStage4Demo") {
+  group = "harness"
+  description = "Run the observability + feedback-flywheel demo (spans, confirm gate, nightly batch)"
+  mainClass.set("com.salesforce.revoman.harness.Stage4DemoKt")
+  classpath = sourceSets["main"].runtimeClasspath
+}
+```
+
+- [ ] **Step 5: Run the loop test, the demo, and the full suite**
+
+Run: `./gradlew :agentic-harness:test --tests "*FlywheelClosesLoopTest"`
+Expected: BUILD SUCCESSFUL, 1 test passed.
+
+Run: `./gradlew :agentic-harness:runStage4Demo -q`
+Expected: section 1 prints an `• invoke_agent` span tree with nested `• chat` (×2) and `• execute_tool` spans carrying `gen_ai.*` attributes + Rundown stats; section 2 prints `confirm -> Positive(...)` and `reject -> Negative(...)`; section 3 prints `eval set grew: 7 -> 8 cases` and a `drafted when_not_to_use for 'quote': Do not use for requests like "quote me a price for this config" — that is the price graph.`; section 4 prints an accuracy move where the calibrated number is strictly higher than the seed number on the grown set.
+
+Run: `./gradlew :agentic-harness:test`
+Expected: BUILD SUCCESSFUL — all Stage 1/2/3/4 test classes pass.
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/Stage4Demo.kt \
+  agentic-harness/build.gradle.kts \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/feedback/FlywheelClosesLoopTest.kt
+git commit -m "feat(harness): Stage 4 flywheel demo — spans, confirm gate, nightly batch, loop close"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (Stage 4 rows of the design's concept-to-component map):**
+- OTel GenAI-style spans (`invoke_agent`/`execute_tool`/`chat`) to console → Task 1 (`GenAiTracer`) + Task 2 (instrumented `Orchestrator`). ✓
+- HITL confirm gate: confirm/edit/reject → positive/correction-pair/negative labels → Task 3 (`ConfirmGate`). ✓
+- Nightly-batch: append confirmed turns to eval set + draft `when_not_to_use` from confusion pairs → Task 4 (`NightlyBatch`). ✓
+- "CI gate tightening": the flywheel demonstrably raises accuracy on the grown set → Task 5 (`FlywheelClosesLoopTest` + demo section 4). ✓
+- Runnable proof: `runStage4Demo` (no key) → Task 5. ✓
+
+**Placeholder scan:** No TBD/TODO/"add error handling"/"similar to Task N". Every code step shows complete code. ✓
+
+**Type consistency:** `Tracer`/`SpanScope`/`NoopTracer`/`GenAiTracer`/`Span` + `invokeAgentAttrs`/`chatAttrs`/`executeToolAttrs` (Task 1) consumed by Task 2 and Task 5. `Orchestrator(baseUrl, tools, llm, tracer = NoopTracer())` (Task 2) — the 4th param is defaulted so Stage 1-3's 3-arg constructions are unchanged. `Proposal`/`Decision.{Confirm,Edit,Reject}`/`FeedbackLabel.{Positive,CorrectionPair,Negative}`/`ConfirmGate.apply` (Task 3) consumed by Task 4 (`NightlyBatch.run(seedEvalSet, labels)`) and Task 5. `BatchOutput(grownEvalSet, draftedClauses)` (Task 4) consumed by Task 5. Reuses verified Stage 3 APIs (`RouterEvaluator.evaluate`, `EvalSet.load`, `ScoringLlmClient`, `EvalCase`, `ConfusionMatrix.correct/total`) and Stage 1/2 (`GraphRegistry.loadToolDefs`, `StubLlmClient`, `MockCpqServer`, `ToolDef.copy`, `Rundown.executedStepCount/stopReason/unsuccessfulStepCount`). ✓
+
+**Backward-compatibility check (the one existing-code modification):** `Orchestrator` gains only a defaulted 4th param and internal span wrapping; its 3-arg construction and `orchestrate` return values are identical, so `OrchestratorTest`, `TauBenchCheckTest`, `LlmJudgeTest`, `BfclCheck` (which builds no Orchestrator), and all demos remain correct. Task 2 Step 4 explicitly re-runs the whole suite to confirm. ✓
+
+**Flywheel correctness (hand-verified):** the drafted clause for the reject is `"Do not use for requests like \"quote me a price for this config\" — that is the price graph."`. Its trigger tokens (length ≥ 4, after tokenize) include `price`, `config`, `graph`, `quote`, `requests`, `like` — `price` and `config` and `quote` all appear as tokens in the target utterance `"quote me a price for this config"`, so `ScoringLlmClient` applies the −5 penalty to the quote tool for that utterance, flipping it to price. On the grown eval set (which now contains the regression case `("quote me a price for this config" → price)`), seed tools mis-route it (quote) while calibrated tools route it correctly (price) → `after.correct > before.correct`. ✓
+
+**Known risks flagged in-plan:** Task 2 must keep the suite green (defaulted param — explicitly re-run); Task 5 Step 2 notes the loop test may pass immediately (acceptable — the behavior is the deliverable).

--- a/docs/superpowers/plans/2026-07-31-graph-contract-blue-box.md
+++ b/docs/superpowers/plans/2026-07-31-graph-contract-blue-box.md
@@ -1,0 +1,1000 @@
+# GraphContract (Blue-Box Unified Contract) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the "blue box" from the architecture diagram — the **unified, deterministic contract** that feeds the LLM — by fusing the two halves that today live as disjoint artifacts: the pre-execution **metadata descriptor** (`ToolDef`) and the post-execution **runtime information** (`Rundown`), plus the **data-lineage** (which `{{var}}` came from which step) that ReVoman captures but never surfaces. One composite type, one tiered renderer, one version envelope.
+
+**Architecture:** A new `contract` package in `agentic-harness/src/main`. `GraphContract` composes `{descriptor: ToolDef, invocation: filled slots, outcome: Rundown}`; a renderer emits both halves + a `dataFlow` provenance block at matched `Verbosity` tiers; a `contractVersion` envelope stamps drift. All deterministic, koog-free, CI-safe. This is the ReVoman-owned half; it does not touch the reasoning/gate (green-box) code. The existing `Orchestrator` is updated to build a `GraphContract` for its `Executed` result (additive; the loose `context` string is superseded by `GraphContract.toJson`).
+
+**Tech Stack:** Kotlin (JVM 21), the `agentic-harness` module, ReVoman (`project(":")`), JUnit5 + Google Truth. No koog, no new deps.
+
+## Global Constraints
+
+- **JDK 21**; never modify the ReVoman library; all work inside `agentic-harness/`.
+- **No koog / kotlinx.coroutines / OTel-SDK** in any `src/main` or `src/test` file. Default `test`/`build`/`check` stays green and never compiles the `claude` source set.
+- **All prior work stays green** after every task: `./gradlew :agentic-harness:test` passes every prior + new test class. Reasoning-layer Tasks 1–2 (RouteDecision confidence, RetrievalPreFilter) are already merged; do not disturb them.
+- **Copyright header** (SFDC Apache-2.0) on every new `.kt` (copy from any existing `agentic-harness/**/*.kt`); JUnit5 + Google Truth; ktfmt Google style (`./gradlew spotlessApply` before every commit).
+- **Verified facts (do not re-derive):**
+  - `tooldef.ToolDef(graphName: String, whenToUse: String, whenNotToUse: List<String>, exampleQueries: List<String>, inputExamples: List<Map<String,String>>, slots: Map<String, SlotSchema>)` — data class.
+  - `output.Rundown` (`Rundown.kt:16`): `@JvmField stepReports: List<StepReport>`, `mutableEnv`, `stopReason: StopReason`; lazy `executedStepCount`, `unsuccessfulStepCount`, `areAllStepsSuccessful`, `firstUnIgnoredUnsuccessfulStepReport`. `immutableEnv: Map<String,Any?>`.
+  - `output.report.StepReport` (`StepReport.kt:30`): `@JvmField step: Step`, `@JvmField envVars: StepEnvVars`, `isSuccessful: Boolean`.
+  - `output.report.StepEnvVars(produced: Set<String> = emptySet(), consumed: Set<String> = emptySet())` (`StepEnvVars.kt:14`) — `produced` = keys written via `pm.environment.set`; `consumed` = keys read via `{{key}}`.
+  - `output.report.Step` (`Step.kt`): `@JvmField name: String`.
+  - `output.Verbosity { SUMMARY, STANDARD, VERBOSE }` (`Verbosity.kt:17`); `fun Rundown.toJson(verbosity: Verbosity = STANDARD): String` is an extension in package `com.salesforce.revoman.output` (`RundownJsonWriter.kt:28`).
+  - `orchestrator.OrchestrationResult.Executed(graph: String, slots: Map<String,String>, rundowns: List<Rundown>, context: String)` (`Orchestrator.kt`). `Orchestrator.orchestrate` currently sets `context = rundowns.joinToString("\n") { it.toJson(Verbosity.SUMMARY) }`.
+  - `orchestrator.GraphRegistry.loadToolDefs(): List<ToolDef>`; `mock.MockCpqServer` (`start(): Int`, `stop()`, `db`); `GraphRunner.runChain(baseUrl, graphs, seedEnv): List<Rundown>`.
+- **Contract of "unified":** the emitted JSON must, in one object, show for a graph: its 4-field descriptor identity + the slots it was invoked with + its runtime outcome (steps/stopReason/success) + a `dataFlow` array mapping each produced/consumed env key to the step that touched it + a `contractVersion`.
+
+---
+
+### Task 1: `DataFlowEdge` + `GraphContract` composite type + version envelope
+
+**Files:**
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/contract/DataFlowEdge.kt`
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/contract/GraphContract.kt`
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/contract/GraphContractTest.kt`
+
+**Interfaces:**
+- Consumes: `ToolDef` (tooldef), `Rundown` + `StepReport` + `StepEnvVars` + `Step` (ReVoman output), `MockCpqServer`/`GraphRunner`/`GraphRegistry` (for the test's real Rundown).
+- Produces:
+  - `data class DataFlowEdge(val key: String, val producedByStep: String?, val consumedBySteps: List<String>)` — one env var's provenance: which step wrote it, which steps read it.
+  - `data class GraphContract(val descriptor: ToolDef, val invocationSlots: Map<String, String>, val outcome: Rundown, val contractVersion: String = CONTRACT_VERSION)` with:
+    - `companion object { const val CONTRACT_VERSION = "1.0" }`
+    - `val dataFlow: List<DataFlowEdge> by lazy { ... }` — computed from `outcome.stepReports`: for every key in any step's `envVars.produced ∪ consumed`, the producing step is the (first) step whose `envVars.produced` contains it, and consumers are all steps whose `envVars.consumed` contains it. Sorted by key.
+    - `val succeeded: Boolean get() = outcome.areAllStepsSuccessful`
+  - Factory `GraphContract.of(descriptor: ToolDef, invocationSlots: Map<String,String>, outcome: Rundown): GraphContract` (thin; for Java-friendly call sites and clarity).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/contract/GraphContractTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.contract
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.GraphRunner
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import com.salesforce.revoman.harness.tooldef.GraphMetadataParser
+import com.salesforce.revoman.harness.tooldef.GraphOasLoader
+import com.salesforce.revoman.harness.tooldef.ToolDefGenerator
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GraphContractTest {
+  private lateinit var server: MockCpqServer
+  private lateinit var baseUrl: String
+
+  @BeforeEach
+  fun setUp() {
+    server = MockCpqServer()
+    baseUrl = "http://127.0.0.1:${server.start()}"
+  }
+
+  @AfterEach fun tearDown() = server.stop()
+
+  private fun configureContract(): GraphContract {
+    val descriptor =
+      ToolDefGenerator.generate(GraphMetadataParser.parse("configure"), GraphOasLoader.load("configure"))
+    val slots = mapOf("productCode" to "SKU-1", "quantity" to "2")
+    val rundowns = GraphRunner.runChain(baseUrl, listOf("configure"), seedEnv = slots)
+    return GraphContract.of(descriptor, slots, rundowns.single())
+  }
+
+  @Test
+  fun `fuses descriptor, invocation slots, and runtime outcome into one object`() {
+    val contract = configureContract()
+    assertThat(contract.descriptor.graphName).isEqualTo("configure")
+    assertThat(contract.invocationSlots).containsEntry("productCode", "SKU-1")
+    assertThat(contract.succeeded).isTrue()
+    assertThat(contract.contractVersion).isEqualTo("1.0")
+  }
+
+  @Test
+  fun `dataFlow exposes provenance — configId was produced by the configure step`() {
+    val contract = configureContract()
+    val configIdEdge = contract.dataFlow.firstOrNull { it.key == "configId" }
+    assertThat(configIdEdge).isNotNull()
+    assertThat(configIdEdge!!.producedByStep).isNotNull()
+    // The producing step's name identifies where the value came from.
+    assertThat(configIdEdge.producedByStep).contains("configure")
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :agentic-harness:test --tests "*GraphContractTest"`
+Expected: FAIL — unresolved references `GraphContract`, `DataFlowEdge`.
+
+- [ ] **Step 3: Write `DataFlowEdge`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/contract/DataFlowEdge.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.contract
+
+/**
+ * The provenance of one environment variable within a graph run: which step WROTE it
+ * (`pm.environment.set`), and which steps READ it (`{{key}}`). This is the data-lineage ReVoman
+ * captures in [com.salesforce.revoman.output.report.StepEnvVars] but never surfaces — the piece
+ * that lets the contract explain "where did this value come from".
+ */
+data class DataFlowEdge(
+  val key: String,
+  val producedByStep: String?,
+  val consumedBySteps: List<String>,
+)
+```
+
+- [ ] **Step 4: Write `GraphContract`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/contract/GraphContract.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.contract
+
+import com.salesforce.revoman.harness.tooldef.ToolDef
+import com.salesforce.revoman.output.Rundown
+
+/**
+ * The blue-box unified contract: the single deterministic artifact that feeds the LLM, fusing the
+ * two halves that otherwise live apart —
+ *  - the pre-execution METADATA descriptor ([descriptor], a [ToolDef]: when_to_use / when_not_to_use
+ *    / example_queries / input_examples + typed slots), and
+ *  - the post-execution RUNTIME information ([outcome], a ReVoman [Rundown]: steps, stopReason,
+ *    per-step request/response, env) —
+ * plus [invocationSlots] (what the graph was actually called with) and [dataFlow] (provenance: which
+ * `{{var}}` came from which step). A [contractVersion] stamps the schema so consumers detect drift.
+ *
+ * Deterministic and testable like ordinary software — the ReVoman-owned half of the system. The
+ * probabilistic reasoning that CONSUMES this contract (router / confidence gate) is a separate layer.
+ */
+data class GraphContract(
+  val descriptor: ToolDef,
+  val invocationSlots: Map<String, String>,
+  val outcome: Rundown,
+  val contractVersion: String = CONTRACT_VERSION,
+) {
+  val succeeded: Boolean
+    get() = outcome.areAllStepsSuccessful
+
+  /** Per-env-key provenance derived from each step's produced/consumed sets. */
+  val dataFlow: List<DataFlowEdge> by lazy {
+    val keys =
+      outcome.stepReports.flatMap { it.envVars.produced + it.envVars.consumed }.toSortedSet()
+    keys.map { key ->
+      val producer = outcome.stepReports.firstOrNull { key in it.envVars.produced }?.step?.name
+      val consumers =
+        outcome.stepReports.filter { key in it.envVars.consumed }.map { it.step.name }.distinct()
+      DataFlowEdge(key, producer, consumers)
+    }
+  }
+
+  companion object {
+    const val CONTRACT_VERSION: String = "1.0"
+
+    fun of(descriptor: ToolDef, invocationSlots: Map<String, String>, outcome: Rundown): GraphContract =
+      GraphContract(descriptor, invocationSlots, outcome)
+  }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `./gradlew :agentic-harness:test --tests "*GraphContractTest"`
+Expected: BUILD SUCCESSFUL, 2 tests passed.
+
+If `dataFlow` for `configId` has a null `producedByStep`: the mock/graph produced it via `pm.environment.set("configId", ...)` in the configure step's afterResponse script, which ReVoman records in `envVars.produced`. If the set is empty, verify the step actually ran successfully (the test seeds valid slots, so it should). Do not weaken the assertion.
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/contract/DataFlowEdge.kt \
+  agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/contract/GraphContract.kt \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/contract/GraphContractTest.kt
+git commit -m "feat(harness): GraphContract fuses ToolDef descriptor + Rundown + data-lineage"
+```
+
+---
+
+### Task 2: `GraphContractWriter` — tiered `toJson(Verbosity)` renderer (both halves + dataFlow)
+
+**Files:**
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/contract/GraphContractWriter.kt`
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/contract/GraphContractWriterTest.kt`
+
+**Interfaces:**
+- Consumes: `GraphContract`, `DataFlowEdge` (Task 1); `output.Verbosity`; `output.toJson` (the existing Rundown renderer).
+- Produces:
+  - `fun GraphContract.toJson(verbosity: Verbosity = Verbosity.STANDARD): String` — an extension in package `com.salesforce.revoman.harness.contract`. Hand-built JSON (no new dep; mirror the style of the harness's existing small JSON emitters), emitting a single object:
+    - always: `contractVersion`, `graph` (descriptor.graphName), `succeeded`, `invocationSlots`.
+    - SUMMARY: + `stopReason`, `executedStepCount`, `unsuccessfulStepCount` (from `outcome`).
+    - STANDARD (adds to SUMMARY): + `whenToUse`, `whenNotToUse`, `dataFlow` (array of `{key, producedByStep, consumedBySteps}`).
+    - VERBOSE (adds to STANDARD): + `exampleQueries`, `inputExamples`, and the full nested `rundown` = `outcome.toJson(Verbosity.VERBOSE)` (reuse the ReVoman renderer, embedded).
+  - Keep it a pure string builder; escape strings minimally (the values here are graph names, keys, enum names — no embedded quotes expected, but escape `"` and `\` defensively).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/contract/GraphContractWriterTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.contract
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.GraphRunner
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.tooldef.GraphMetadataParser
+import com.salesforce.revoman.harness.tooldef.GraphOasLoader
+import com.salesforce.revoman.harness.tooldef.ToolDefGenerator
+import com.salesforce.revoman.output.Verbosity
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GraphContractWriterTest {
+  private lateinit var server: MockCpqServer
+  private lateinit var baseUrl: String
+
+  @BeforeEach
+  fun setUp() {
+    server = MockCpqServer()
+    baseUrl = "http://127.0.0.1:${server.start()}"
+  }
+
+  @AfterEach fun tearDown() = server.stop()
+
+  private fun contract(): GraphContract {
+    val descriptor =
+      ToolDefGenerator.generate(GraphMetadataParser.parse("configure"), GraphOasLoader.load("configure"))
+    val slots = mapOf("productCode" to "SKU-1", "quantity" to "2")
+    val rundowns = GraphRunner.runChain(baseUrl, listOf("configure"), seedEnv = slots)
+    return GraphContract.of(descriptor, slots, rundowns.single())
+  }
+
+  @Test
+  fun `summary carries version, graph, invocation slots, and outcome stats but not descriptions`() {
+    val json = contract().toJson(Verbosity.SUMMARY)
+    assertThat(json).contains("\"contractVersion\"")
+    assertThat(json).contains("\"graph\"")
+    assertThat(json).contains("configure")
+    assertThat(json).contains("\"invocationSlots\"")
+    assertThat(json).contains("\"stopReason\"")
+    // SUMMARY omits the heavy descriptor prose and dataFlow.
+    assertThat(json).doesNotContain("\"whenToUse\"")
+    assertThat(json).doesNotContain("\"dataFlow\"")
+  }
+
+  @Test
+  fun `standard adds descriptor whenToUse and the dataFlow provenance block`() {
+    val json = contract().toJson(Verbosity.STANDARD)
+    assertThat(json).contains("\"whenToUse\"")
+    assertThat(json).contains("\"dataFlow\"")
+    assertThat(json).contains("configId") // a produced key appears in the lineage
+  }
+
+  @Test
+  fun `verbose embeds the full nested rundown json`() {
+    val json = contract().toJson(Verbosity.VERBOSE)
+    assertThat(json).contains("\"rundown\"")
+    assertThat(json).contains("\"exampleQueries\"")
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :agentic-harness:test --tests "*GraphContractWriterTest"`
+Expected: FAIL — unresolved reference `toJson` on `GraphContract`.
+
+- [ ] **Step 3: Write `GraphContractWriter`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/contract/GraphContractWriter.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.contract
+
+import com.salesforce.revoman.output.Verbosity
+import com.salesforce.revoman.output.toJson
+
+/**
+ * Renders a [GraphContract] to JSON at matched [Verbosity] tiers — the single serializer that emits
+ * BOTH halves of the unified contract (metadata descriptor + runtime outcome) plus the data-lineage
+ * and version envelope. SUMMARY is a health check; STANDARD adds the descriptions and the dataFlow
+ * provenance; VERBOSE embeds the full nested ReVoman [com.salesforce.revoman.output.Rundown] JSON.
+ */
+fun GraphContract.toJson(verbosity: Verbosity = Verbosity.STANDARD): String {
+  val sb = StringBuilder()
+  sb.append("{")
+  sb.append("\"contractVersion\":").append(str(contractVersion))
+  sb.append(",\"graph\":").append(str(descriptor.graphName))
+  sb.append(",\"succeeded\":").append(succeeded)
+  sb.append(",\"invocationSlots\":").append(strMap(invocationSlots))
+  // SUMMARY-and-up: runtime stats.
+  sb.append(",\"stopReason\":").append(str(outcome.stopReason.toString()))
+  sb.append(",\"executedStepCount\":").append(outcome.executedStepCount)
+  sb.append(",\"unsuccessfulStepCount\":").append(outcome.unsuccessfulStepCount)
+
+  if (verbosity == Verbosity.STANDARD || verbosity == Verbosity.VERBOSE) {
+    sb.append(",\"whenToUse\":").append(str(descriptor.whenToUse))
+    sb.append(",\"whenNotToUse\":").append(strList(descriptor.whenNotToUse))
+    sb.append(",\"dataFlow\":").append(dataFlowJson())
+  }
+  if (verbosity == Verbosity.VERBOSE) {
+    sb.append(",\"exampleQueries\":").append(strList(descriptor.exampleQueries))
+    sb.append(",\"inputExamples\":").append(strMapList(descriptor.inputExamples))
+    // Embed the full ReVoman runtime JSON as a nested object (already valid JSON).
+    sb.append(",\"rundown\":").append(outcome.toJson(Verbosity.VERBOSE))
+  }
+  sb.append("}")
+  return sb.toString()
+}
+
+private fun GraphContract.dataFlowJson(): String =
+  dataFlow.joinToString(",", "[", "]") { edge ->
+    "{\"key\":${str(edge.key)}," +
+      "\"producedByStep\":${edge.producedByStep?.let { str(it) } ?: "null"}," +
+      "\"consumedBySteps\":${strList(edge.consumedBySteps)}}"
+  }
+
+private fun str(s: String): String = "\"" + s.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+
+private fun strList(xs: List<String>): String = xs.joinToString(",", "[", "]") { str(it) }
+
+private fun strMap(m: Map<String, String>): String =
+  m.entries.joinToString(",", "{", "}") { "${str(it.key)}:${str(it.value)}" }
+
+private fun strMapList(ms: List<Map<String, String>>): String =
+  ms.joinToString(",", "[", "]") { strMap(it) }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :agentic-harness:test --tests "*GraphContractWriterTest"`
+Expected: BUILD SUCCESSFUL, 3 tests passed.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/contract/GraphContractWriter.kt \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/contract/GraphContractWriterTest.kt
+git commit -m "feat(harness): tiered GraphContract JSON renderer (descriptor + runtime + dataFlow)"
+```
+
+---
+
+### Task 3: Wire `GraphContract` into the orchestrator + runnable `ContractDemo`
+
+**Files:**
+- Modify: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/Orchestrator.kt`
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/ContractDemo.kt`
+- Modify: `agentic-harness/build.gradle.kts` (add `runContractDemo` JavaExec task)
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/orchestrator/OrchestratorContractTest.kt`
+
+**Interfaces:**
+- Consumes: `GraphContract` + `toJson` (Tasks 1–2); existing `Orchestrator`, `OrchestrationResult`, `GraphRegistry`, `MockCpqServer`.
+- Produces:
+  - `OrchestrationResult.Executed` gains one field: `val contract: GraphContract?` — **defaulted null** so existing constructions/tests are unaffected. The `context` field stays (backward compat). When the orchestrator executes, it builds `GraphContract.of(tool, slots, rundowns.last())` and sets both `contract` and (for continuity) `context = contract.toJson(Verbosity.STANDARD)`.
+  - `fun main()` in `ContractDemo.kt` + a `runContractDemo` JavaExec task (mainClass `com.salesforce.revoman.harness.ContractDemoKt`) that orchestrates one intent, then prints the same contract at SUMMARY, STANDARD, and VERBOSE so the tiers are visible side by side — the "unified contract in action".
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/orchestrator/OrchestratorContractTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.orchestrator
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.contract.toJson
+import com.salesforce.revoman.harness.llm.StubLlmClient
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.output.Verbosity
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class OrchestratorContractTest {
+  private lateinit var server: MockCpqServer
+  private lateinit var baseUrl: String
+  private val tools = GraphRegistry.loadToolDefs()
+
+  @BeforeEach
+  fun setUp() {
+    server = MockCpqServer()
+    baseUrl = "http://127.0.0.1:${server.start()}"
+  }
+
+  @AfterEach fun tearDown() = server.stop()
+
+  @Test
+  fun `an executed turn carries a unified GraphContract`() {
+    val result =
+      Orchestrator(baseUrl, tools, StubLlmClient()).orchestrate("configure 2 units of SKU-1")
+    val executed = result as OrchestrationResult.Executed
+
+    assertThat(executed.contract).isNotNull()
+    val contract = executed.contract!!
+    assertThat(contract.descriptor.graphName).isEqualTo("configure")
+    assertThat(contract.invocationSlots).containsEntry("quantity", "2")
+    assertThat(contract.succeeded).isTrue()
+
+    // The unified contract renders both halves + provenance.
+    val json = contract.toJson(Verbosity.STANDARD)
+    assertThat(json).contains("\"whenToUse\"")
+    assertThat(json).contains("\"dataFlow\"")
+    assertThat(json).contains("configId")
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :agentic-harness:test --tests "*OrchestratorContractTest"`
+Expected: FAIL — `OrchestrationResult.Executed.contract` does not exist.
+
+- [ ] **Step 3: Add `contract` to `Executed` and build it in the orchestrator**
+
+In `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/Orchestrator.kt`:
+
+Add the import:
+```kotlin
+import com.salesforce.revoman.harness.contract.GraphContract
+import com.salesforce.revoman.harness.contract.toJson
+```
+
+Change the `Executed` data class to add the defaulted field (keep the other members):
+```kotlin
+  data class Executed(
+    val graph: String,
+    val slots: Map<String, String>,
+    val rundowns: List<Rundown>,
+    val context: String,
+    val contract: GraphContract? = null,
+  ) : OrchestrationResult
+```
+
+In the `execute_tool` span block, after `rundowns` is obtained and before building the result, build the contract and use it for the context (locate the block that currently does `val context = rundowns.joinToString("\n") { it.toJson(Verbosity.SUMMARY) }` and returns `OrchestrationResult.Executed(graphName, slots, rundowns, context)`), replacing it with:
+```kotlin
+        val contract = GraphContract.of(tool, slots, rundowns.last())
+        val context = contract.toJson(Verbosity.STANDARD)
+        OrchestrationResult.Executed(graphName, slots, rundowns, context, contract)
+```
+(Here `tool` is the `ToolDef` already resolved earlier in `orchestrate` as `tools.firstOrNull { it.graphName == graphName }`. If that local is not in scope inside the span lambda, resolve it again: `val tool = tools.first { it.graphName == graphName }`.)
+
+Note: the harness's `Rundown.toJson` import may already be present; the contract's `toJson` is a different extension in `harness.contract`. Both imports coexist (different receiver types). If a clash on the simple name `toJson` occurs, import the contract one and call the Rundown one via its package or keep the existing `Verbosity.SUMMARY` Rundown rendering only inside `GraphContractWriter` (it already lives there) — the orchestrator only needs `contract.toJson(...)`.
+
+- [ ] **Step 4: Run the test AND the full suite**
+
+Run: `./gradlew :agentic-harness:test --tests "*OrchestratorContractTest"`
+Expected: BUILD SUCCESSFUL, 1 test passed.
+
+Run: `./gradlew :agentic-harness:test`
+Expected: BUILD SUCCESSFUL — all prior test classes still green (the new `contract` field is defaulted; `OrchestratorTest`, `OrchestratorTracingTest`, `TauBenchCheck`, `LlmJudge`, Stage-3/4 tests unaffected).
+
+- [ ] **Step 5: Write `ContractDemo`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/ContractDemo.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness
+
+import com.salesforce.revoman.harness.contract.toJson
+import com.salesforce.revoman.harness.llm.StubLlmClient
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import com.salesforce.revoman.harness.orchestrator.Orchestrator
+import com.salesforce.revoman.harness.orchestrator.OrchestrationResult
+import com.salesforce.revoman.output.Verbosity
+
+/**
+ * Blue-box demo: the unified GraphContract in action. Orchestrates one intent, then prints the SAME
+ * contract at SUMMARY / STANDARD / VERBOSE so the tiers are visible side by side — descriptor
+ * metadata + runtime outcome + data-lineage, fused, deterministic, no LLM key.
+ */
+fun main() {
+  val tools = GraphRegistry.loadToolDefs()
+  val server = MockCpqServer()
+  val baseUrl = "http://127.0.0.1:${server.start()}"
+  try {
+    val result =
+      Orchestrator(baseUrl, tools, StubLlmClient()).orchestrate("configure 2 units of SKU-1")
+    val contract =
+      (result as? OrchestrationResult.Executed)?.contract
+        ?: run {
+          println("No contract (outcome: $result)")
+          return
+        }
+    listOf(Verbosity.SUMMARY, Verbosity.STANDARD, Verbosity.VERBOSE).forEach { v ->
+      println("\n===== GraphContract @ $v =====")
+      println(contract.toJson(v))
+    }
+  } finally {
+    server.stop()
+  }
+}
+```
+
+- [ ] **Step 6: Add the run task to the module build file**
+
+Append to `agentic-harness/build.gradle.kts`:
+
+```kotlin
+tasks.register<JavaExec>("runContractDemo") {
+  group = "harness"
+  description = "Print the unified GraphContract (descriptor + runtime + dataFlow) at all verbosity tiers"
+  mainClass.set("com.salesforce.revoman.harness.ContractDemoKt")
+  classpath = sourceSets["main"].runtimeClasspath
+}
+```
+
+- [ ] **Step 7: Run the demo and the full suite**
+
+Run: `./gradlew :agentic-harness:runContractDemo -q`
+Expected: three blocks — `===== GraphContract @ SUMMARY =====` (version/graph/slots/stopReason, no descriptions), `@ STANDARD` (adds whenToUse/whenNotToUse/dataFlow with a `configId` edge whose `producedByStep` names the configure step), `@ VERBOSE` (adds exampleQueries/inputExamples and a nested `rundown` object).
+
+Run: `./gradlew :agentic-harness:test`
+Expected: BUILD SUCCESSFUL — every prior + new test class passes.
+
+- [ ] **Step 8: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/orchestrator/Orchestrator.kt \
+  agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/ContractDemo.kt \
+  agentic-harness/build.gradle.kts \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/orchestrator/OrchestratorContractTest.kt
+git commit -m "feat(harness): orchestrator emits unified GraphContract; runnable ContractDemo"
+```
+
+---
+
+### Task 4: `ContractFidelityCheck` — deterministic drift catch (declared vs actual, no LLM)
+
+**Files:**
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/contract/ContractFidelityCheck.kt`
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/contract/ContractFidelityCheckTest.kt`
+
+**Why:** The contract's metadata half *declares* what a graph produces/consumes (`GraphSpec.outputKeys`, `ToolDef.slots`); its runtime half shows what *actually* happened (`GraphContract.dataFlow`, from `StepEnvVars`). Fidelity accuracy = do they match? A mismatch means the API drifted under the graph — caught deterministically, with zero LLM cost, before an agent ever reasons over a stale descriptor. This is the design's Layer-1 "same engine tests graphs in CI".
+
+**Interfaces:**
+- Consumes: `GraphContract`/`DataFlowEdge` (Task 1); `tooldef.GraphSpec` (`GraphMetadataParser.parse`), `tooldef.ToolDef.slots`.
+- Produces:
+  - `data class FidelityReport(val graph: String, val missingProduced: Set<String>, val unexpectedProduced: Set<String>, val faithful: Boolean)` — `missingProduced` = keys the metadata DECLARED as outputs (`spec.outputKeys`) that the run did NOT actually produce; `unexpectedProduced` = keys the run produced that the metadata did NOT declare (the drift signal). `faithful = missingProduced.isEmpty() && unexpectedProduced.isEmpty()`.
+  - `class ContractFidelityCheck { fun check(contract: GraphContract, spec: GraphSpec): FidelityReport }` — compares `spec.outputKeys.toSet()` against the set of `contract.dataFlow.filter { it.producedByStep != null }.map { it.key }` (actual producers). (Infra keys like `baseUrl`/`accessToken` are never in `outputKeys` and are consumed-only, so they don't appear as false drift.)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/contract/ContractFidelityCheckTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.contract
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.GraphRunner
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.tooldef.GraphMetadataParser
+import com.salesforce.revoman.harness.tooldef.GraphOasLoader
+import com.salesforce.revoman.harness.tooldef.GraphSpec
+import com.salesforce.revoman.harness.tooldef.ToolDefGenerator
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ContractFidelityCheckTest {
+  private lateinit var server: MockCpqServer
+  private lateinit var baseUrl: String
+  private val check = ContractFidelityCheck()
+
+  @BeforeEach
+  fun setUp() {
+    server = MockCpqServer()
+    baseUrl = "http://127.0.0.1:${server.start()}"
+  }
+
+  @AfterEach fun tearDown() = server.stop()
+
+  private fun configureContract(): GraphContract {
+    val descriptor =
+      ToolDefGenerator.generate(GraphMetadataParser.parse("configure"), GraphOasLoader.load("configure"))
+    val slots = mapOf("productCode" to "SKU-1", "quantity" to "2")
+    val rundowns = GraphRunner.runChain(baseUrl, listOf("configure"), seedEnv = slots)
+    return GraphContract.of(descriptor, slots, rundowns.single())
+  }
+
+  @Test
+  fun `a graph whose runtime matches its declared metadata is faithful`() {
+    val spec = GraphMetadataParser.parse("configure")
+    val report = check.check(configureContract(), spec)
+    assertThat(report.faithful).isTrue()
+    assertThat(report.missingProduced).isEmpty()
+    assertThat(report.unexpectedProduced).isEmpty()
+  }
+
+  @Test
+  fun `a declared output the run never produced is caught as drift`() {
+    // Simulate metadata drift: the spec claims an extra output 'discountId' the graph never sets.
+    val driftedSpec =
+      GraphMetadataParser.parse("configure").let {
+        GraphSpec(it.name, it.description, it.slots, it.outputKeys + "discountId")
+      }
+    val report = check.check(configureContract(), driftedSpec)
+    assertThat(report.faithful).isFalse()
+    assertThat(report.missingProduced).contains("discountId")
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :agentic-harness:test --tests "*ContractFidelityCheckTest"`
+Expected: FAIL — unresolved references `ContractFidelityCheck`, `FidelityReport`.
+
+- [ ] **Step 3: Write `ContractFidelityCheck`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/contract/ContractFidelityCheck.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.contract
+
+import com.salesforce.revoman.harness.tooldef.GraphSpec
+
+/** Whether a contract's runtime data-flow matches what its metadata declared, and how it drifted. */
+data class FidelityReport(
+  val graph: String,
+  val missingProduced: Set<String>,
+  val unexpectedProduced: Set<String>,
+) {
+  val faithful: Boolean
+    get() = missingProduced.isEmpty() && unexpectedProduced.isEmpty()
+}
+
+/**
+ * The blue-box Layer-1 eval: deterministic, no LLM. Compares what the graph's metadata DECLARES it
+ * produces ([GraphSpec.outputKeys]) against what the run ACTUALLY produced (the contract's data-flow
+ * producers). Any mismatch is API drift — the production contract changing under the graph — caught
+ * in CI before an agent ever reasons over a stale descriptor.
+ */
+class ContractFidelityCheck {
+  fun check(contract: GraphContract, spec: GraphSpec): FidelityReport {
+    val declared = spec.outputKeys.toSet()
+    val actual = contract.dataFlow.filter { it.producedByStep != null }.map { it.key }.toSet()
+    return FidelityReport(
+      graph = spec.name,
+      missingProduced = declared - actual,
+      unexpectedProduced = actual - declared,
+    )
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :agentic-harness:test --tests "*ContractFidelityCheckTest"`
+Expected: BUILD SUCCESSFUL, 2 tests passed.
+
+If the "faithful" test fails with `unexpectedProduced` non-empty: the configure graph's afterResponse script sets a key beyond `configId` (e.g. it might set nothing else — check `graphs/configure/configure-product.request.yaml`). If the graph genuinely produces exactly `configId` and `GraphMetadataParser` declares exactly that, the sets match. Do not weaken the assertion; if there is a real extra produced key, that is a true finding — add it to the graph's declared outputs or report it.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/contract/ContractFidelityCheck.kt \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/contract/ContractFidelityCheckTest.kt
+git commit -m "feat(harness): ContractFidelityCheck — deterministic API-drift catch (declared vs actual)"
+```
+
+---
+
+### Task 5: `ContractAblationEval` — vary the contract, measure accuracy delta + runnable eval demo
+
+**Files:**
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/contract/ContractAblationEval.kt`
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/ContractEvalDemo.kt`
+- Modify: `agentic-harness/build.gradle.kts` (add `runContractEvalDemo` JavaExec task)
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/contract/ContractAblationEvalTest.kt`
+
+**Why:** The blue box exists to feed the LLM, so its efficacy is measured by holding the reasoning fixed and varying the contract's content: does a richer descriptor make the green box more accurate? This reuses the Stage-3 confusion matrix as the measuring instrument — grading the contract by how well it makes reasoning work — and is exactly the calibration loop the design describes, now driven by the *contract* rather than a hand-edit.
+
+**Interfaces:**
+- Consumes: `eval.RouterEvaluator`, `eval.EvalSet`, `eval.EvalReport`, `eval.ConfusionMatrix` (Stage 3); `llm.ScoringLlmClient`; `tooldef.ToolDef` (data class, `.copy`).
+- Produces:
+  - `data class AblationResult(val variantName: String, val accuracyCorrect: Int, val accuracyTotal: Int)` with `val accuracy: Double get() = if (accuracyTotal == 0) 0.0 else accuracyCorrect.toDouble() / accuracyTotal`.
+  - `class ContractAblationEval(private val evaluator: RouterEvaluator = RouterEvaluator(ScoringLlmClient())) { fun compare(cases: List<EvalCase>, variantA: Pair<String, List<ToolDef>>, variantB: Pair<String, List<ToolDef>>): Pair<AblationResult, AblationResult> }` — runs the same eval set through the router twice, once per tool-def variant, and returns both results (so the caller sees the delta). Each variant is a `(name, tools)` pair.
+  - (This is the generalization of Stage 3's manual "add a when_not_to_use clause and re-run": now any contract-content difference between two `List<ToolDef>` variants is measured against the same eval set.)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/contract/ContractAblationEvalTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.contract
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.eval.EvalSet
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import org.junit.jupiter.api.Test
+
+class ContractAblationEvalTest {
+  private val cases = EvalSet.load()
+
+  @Test
+  fun `enriching the contract (adding when_not_to_use) improves accuracy on the eval set`() {
+    // Variant A: descriptors with when_not_to_use STRIPPED (the poorer contract).
+    val stripped = GraphRegistry.loadToolDefs().map { it.copy(whenNotToUse = emptyList()) }
+    // Variant B: enrich the 'quote' descriptor with the disambiguating clause (the richer contract).
+    val enriched =
+      stripped.map {
+        if (it.graphName == "quote")
+          it.copy(whenNotToUse = listOf("Do not use when the user asks for a price or cost — that is the price graph."))
+        else it
+      }
+
+    val (a, b) =
+      ContractAblationEval().compare(cases, "stripped" to stripped, "enriched" to enriched)
+
+    assertThat(a.variantName).isEqualTo("stripped")
+    assertThat(b.variantName).isEqualTo("enriched")
+    // The richer contract scores strictly higher — the blue box improved reasoning accuracy.
+    assertThat(b.accuracyCorrect).isGreaterThan(a.accuracyCorrect)
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :agentic-harness:test --tests "*ContractAblationEvalTest"`
+Expected: FAIL — unresolved references `ContractAblationEval`, `AblationResult`.
+
+- [ ] **Step 3: Write `ContractAblationEval`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/contract/ContractAblationEval.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.contract
+
+import com.salesforce.revoman.harness.eval.EvalCase
+import com.salesforce.revoman.harness.eval.RouterEvaluator
+import com.salesforce.revoman.harness.llm.ScoringLlmClient
+import com.salesforce.revoman.harness.tooldef.ToolDef
+
+/** Graph-selection accuracy for one contract variant on a fixed eval set. */
+data class AblationResult(val variantName: String, val accuracyCorrect: Int, val accuracyTotal: Int) {
+  val accuracy: Double
+    get() = if (accuracyTotal == 0) 0.0 else accuracyCorrect.toDouble() / accuracyTotal
+}
+
+/**
+ * The blue-box efficacy eval: hold the reasoning fixed, vary the CONTRACT content, and measure the
+ * accuracy delta on the same labeled eval set — reusing the Stage-3 confusion matrix as the
+ * instrument. This grades the contract by how well it makes the reasoning work, and is the
+ * generalization of the manual calibration loop: any difference between two `ToolDef` variants
+ * (richer descriptions, added examples, disambiguating clauses) is measured, not guessed.
+ */
+class ContractAblationEval(
+  private val evaluator: RouterEvaluator = RouterEvaluator(ScoringLlmClient())
+) {
+  fun compare(
+    cases: List<EvalCase>,
+    variantA: Pair<String, List<ToolDef>>,
+    variantB: Pair<String, List<ToolDef>>,
+  ): Pair<AblationResult, AblationResult> = result(cases, variantA) to result(cases, variantB)
+
+  private fun result(cases: List<EvalCase>, variant: Pair<String, List<ToolDef>>): AblationResult {
+    val report = evaluator.evaluate(cases, variant.second)
+    return AblationResult(variant.first, report.matrix.correct, report.matrix.total)
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :agentic-harness:test --tests "*ContractAblationEvalTest"`
+Expected: BUILD SUCCESSFUL, 1 test passed (enriched > stripped, mirroring the Stage-3 6/7 → 7/7 result).
+
+- [ ] **Step 5: Write `ContractEvalDemo`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/ContractEvalDemo.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness
+
+import com.salesforce.revoman.harness.GraphRunner
+import com.salesforce.revoman.harness.contract.ContractAblationEval
+import com.salesforce.revoman.harness.contract.ContractFidelityCheck
+import com.salesforce.revoman.harness.contract.GraphContract
+import com.salesforce.revoman.harness.eval.EvalSet
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import com.salesforce.revoman.harness.tooldef.GraphMetadataParser
+import com.salesforce.revoman.harness.tooldef.GraphOasLoader
+import com.salesforce.revoman.harness.tooldef.GraphSpec
+import com.salesforce.revoman.harness.tooldef.ToolDefGenerator
+
+/**
+ * Blue-box eval demo: how we TEST and IMPROVE the unified contract, deterministic (no key).
+ * (1) Fidelity — the contract's runtime matches its declared metadata (Layer-1, no LLM).
+ * (2) Simulated drift — a declared output the run never produces is caught.
+ * (3) Efficacy — enriching the contract raises graph-selection accuracy on the eval set.
+ */
+fun main() {
+  val server = MockCpqServer()
+  val baseUrl = "http://127.0.0.1:${server.start()}"
+  try {
+    val descriptor =
+      ToolDefGenerator.generate(GraphMetadataParser.parse("configure"), GraphOasLoader.load("configure"))
+    val slots = mapOf("productCode" to "SKU-1", "quantity" to "2")
+    val contract =
+      GraphContract.of(descriptor, slots, GraphRunner.runChain(baseUrl, listOf("configure"), slots).single())
+    val check = ContractFidelityCheck()
+
+    println("=== 1. Fidelity: does the contract mirror reality? (no LLM) ===")
+    val spec = GraphMetadataParser.parse("configure")
+    val ok = check.check(contract, spec)
+    println("  configure faithful=${ok.faithful} (declared==actually-produced)")
+
+    println("\n=== 2. Simulated API drift: metadata declares an output the run never produces ===")
+    val drifted = GraphSpec(spec.name, spec.description, spec.slots, spec.outputKeys + "discountId")
+    val drift = check.check(contract, drifted)
+    println("  faithful=${drift.faithful}  missingProduced=${drift.missingProduced}  <-- drift caught in CI")
+
+    println("\n=== 3. Efficacy: enrich the contract, measure accuracy on the eval set ===")
+    val cases = EvalSet.load()
+    val stripped = GraphRegistry.loadToolDefs().map { it.copy(whenNotToUse = emptyList()) }
+    val enriched =
+      stripped.map {
+        if (it.graphName == "quote")
+          it.copy(whenNotToUse = listOf("Do not use when the user asks for a price or cost — that is the price graph."))
+        else it
+      }
+    val (a, b) = ContractAblationEval().compare(cases, "stripped" to stripped, "enriched" to enriched)
+    println("  ${a.variantName}: ${a.accuracyCorrect}/${a.accuracyTotal}")
+    println("  ${b.variantName}: ${b.accuracyCorrect}/${b.accuracyTotal}")
+    println("  contract enrichment moved accuracy: ${a.accuracyCorrect}/${a.accuracyTotal} -> ${b.accuracyCorrect}/${b.accuracyTotal}")
+  } finally {
+    server.stop()
+  }
+}
+```
+
+- [ ] **Step 6: Add the run task to the module build file**
+
+Append to `agentic-harness/build.gradle.kts`:
+
+```kotlin
+tasks.register<JavaExec>("runContractEvalDemo") {
+  group = "harness"
+  description = "Blue-box evals: contract fidelity (drift catch) + ablation accuracy delta"
+  mainClass.set("com.salesforce.revoman.harness.ContractEvalDemoKt")
+  classpath = sourceSets["main"].runtimeClasspath
+}
+```
+
+- [ ] **Step 7: Run the demo and the full suite**
+
+Run: `./gradlew :agentic-harness:runContractEvalDemo -q`
+Expected: section 1 `configure faithful=true`; section 2 `faithful=false  missingProduced=[discountId]  <-- drift caught in CI`; section 3 two accuracy lines and `contract enrichment moved accuracy: 6/7 -> 7/7`.
+
+Run: `./gradlew :agentic-harness:test`
+Expected: BUILD SUCCESSFUL — all prior + new test classes pass.
+
+- [ ] **Step 8: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/contract/ContractAblationEval.kt \
+  agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/ContractEvalDemo.kt \
+  agentic-harness/build.gradle.kts \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/contract/ContractAblationEvalTest.kt
+git commit -m "feat(harness): ContractAblationEval — measure accuracy delta from contract enrichment"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (the blue-box must-haves from the scoping answer):**
+1. `GraphContract` composite type → Task 1. ✓
+2. `GraphContract.toJson(Verbosity)` tiered renderer → Task 2. ✓
+3. `dataFlow` provenance block (surfaces `StepEnvVars.produced/consumed`) → Task 1 (`dataFlow` computed) + Task 2 (rendered). ✓
+4. Slots-in ↔ outputs-out binding → Task 1 (`invocationSlots` on the contract) + the `dataFlow` producers = the graph's outputs. ✓
+5. `contractVersion` envelope → Task 1 (`CONTRACT_VERSION = "1.0"`, rendered in every tier). ✓
+- Wired into the live orchestrator + runnable proof → Task 3. ✓
+- **Blue-box test + improve accuracy (the eval story):** fidelity/drift catch (deterministic, no LLM) → Task 4 (`ContractFidelityCheck`); efficacy (vary the contract, measure accuracy delta on the eval set via the Stage-3 confusion matrix) → Task 5 (`ContractAblationEval`). Runnable proof shows fidelity-pass, a simulated drift-fail, and a 6/7 → 7/7 enrichment move → Task 5 (`ContractEvalDemo`). ✓
+- Nice-to-haves (mermaid preview, OTel nesting) intentionally deferred — not in this plan (YAGNI for the keystone).
+
+**Eval-scaffold type consistency:** `FidelityReport(graph, missingProduced, unexpectedProduced)` + `ContractFidelityCheck.check(contract, spec)` (Task 4) reuse `GraphContract.dataFlow` (Task 1) and `GraphSpec.outputKeys`. `AblationResult(variantName, accuracyCorrect, accuracyTotal)` + `ContractAblationEval.compare(cases, variantA, variantB)` (Task 5) reuse the Stage-3 `RouterEvaluator.evaluate → EvalReport.matrix.correct/total` and `ToolDef.copy`. Both eval scaffolds are deterministic and koog-free; neither modifies shipped code, so all prior stages stay green. ✓
+
+**Placeholder scan:** No TBD/TODO/"add error handling"/"similar to Task N". Every step shows complete code.
+
+**Type consistency:** `DataFlowEdge(key, producedByStep, consumedBySteps)` + `GraphContract(descriptor, invocationSlots, outcome, contractVersion)` + `GraphContract.of(...)` (Task 1) consumed by the renderer (Task 2) and the orchestrator + demo (Task 3). `GraphContract.toJson(Verbosity)` (Task 2) called in Tasks 2 and 3. `OrchestrationResult.Executed` gains a defaulted `contract: GraphContract?` (Task 3) — backward-compatible. Reuses verified ReVoman surface: `Rundown.stepReports/areAllStepsSuccessful/executedStepCount/unsuccessfulStepCount/stopReason/toJson`, `StepReport.step.name/envVars`, `StepEnvVars.produced/consumed`, `Verbosity`. ✓
+
+**Backward-compat:** the only shipped-code edit is `OrchestrationResult.Executed` gaining a defaulted `contract` field and the orchestrator building it (the `context` string is now sourced from `contract.toJson(STANDARD)` instead of the raw join — a richer but still-present context; any test asserting `context` contains `areAllStepsSuccessful`/`unsuccessfulStepCount` still passes because the STANDARD contract JSON embeds those runtime stats). Task 3 Step 4 re-runs the whole suite to confirm. ✓
+
+**Known risk flagged in-plan:** Task 3 Step 3 notes the `toJson` name coexistence (Rundown's vs GraphContract's extension) and the `tool` local scope; both have inline resolutions.

--- a/docs/superpowers/plans/2026-07-31-reasoning-layer-scaffolds.md
+++ b/docs/superpowers/plans/2026-07-31-reasoning-layer-scaffolds.md
@@ -1,0 +1,1012 @@
+# Reasoning-Layer Scaffolds Implementation Plan (Delta on `agentic-harness`)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete the reasoning layer's six reliability scaffolds as a delta on the existing `agentic-harness` module: add confidence/margin to routing, a retrieval pre-filter, the confidence/disambiguation gate (ask-don't-guess), a confirm-gate preview object, end-to-end `ReasoningLayer` wiring, and a real Claude client wired to this environment's AWS Bedrock proxy (best-effort, gated).
+
+**Architecture:** All new deterministic scaffolds live in `agentic-harness/src/main` (koog-free, CI-safe), driven by the existing `ScoringLlmClient`/`StubLlmClient`. The new `reasoning.ReasoningLayer` is the reasoning-layer-complete entry point (retrieve → route → fill → gate), leaving the Stage-2 `Orchestrator` intact. The real Claude client (Bedrock-proxy) stays in the isolated `claude` source set the default build never compiles.
+
+**Tech Stack:** Kotlin (JVM 21), the `agentic-harness` module, ReVoman (`project(":")`), JUnit5 + Google Truth. koog (`ai.koog:koog-agents:1.1.1` + `koog-agents-additions:1.1.1-beta`) only in the `claude` source set.
+
+## Global Constraints
+
+- **JDK 21**; never modify the ReVoman library; all work inside `agentic-harness/`.
+- **No koog / kotlinx.coroutines / OTel-SDK** in any `src/main` or `src/test` file. Default `test`/`build`/`check` stays green and never compiles the `claude` source set.
+- **All prior stages (1–4) stay green** after every task: `./gradlew :agentic-harness:test` passes every prior + new test class. The one modification to shipped code (`RouteDecision` gains two fields with defaults) must not break any existing caller.
+- **Tests never require an API key.** The real-LLM path is gated on env vars and falls back to a printed skip.
+- **Copyright header** (SFDC Apache-2.0) on every new `.kt` (copy from any existing `agentic-harness/**/*.kt`); JUnit5 + Google Truth; ktfmt Google style (`./gradlew spotlessApply` before every commit).
+- **Verified facts (do not re-derive):**
+  - `llm.RouteDecision` is currently `data class RouteDecision(val graphName: String?, val rationale: String)`. Constructed in `ScoringLlmClient.route` (2 sites) and `StubLlmClient.route` (2 sites) and referenced in tests/`ClaudeLlmClient`.
+  - `llm.LlmClient { fun route(utterance, tools: List<ToolDef>): RouteDecision; fun fillSlots(utterance, tool: ToolDef): Map<String,String> }`.
+  - `llm.ScoringLlmClient` scores each tool = (# utterance tokens found in `graphName + whenToUse + exampleQueries`, lowercased, substring) − 5×(# `whenNotToUse` clauses with ≥2 matching trigger tokens). `route` picks max; null if max ≤ 0. `tokenize` = lowercase, split `[^a-z0-9]+`, keep len ≥ 3 minus stopwords.
+  - `orchestrator.Router(llm, tools).route(utterance): RouteDecision`; `orchestrator.SlotFiller(llm).fill(utterance, tool): FillResult` (`Valid(slots: Map<String,String>)` | `Invalid(errors: List<String>)`).
+  - `tooldef.ToolDef(graphName, whenToUse, whenNotToUse: List<String>, exampleQueries: List<String>, inputExamples, slots: Map<String, SlotSchema>)` — data class. `tooldef.SlotSchema(type: SlotType, values: List<String>, required: Boolean)`; `SlotType { STRING, INT, ENUM }`.
+  - `orchestrator.GraphRegistry.loadToolDefs(): List<ToolDef>`, `GRAPHS = [configure, price, quote]`.
+  - `GraphRunner.runChain(baseUrl, graphs: List<String>, seedEnv: Map<String,Any?>): List<Rundown>`; `mock.MockCpqServer` (`start(): Int`, `stop()`, `db`).
+  - `telemetry.GenAiTracer` / `NoopTracer` / `Tracer` + `invokeAgentAttrs`/`chatAttrs`/`executeToolAttrs` (Stage 4).
+  - koog (verified in `~/code-clones/oss/koog`): `ai.koog.prompt.executor.llms.all.simpleBedrockExecutorWithBearerToken(bedrockApiKey: String, settings: BedrockClientSettings = ...)`; `ai.koog.prompt.executor.clients.bedrock.BedrockClientSettings(regionName, endpointUrl: String? = null, maxRetries)`; `ai.koog.prompt.executor.clients.bedrock.BedrockModels.AnthropicClaude45Opus: LLModel` (and `AnthropicClaude4Opus`, `AnthropicClaude41Opus`). Both artifacts (`koog-agents`, `koog-agents-additions`) are already on the `claude` source set. `PromptExecutor.execute(prompt, model): suspend -> Message.Assistant` with `.content: String`; build prompts with `ai.koog.prompt.dsl.prompt("id") { system(...); user(...) }`.
+  - This environment's Claude access (from `~/.claude/settings.json`, values not printed): `CLAUDE_CODE_USE_BEDROCK=1`, `ANTHROPIC_BEDROCK_BASE_URL` (SFDC gateway), `ANTHROPIC_AUTH_TOKEN` (bearer), model `global.anthropic.claude-opus-4-8[1m]`. There is NO direct `ANTHROPIC_API_KEY`.
+
+---
+
+### Task 1: Add `confidence` + `margin` to `RouteDecision`; expose scores from `ScoringLlmClient`
+
+**Files:**
+- Modify: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/llm/LlmClient.kt`
+- Modify: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/llm/ScoringLlmClient.kt`
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/llm/RouteConfidenceTest.kt`
+
+**Interfaces:**
+- Consumes: existing `RouteDecision`, `ScoringLlmClient`, `ToolDef`.
+- Produces:
+  - `RouteDecision(graphName: String?, rationale: String, confidence: Double = 0.0, margin: Double = 0.0)` — the two new fields **default**, so `StubLlmClient` and `ClaudeLlmClient` (which construct `RouteDecision(x, y)`) still compile untouched.
+  - `ScoringLlmClient.scores(utterance: String, tools: List<ToolDef>): Map<String, Int>` — the raw per-graph score map (public, for the gate + tests).
+  - `ScoringLlmClient.route` now fills `confidence` = `top / (sum of positive scores)` (0.0 if none positive), and `margin` = `(top − secondBest) / top` (1.0 if only one positive, 0.0 if top ≤ 0). Both in `[0,1]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/llm/RouteConfidenceTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.llm
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import org.junit.jupiter.api.Test
+
+class RouteConfidenceTest {
+  private val tools = GraphRegistry.loadToolDefs()
+  private val scoring = ScoringLlmClient()
+
+  @Test
+  fun `an unambiguous utterance routes with high margin`() {
+    val decision = scoring.route("configure 2 units of SKU-1", tools)
+    assertThat(decision.graphName).isEqualTo("configure")
+    assertThat(decision.confidence).isGreaterThan(0.0)
+    assertThat(decision.margin).isGreaterThan(0.0)
+  }
+
+  @Test
+  fun `scores exposes a per-graph score map`() {
+    val scores = scoring.scores("configure 2 units of SKU-1", tools)
+    assertThat(scores.keys).containsExactly("configure", "price", "quote")
+    assertThat(scores["configure"]!!).isGreaterThan(0)
+  }
+
+  @Test
+  fun `a no-match utterance has zero confidence and margin`() {
+    val decision = scoring.route("xyzzy plugh", tools)
+    assertThat(decision.graphName).isNull()
+    assertThat(decision.confidence).isEqualTo(0.0)
+    assertThat(decision.margin).isEqualTo(0.0)
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :agentic-harness:test --tests "*RouteConfidenceTest"`
+Expected: FAIL — `confidence`/`margin`/`scores` unresolved.
+
+- [ ] **Step 3: Add the two fields to `RouteDecision`**
+
+In `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/llm/LlmClient.kt`, replace the `RouteDecision` line with:
+
+```kotlin
+/**
+ * The router's output: the chosen graph (or null when nothing matched), a short rationale, and the
+ * router's confidence signals. [confidence] is the normalized top score in [0,1]; [margin] is the
+ * normalized gap to the second-best graph in [0,1]. The disambiguation gate reads [margin] to
+ * decide whether to ask instead of guess. Both default so callers that don't produce them (the
+ * keyword stub, the Claude client) are unaffected.
+ */
+data class RouteDecision(
+  val graphName: String?,
+  val rationale: String,
+  val confidence: Double = 0.0,
+  val margin: Double = 0.0,
+)
+```
+
+- [ ] **Step 4: Expose `scores` and fill confidence/margin in `ScoringLlmClient`**
+
+In `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/llm/ScoringLlmClient.kt`, replace the `route` function and add `scores` (keep `score`, `tokenize`, `fillSlots`, fields unchanged):
+
+```kotlin
+  override fun route(utterance: String, tools: List<ToolDef>): RouteDecision {
+    val scored = scores(utterance, tools)
+    val ranked = scored.entries.sortedByDescending { it.value }
+    val top = ranked.firstOrNull()
+    if (top == null || top.value <= 0) {
+      return RouteDecision(null, "no graph scored above zero for: $utterance", 0.0, 0.0)
+    }
+    val positiveSum = ranked.sumOf { maxOf(it.value, 0) }
+    val second = ranked.getOrNull(1)?.value?.coerceAtLeast(0) ?: 0
+    val confidence = if (positiveSum > 0) top.value.toDouble() / positiveSum else 0.0
+    val margin = (top.value - second).toDouble() / top.value
+    return RouteDecision(top.key, "score=${top.value} for '${top.key}'", confidence, margin)
+  }
+
+  /** The raw per-graph score for each tool — the basis for confidence, margin, and the gate. */
+  fun scores(utterance: String, tools: List<ToolDef>): Map<String, Int> {
+    val tokens = tokenize(utterance)
+    return tools.associate { it.graphName to score(tokens, it) }
+  }
+```
+
+- [ ] **Step 5: Run the test AND the full suite (existing callers must stay green)**
+
+Run: `./gradlew :agentic-harness:test --tests "*RouteConfidenceTest"`
+Expected: BUILD SUCCESSFUL, 3 tests passed.
+
+Run: `./gradlew :agentic-harness:test`
+Expected: BUILD SUCCESSFUL — all prior stages green (the defaulted fields keep `StubLlmClient`, Stage-3 `RouterEvaluatorTest`, etc. compiling and passing unchanged).
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/llm/LlmClient.kt \
+  agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/llm/ScoringLlmClient.kt \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/llm/RouteConfidenceTest.kt
+git commit -m "feat(harness): RouteDecision carries confidence + margin from ScoringLlmClient"
+```
+
+---
+
+### Task 2: `RetrievalPreFilter` — top-K candidate narrowing (embedding stub)
+
+**Files:**
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/retrieval/RetrievalPreFilter.kt`
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/retrieval/RetrievalPreFilterTest.kt`
+
+**Interfaces:**
+- Consumes: `ToolDef`.
+- Produces:
+  - `object RetrievalPreFilter { fun topK(intent: String, tools: List<ToolDef>, k: Int): List<ToolDef> }` — bag-of-tokens cosine similarity between `intent` and each tool's `whenToUse + " " + exampleQueries`. Returns the `k` highest-similarity tools (ties broken by input order). When `k >= tools.size`, returns `tools` unchanged (the no-op at 3 graphs). When `intent` shares no tokens with any tool, still returns the first `k` (never empty for `k>0`), so routing always has candidates.
+  - Tokenizer identical in spirit to `ScoringLlmClient` (lowercase, split `[^a-z0-9]+`, len ≥ 3) — local private copy (do not couple the two).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/retrieval/RetrievalPreFilterTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.retrieval
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import com.salesforce.revoman.harness.tooldef.SlotSchema
+import com.salesforce.revoman.harness.tooldef.SlotType
+import com.salesforce.revoman.harness.tooldef.ToolDef
+import org.junit.jupiter.api.Test
+
+class RetrievalPreFilterTest {
+  private val realTools = GraphRegistry.loadToolDefs()
+
+  @Test
+  fun `is a no-op when k is at least the number of tools`() {
+    val out = RetrievalPreFilter.topK("configure a product", realTools, k = 3)
+    assertThat(out).isEqualTo(realTools)
+  }
+
+  @Test
+  fun `narrows a large synthetic tool set to the relevant candidates`() {
+    // 10 synthetic graphs; only these three should surface for a pricing intent.
+    val tools =
+      (1..10).map { i ->
+        val (name, blurb) =
+          when (i) {
+            1 -> "price" to "compute the price and total cost of a configuration"
+            2 -> "discount" to "apply a pricing discount to a cost total"
+            3 -> "tax" to "compute tax on a price total"
+            else -> "graph$i" to "unrelated capability number $i about widgets and gadgets"
+          }
+        ToolDef(name, blurb, emptyList(), listOf(blurb), emptyList(),
+          mapOf("x" to SlotSchema(SlotType.STRING)))
+      }
+    val top3 = RetrievalPreFilter.topK("what is the price and cost total", tools, k = 3)
+    assertThat(top3.map { it.graphName }).containsExactly("price", "discount", "tax")
+  }
+
+  @Test
+  fun `never returns empty for k greater than zero even with no token overlap`() {
+    val out = RetrievalPreFilter.topK("zzzz qqqq", realTools, k = 2)
+    assertThat(out).hasSize(2)
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :agentic-harness:test --tests "*RetrievalPreFilterTest"`
+Expected: FAIL — unresolved reference `RetrievalPreFilter`.
+
+- [ ] **Step 3: Write `RetrievalPreFilter`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/retrieval/RetrievalPreFilter.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.retrieval
+
+import com.salesforce.revoman.harness.tooldef.ToolDef
+import kotlin.math.sqrt
+
+/**
+ * Scaffold 4: narrows many graphs to the top-K relevant candidates BEFORE the router reasons, so
+ * the model reasons over a small, clean set (the reliability control from `reasoning-layer.md`).
+ * The embedding is a local bag-of-tokens cosine stub — enough to prove the seam; a real vector
+ * store drops in behind the same `topK` signature. A no-op at 3 graphs (returns all), it
+ * demonstrably narrows a larger set.
+ */
+object RetrievalPreFilter {
+  fun topK(intent: String, tools: List<ToolDef>, k: Int): List<ToolDef> {
+    if (k >= tools.size) return tools
+    val q = vector(intent)
+    return tools
+      .withIndex()
+      .sortedWith(
+        compareByDescending<IndexedValue<ToolDef>> { cosine(q, vector(docText(it.value))) }
+          .thenBy { it.index }
+      )
+      .take(k)
+      .map { it.value }
+  }
+
+  private fun docText(tool: ToolDef): String =
+    tool.whenToUse + " " + tool.exampleQueries.joinToString(" ")
+
+  private fun vector(text: String): Map<String, Int> =
+    tokenize(text).groupingBy { it }.eachCount()
+
+  private fun cosine(a: Map<String, Int>, b: Map<String, Int>): Double {
+    if (a.isEmpty() || b.isEmpty()) return 0.0
+    val dot = a.keys.intersect(b.keys).sumOf { a.getValue(it) * b.getValue(it) }
+    val magA = sqrt(a.values.sumOf { it * it }.toDouble())
+    val magB = sqrt(b.values.sumOf { it * it }.toDouble())
+    return if (magA == 0.0 || magB == 0.0) 0.0 else dot / (magA * magB)
+  }
+
+  private fun tokenize(text: String): List<String> =
+    text.lowercase().split(Regex("[^a-z0-9]+")).filter { it.length >= 3 }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :agentic-harness:test --tests "*RetrievalPreFilterTest"`
+Expected: BUILD SUCCESSFUL, 3 tests passed.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/retrieval/RetrievalPreFilter.kt \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/retrieval/RetrievalPreFilterTest.kt
+git commit -m "feat(harness): retrieval pre-filter (top-K candidate narrowing, embedding stub)"
+```
+
+---
+
+### Task 3: `ConfidencePolicy` + `ActionPreview` + `ReasoningOutcome`
+
+**Files:**
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/reasoning/ConfidencePolicy.kt`
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/reasoning/ActionPreview.kt`
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/reasoning/ReasoningOutcome.kt`
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/reasoning/ConfidencePolicyTest.kt`
+
+**Interfaces:**
+- Produces:
+  - `data class ConfidencePolicy(val defaultThreshold: Double = 0.60, val perGraphThreshold: Map<String, Double> = emptyMap(), val writeGraphs: Set<String> = setOf("quote")) { fun threshold(graph: String): Double; fun isWrite(graph: String): Boolean }` — `threshold` returns `perGraphThreshold[graph] ?: if (isWrite(graph)) 0.90 else defaultThreshold`. The 0.90 write default is the financial-services band.
+  - `data class ActionPreview(val graph: String, val slots: Map<String, String>, val chain: List<String>, val isWrite: Boolean)`.
+  - `sealed interface ReasoningOutcome { data class NoMatch(val intent: String); data class Clarify(val question: String, val candidates: List<String>); data class ConfirmRequired(val preview: ActionPreview); data class Proceed(val graph: String, val slots: Map<String, String>) }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/reasoning/ConfidencePolicyTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.reasoning
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class ConfidencePolicyTest {
+  @Test
+  fun `write graphs default to the financial-services 0-90 band`() {
+    val policy = ConfidencePolicy()
+    assertThat(policy.isWrite("quote")).isTrue()
+    assertThat(policy.threshold("quote")).isEqualTo(0.90)
+  }
+
+  @Test
+  fun `read graphs use the default threshold`() {
+    val policy = ConfidencePolicy()
+    assertThat(policy.isWrite("configure")).isFalse()
+    assertThat(policy.threshold("configure")).isEqualTo(0.60)
+  }
+
+  @Test
+  fun `per-graph override wins over the write default`() {
+    val policy = ConfidencePolicy(perGraphThreshold = mapOf("quote" to 0.50))
+    assertThat(policy.threshold("quote")).isEqualTo(0.50)
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :agentic-harness:test --tests "*ConfidencePolicyTest"`
+Expected: FAIL — unresolved references `ConfidencePolicy` (and later `ActionPreview`, `ReasoningOutcome`).
+
+- [ ] **Step 3: Write the three files**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/reasoning/ConfidencePolicy.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.reasoning
+
+/**
+ * The tunable policy for the disambiguation gate: below a graph's [threshold] the layer asks
+ * instead of guessing. Write graphs default to the financial-services band (0.90) per the industry
+ * research; reads use [defaultThreshold]. Per-graph overrides win. The margin/threshold trade is
+ * deliberately tunable — that is the whole point of the gate.
+ */
+data class ConfidencePolicy(
+  val defaultThreshold: Double = 0.60,
+  val perGraphThreshold: Map<String, Double> = emptyMap(),
+  val writeGraphs: Set<String> = setOf("quote"),
+) {
+  fun isWrite(graph: String): Boolean = graph in writeGraphs
+
+  fun threshold(graph: String): Double =
+    perGraphThreshold[graph] ?: if (isWrite(graph)) FINANCIAL_SERVICES_BAND else defaultThreshold
+
+  companion object {
+    const val FINANCIAL_SERVICES_BAND: Double = 0.90
+  }
+}
+```
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/reasoning/ActionPreview.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.reasoning
+
+/**
+ * The confirm gate's proposed-action preview for a write: exactly what would run, shown to the
+ * human, executed only on confirm. Carries what `GraphRunner.runChain` needs so confirmation
+ * executes without re-deriving anything.
+ */
+data class ActionPreview(
+  val graph: String,
+  val slots: Map<String, String>,
+  val chain: List<String>,
+  val isWrite: Boolean,
+)
+```
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/reasoning/ReasoningOutcome.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.reasoning
+
+/** The reasoning layer's decision for one intent — proceed, ask, confirm, or no match. */
+sealed interface ReasoningOutcome {
+  data class NoMatch(val intent: String) : ReasoningOutcome
+
+  /** The ask-don't-guess result: top-2 within margin, or a required slot missing/invalid. */
+  data class Clarify(val question: String, val candidates: List<String>) : ReasoningOutcome
+
+  /** A confident write: preview shown, nothing executed until the human confirms. */
+  data class ConfirmRequired(val preview: ActionPreview) : ReasoningOutcome
+
+  /** A confident read: safe to execute. */
+  data class Proceed(val graph: String, val slots: Map<String, String>) : ReasoningOutcome
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :agentic-harness:test --tests "*ConfidencePolicyTest"`
+Expected: BUILD SUCCESSFUL, 3 tests passed.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/reasoning/ConfidencePolicy.kt \
+  agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/reasoning/ActionPreview.kt \
+  agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/reasoning/ReasoningOutcome.kt \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/reasoning/ConfidencePolicyTest.kt
+git commit -m "feat(harness): ConfidencePolicy + ActionPreview + ReasoningOutcome types"
+```
+
+---
+
+### Task 4: `DisambiguationGate` — the ask-don't-guess decision
+
+**Files:**
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/reasoning/DisambiguationGate.kt`
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/reasoning/DisambiguationGateTest.kt`
+
+**Interfaces:**
+- Consumes: `RouteDecision` (Task 1), `FillResult` (`Valid`/`Invalid`), `ConfidencePolicy`/`ActionPreview`/`ReasoningOutcome` (Task 3).
+- Produces:
+  - `class DisambiguationGate(private val policy: ConfidencePolicy = ConfidencePolicy()) { fun decide(decision: RouteDecision, secondBestGraph: String?, fill: FillResult, chain: List<String>): ReasoningOutcome }`.
+  - Decision order: (1) `decision.graphName == null` → `NoMatch`; (2) `decision.margin < policy.threshold(graph)` → `Clarify("Did you mean X or Y?", [graph, secondBestGraph].filterNotNull())`; (3) `fill is Invalid` → `Clarify("I need more detail: <errors>", [graph])`; (4) `fill is Valid` and `policy.isWrite(graph)` → `ConfirmRequired(ActionPreview(graph, slots, chain, isWrite = true))`; (5) else → `Proceed(graph, slots)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/reasoning/DisambiguationGateTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.reasoning
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.llm.RouteDecision
+import com.salesforce.revoman.harness.orchestrator.FillResult
+import org.junit.jupiter.api.Test
+
+class DisambiguationGateTest {
+  private val gate = DisambiguationGate()
+
+  @Test
+  fun `no route yields NoMatch`() {
+    val outcome = gate.decide(RouteDecision(null, "none", 0.0, 0.0), null, FillResult.Valid(emptyMap()), listOf("configure"))
+    assertThat(outcome).isInstanceOf(ReasoningOutcome.NoMatch::class.java)
+  }
+
+  @Test
+  fun `low margin asks instead of guessing`() {
+    // Confident-ish confidence but a tiny margin between the top two graphs.
+    val decision = RouteDecision("configure", "close call", confidence = 0.55, margin = 0.10)
+    val outcome =
+      gate.decide(decision, secondBestGraph = "price", FillResult.Valid(mapOf("productCode" to "SKU-1")), listOf("configure"))
+    assertThat(outcome).isInstanceOf(ReasoningOutcome.Clarify::class.java)
+    val clarify = outcome as ReasoningOutcome.Clarify
+    assertThat(clarify.candidates).containsExactly("configure", "price")
+  }
+
+  @Test
+  fun `a confident read proceeds`() {
+    val decision = RouteDecision("configure", "clear", confidence = 0.9, margin = 0.9)
+    val outcome =
+      gate.decide(decision, "price", FillResult.Valid(mapOf("productCode" to "SKU-1", "quantity" to "2")), listOf("configure"))
+    assertThat(outcome).isInstanceOf(ReasoningOutcome.Proceed::class.java)
+  }
+
+  @Test
+  fun `a confident write requires confirmation with a preview, not execution`() {
+    val decision = RouteDecision("quote", "clear", confidence = 0.95, margin = 0.95)
+    val outcome = gate.decide(decision, "price", FillResult.Valid(mapOf("priceId" to "prc-2")), listOf("quote"))
+    assertThat(outcome).isInstanceOf(ReasoningOutcome.ConfirmRequired::class.java)
+    val preview = (outcome as ReasoningOutcome.ConfirmRequired).preview
+    assertThat(preview.graph).isEqualTo("quote")
+    assertThat(preview.isWrite).isTrue()
+    assertThat(preview.slots).containsEntry("priceId", "prc-2")
+  }
+
+  @Test
+  fun `an invalid slot-fill asks for clarification`() {
+    val decision = RouteDecision("configure", "clear", confidence = 0.9, margin = 0.9)
+    val outcome =
+      gate.decide(decision, "price", FillResult.Invalid(listOf("missing required slot 'quantity'")), listOf("configure"))
+    assertThat(outcome).isInstanceOf(ReasoningOutcome.Clarify::class.java)
+    assertThat((outcome as ReasoningOutcome.Clarify).question).contains("quantity")
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :agentic-harness:test --tests "*DisambiguationGateTest"`
+Expected: FAIL — unresolved reference `DisambiguationGate`.
+
+- [ ] **Step 3: Write `DisambiguationGate`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/reasoning/DisambiguationGate.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.reasoning
+
+import com.salesforce.revoman.harness.llm.RouteDecision
+import com.salesforce.revoman.harness.orchestrator.FillResult
+
+/**
+ * Scaffold 5, the single most important reliability rule: gate on uncertainty, never guess. When
+ * the top-two graphs are within the policy margin, or a required slot is missing/invalid, the layer
+ * returns a [ReasoningOutcome.Clarify] (ask the user) rather than a coin-flip. Confident writes
+ * route to [ReasoningOutcome.ConfirmRequired] (human validates before execution); confident reads
+ * [ReasoningOutcome.Proceed].
+ */
+class DisambiguationGate(private val policy: ConfidencePolicy = ConfidencePolicy()) {
+  fun decide(
+    decision: RouteDecision,
+    secondBestGraph: String?,
+    fill: FillResult,
+    chain: List<String>,
+  ): ReasoningOutcome {
+    val graph = decision.graphName ?: return ReasoningOutcome.NoMatch("(none)")
+
+    if (decision.margin < policy.threshold(graph)) {
+      val candidates = listOfNotNull(graph, secondBestGraph)
+      return ReasoningOutcome.Clarify(
+        "I'm not confident which action you want. Did you mean ${candidates.joinToString(" or ")}?",
+        candidates,
+      )
+    }
+
+    return when (fill) {
+      is FillResult.Invalid ->
+        ReasoningOutcome.Clarify(
+          "I need more detail before I can proceed: ${fill.errors.joinToString("; ")}",
+          listOf(graph),
+        )
+      is FillResult.Valid ->
+        if (policy.isWrite(graph))
+          ReasoningOutcome.ConfirmRequired(ActionPreview(graph, fill.slots, chain, isWrite = true))
+        else ReasoningOutcome.Proceed(graph, fill.slots)
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew :agentic-harness:test --tests "*DisambiguationGateTest"`
+Expected: BUILD SUCCESSFUL, 5 tests passed.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/reasoning/DisambiguationGate.kt \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/reasoning/DisambiguationGateTest.kt
+git commit -m "feat(harness): DisambiguationGate — ask-don't-guess on low margin / bad slots"
+```
+
+---
+
+### Task 5: `ReasoningLayer` end-to-end wiring + `Stage5Demo`
+
+**Files:**
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/reasoning/ReasoningLayer.kt`
+- Create: `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/Stage5Demo.kt`
+- Modify: `agentic-harness/build.gradle.kts` (add `runStage5Demo` JavaExec task)
+- Test: `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/reasoning/ReasoningLayerTest.kt`
+
+**Interfaces:**
+- Consumes: `RetrievalPreFilter` (Task 2), `ScoringLlmClient` (Task 1), `DisambiguationGate`/`ConfidencePolicy`/`ReasoningOutcome`/`ActionPreview` (Tasks 3–4), `SlotFiller`/`FillResult`, `GraphRunner`, `MockCpqServer`, `GenAiTracer`/`NoopTracer`, `Rundown`.
+- Produces:
+  - `class ReasoningLayer(private val tools: List<ToolDef>, private val llm: ScoringLlmClient = ScoringLlmClient(), private val policy: ConfidencePolicy = ConfidencePolicy(), private val topK: Int = tools.size, private val tracer: Tracer = NoopTracer())`.
+  - `fun handle(intent: String): ReasoningOutcome` — traced `invoke_agent` span; `RetrievalPreFilter.topK(intent, tools, topK)` → candidates; `chat` span for routing via `llm.route(intent, candidates)`; determine `secondBestGraph` from `llm.scores(intent, candidates)` (2nd-highest key, or null); `chat` span for slot-fill via `SlotFiller(llm).fill(intent, tool)` (only when a graph matched); then `DisambiguationGate(policy).decide(...)`. Returns the outcome; **executes nothing**.
+  - `fun confirm(preview: ActionPreview, baseUrl: String): List<Rundown>` — `execute_tool` span; runs `GraphRunner.runChain(baseUrl, preview.chain, preview.slots)`. The only path that touches ReVoman.
+  - `fun main()` in `Stage5Demo.kt` + `runStage5Demo` task (mainClass `com.salesforce.revoman.harness.Stage5DemoKt`) demonstrating four utterances: a read that proceeds, a write that returns `ConfirmRequired` (then `confirm` executes), an ambiguous one that returns `Clarify`, and a no-match — all traced to console.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/reasoning/ReasoningLayerTest.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.reasoning
+
+import com.google.common.truth.Truth.assertThat
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ReasoningLayerTest {
+  private lateinit var server: MockCpqServer
+  private lateinit var baseUrl: String
+  private val tools = GraphRegistry.loadToolDefs()
+
+  @BeforeEach
+  fun setUp() {
+    server = MockCpqServer()
+    baseUrl = "http://127.0.0.1:${server.start()}"
+  }
+
+  @AfterEach fun tearDown() = server.stop()
+
+  @Test
+  fun `a confident read proceeds without executing`() {
+    val outcome = ReasoningLayer(tools).handle("configure 2 units of SKU-1")
+    assertThat(outcome).isInstanceOf(ReasoningOutcome.Proceed::class.java)
+    assertThat(server.db).isEmpty() // handle() never executes
+  }
+
+  @Test
+  fun `a write intent requires confirmation and executes only on confirm`() {
+    val layer = ReasoningLayer(tools)
+    val outcome = layer.handle("create a draft quote for prc-2")
+    assertThat(outcome).isInstanceOf(ReasoningOutcome.ConfirmRequired::class.java)
+    assertThat(server.db).isEmpty() // nothing ran yet
+
+    val preview = (outcome as ReasoningOutcome.ConfirmRequired).preview
+    val rundowns = layer.confirm(preview, baseUrl)
+    assertThat(rundowns).isNotEmpty()
+    assertThat(server.db.values).contains("DRAFT") // now it ran
+  }
+
+  @Test
+  fun `an ambiguous intent asks instead of guessing and never executes`() {
+    // A high write-threshold (0.90) means a low-margin quote intent must ask.
+    val policy = ConfidencePolicy(perGraphThreshold = mapOf("configure" to 0.99))
+    val outcome = ReasoningLayer(tools, policy = policy).handle("configure or price this")
+    assertThat(outcome).isInstanceOf(ReasoningOutcome.Clarify::class.java)
+    assertThat(server.db).isEmpty()
+  }
+
+  @Test
+  fun `an unrelated intent is NoMatch`() {
+    assertThat(ReasoningLayer(tools).handle("what is the weather"))
+      .isInstanceOf(ReasoningOutcome.NoMatch::class.java)
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew :agentic-harness:test --tests "*ReasoningLayerTest"`
+Expected: FAIL — unresolved reference `ReasoningLayer`.
+
+- [ ] **Step 3: Write `ReasoningLayer`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/reasoning/ReasoningLayer.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness.reasoning
+
+import com.salesforce.revoman.harness.GraphRunner
+import com.salesforce.revoman.harness.llm.ScoringLlmClient
+import com.salesforce.revoman.harness.orchestrator.SlotFiller
+import com.salesforce.revoman.harness.retrieval.RetrievalPreFilter
+import com.salesforce.revoman.harness.telemetry.NoopTracer
+import com.salesforce.revoman.harness.telemetry.Tracer
+import com.salesforce.revoman.harness.telemetry.chatAttrs
+import com.salesforce.revoman.harness.telemetry.executeToolAttrs
+import com.salesforce.revoman.harness.telemetry.invokeAgentAttrs
+import com.salesforce.revoman.harness.tooldef.ToolDef
+import com.salesforce.revoman.output.Rundown
+
+/**
+ * The complete reasoning layer: the one probabilistic surface, scaffolded for reliability.
+ * `handle` runs retrieve → route (with confidence) → fill (validated) → gate, and returns a
+ * [ReasoningOutcome] WITHOUT executing anything. `confirm` is the only path that hands a graph to
+ * ReVoman, and only after the gate said a human must approve (writes) or the caller chose to run a
+ * `Proceed`. Every turn is traced with OTel GenAI-convention spans.
+ */
+class ReasoningLayer(
+  private val tools: List<ToolDef>,
+  private val llm: ScoringLlmClient = ScoringLlmClient(),
+  private val policy: ConfidencePolicy = ConfidencePolicy(),
+  private val topK: Int = tools.size,
+  private val tracer: Tracer = NoopTracer(),
+) {
+  private val gate = DisambiguationGate(policy)
+  private val slotFiller = SlotFiller(llm)
+
+  fun handle(intent: String): ReasoningOutcome =
+    tracer.span("invoke_agent", invokeAgentAttrs("reasoning-layer")) { agent ->
+      agent.setAttribute("gen_ai.prompt", intent)
+      val candidates = RetrievalPreFilter.topK(intent, tools, topK)
+
+      val decision =
+        tracer.span("chat", chatAttrs("router")) { chat ->
+          val d = llm.route(intent, candidates)
+          chat.setAttribute("gen_ai.response.text", d.graphName ?: "none")
+          chat.setAttribute("confidence", d.confidence)
+          chat.setAttribute("margin", d.margin)
+          d
+        }
+      val graph = decision.graphName ?: return@span ReasoningOutcome.NoMatch(intent)
+      val tool = candidates.first { it.graphName == graph }
+
+      val secondBest =
+        llm.scores(intent, candidates)
+          .entries
+          .sortedByDescending { it.value }
+          .getOrNull(1)
+          ?.takeIf { it.value > 0 }
+          ?.key
+
+      val fill =
+        tracer.span("chat", chatAttrs("slot-filler")) { slotFiller.fill(intent, tool) }
+
+      val outcome = gate.decide(decision, secondBest, fill, chain = listOf(graph))
+      agent.setAttribute("turn.outcome", outcome::class.simpleName ?: "unknown")
+      outcome
+    }
+
+  fun confirm(preview: ActionPreview, baseUrl: String): List<Rundown> =
+    tracer.span("execute_tool", executeToolAttrs(preview.graph)) {
+      GraphRunner.runChain(baseUrl, preview.chain, seedEnv = preview.slots)
+    }
+}
+```
+
+- [ ] **Step 4: Run the test AND the full suite**
+
+Run: `./gradlew :agentic-harness:test --tests "*ReasoningLayerTest"`
+Expected: BUILD SUCCESSFUL, 4 tests passed.
+
+If the ambiguous test does not produce `Clarify`: the stub's scoring may give the top graph a margin at/above the threshold. The test forces this by setting `configure`'s threshold to 0.99 — confirm `ScoringLlmClient.route`'s margin for "configure or price this" is below 0.99 (it will be, since both `configure` and `price` score > 0, so margin = (top−second)/top < 1.0 < 0.99 only if second > 0.01·top; if the utterance yields a single positive graph, rephrase the test intent to one that scores two graphs — e.g. "configure or price this" contains both "configure" and "price" tokens). Do not weaken the assertion; adjust the intent string so two graphs genuinely score.
+
+- [ ] **Step 5: Write `Stage5Demo`**
+
+Create `agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/Stage5Demo.kt`:
+
+```kotlin
+/**
+ * ************************************************************************************************
+ * Copyright (c) 2023, Salesforce, Inc. All rights reserved. SPDX-License-Identifier: Apache License
+ * Version 2.0 For full license text, see the LICENSE file in the repo root or
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * ************************************************************************************************
+ */
+package com.salesforce.revoman.harness
+
+import com.salesforce.revoman.harness.mock.MockCpqServer
+import com.salesforce.revoman.harness.orchestrator.GraphRegistry
+import com.salesforce.revoman.harness.reasoning.ConfidencePolicy
+import com.salesforce.revoman.harness.reasoning.ReasoningLayer
+import com.salesforce.revoman.harness.reasoning.ReasoningOutcome
+import com.salesforce.revoman.harness.telemetry.GenAiTracer
+
+/**
+ * Stage 5 runnable demo: the complete reasoning layer with all six scaffolds, deterministic (no
+ * key). Shows the four outcomes — proceed (read), confirm-then-execute (write), ask (ambiguous),
+ * no-match — each traced with OTel GenAI-convention spans printed to console.
+ */
+fun main() {
+  val tools = GraphRegistry.loadToolDefs()
+  val server = MockCpqServer()
+  val baseUrl = "http://127.0.0.1:${server.start()}"
+  // A high 'configure' threshold forces the ambiguous case to ask.
+  val policy = ConfidencePolicy(perGraphThreshold = mapOf("configure" to 0.99))
+  val layer = ReasoningLayer(tools, policy = policy, tracer = GenAiTracer())
+
+  try {
+    listOf(
+      "price configuration cfg-1", // confident read -> Proceed
+      "create a draft quote for prc-2", // confident write -> ConfirmRequired -> confirm
+      "configure or price this", // ambiguous -> Clarify (ask, don't guess)
+      "what is the weather", // no match
+    )
+      .forEach { intent ->
+        println("\n>>> $intent")
+        when (val outcome = layer.handle(intent)) {
+          is ReasoningOutcome.Proceed -> println("  PROCEED: ${outcome.graph} slots=${outcome.slots}")
+          is ReasoningOutcome.ConfirmRequired -> {
+            println("  CONFIRM REQUIRED (write): ${outcome.preview}")
+            val rundowns = layer.confirm(outcome.preview, baseUrl)
+            println("  confirmed -> executed ${rundowns.size} graph(s); DB=${server.db}")
+          }
+          is ReasoningOutcome.Clarify -> println("  ASK: ${outcome.question} candidates=${outcome.candidates}")
+          is ReasoningOutcome.NoMatch -> println("  NO MATCH")
+        }
+      }
+  } finally {
+    server.stop()
+  }
+}
+```
+
+- [ ] **Step 6: Add the run task**
+
+Append to `agentic-harness/build.gradle.kts`:
+
+```kotlin
+tasks.register<JavaExec>("runStage5Demo") {
+  group = "harness"
+  description = "Run the complete reasoning layer (retrieve -> route -> fill -> gate: ask|confirm|proceed)"
+  mainClass.set("com.salesforce.revoman.harness.Stage5DemoKt")
+  classpath = sourceSets["main"].runtimeClasspath
+}
+```
+
+- [ ] **Step 7: Run the demo and the full suite**
+
+Run: `./gradlew :agentic-harness:runStage5Demo -q`
+Expected: `>>> price configuration cfg-1` → `PROCEED: price ...`; `>>> create a draft quote for prc-2` → `CONFIRM REQUIRED (write)` then `confirmed -> executed 1 graph(s); DB={...DRAFT...}`; `>>> configure or price this` → `ASK: ... candidates=[configure, price]`; `>>> what is the weather` → `NO MATCH`. Each preceded by an `• invoke_agent` span tree.
+
+Run: `./gradlew :agentic-harness:test`
+Expected: BUILD SUCCESSFUL — all prior + new test classes pass.
+
+- [ ] **Step 8: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/reasoning/ReasoningLayer.kt \
+  agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/Stage5Demo.kt \
+  agentic-harness/build.gradle.kts \
+  agentic-harness/src/test/kotlin/com/salesforce/revoman/harness/reasoning/ReasoningLayerTest.kt
+git commit -m "feat(harness): ReasoningLayer wires retrieve->route->fill->gate; Stage5 demo"
+```
+
+---
+
+### Task 6: Real Claude via Bedrock proxy (best-effort, gated) + native tool-use slot-fill
+
+**Files:**
+- Modify: `agentic-harness/src/claude/kotlin/com/salesforce/revoman/harness/llm/claude/ClaudeLlmClient.kt`
+- Modify: `agentic-harness/src/claude/kotlin/com/salesforce/revoman/harness/ClaudeDemo.kt`
+
+**Interfaces:**
+- Consumes (claude source set only): koog `simpleBedrockExecutorWithBearerToken`, `BedrockClientSettings`, `BedrockModels`; the existing `ClaudeLlmClient` structure; `ReasoningLayer` for the demo.
+- Produces:
+  - `ClaudeLlmClient` gains a companion `fromBedrockEnv(): LlmClient?` that returns an instance wired to the Bedrock proxy when `ANTHROPIC_BEDROCK_BASE_URL` + a bearer token (`ANTHROPIC_AUTH_TOKEN`) are set, else `null`. It builds `simpleBedrockExecutorWithBearerToken(token, BedrockClientSettings(endpointUrl = baseUrl))` and uses `BedrockModels.AnthropicClaude45Opus` (or the closest available). Keep the existing direct-Anthropic `fromEnv()` for the public-API case.
+  - `fillSlots` additionally builds an Anthropic tool-use `input_schema` from the tool's `SlotSchema` map (types + enum `values`) and forces that tool (constrained decoding), so the model returns strict structured arguments; the returned args still pass through the existing validation before use.
+  - `ClaudeDemo.main()` prefers `fromBedrockEnv()` then `fromEnv()`; if both null, prints a skip line and exits 0. On a live client, it drives `ReasoningLayer` over a couple of intents.
+- **Scope note:** deliverable is that `compileClaudeKotlin` still SUCCEEDS and the default `test` stays green and never compiles this source set. A live call working against the SFDC proxy is **best-effort** — if the proxy's protocol/auth rejects koog's Bedrock client, capture the exact error and report `DONE_WITH_CONCERNS`; do NOT modify `main`/`test` to compensate, and do NOT block. The deterministic layer (Tasks 1–5) is the real deliverable.
+
+- [ ] **Step 1: Read the current claude source-set files**
+
+Read `agentic-harness/src/claude/kotlin/com/salesforce/revoman/harness/llm/claude/ClaudeLlmClient.kt` and `.../ClaudeDemo.kt` in full before editing — preserve the existing `fromEnv()` / direct-Anthropic path and the `LlmClient` contract.
+
+- [ ] **Step 2: Add the Bedrock-proxy factory + native tool-use to `ClaudeLlmClient`**
+
+Add to the `ClaudeLlmClient` companion (adjust imports; the executor construction differs from the direct-Anthropic one). The client should accept a pre-built `PromptExecutor` + `LLModel` so both factories share the routing/slot-fill logic:
+
+```kotlin
+// imports (claude source set)
+import ai.koog.prompt.executor.clients.bedrock.BedrockClientSettings
+import ai.koog.prompt.executor.clients.bedrock.BedrockModels
+import ai.koog.prompt.executor.llms.all.simpleBedrockExecutorWithBearerToken
+
+  companion object {
+    /** Direct public Anthropic API (sk-ant-... key). Null when unset. */
+    fun fromEnv(): LlmClient? = System.getenv("ANTHROPIC_API_KEY")?.let(::ClaudeLlmClient)
+
+    /**
+     * This environment's path: an AWS Bedrock proxy (bearer token + custom gateway URL) rather
+     * than the public Anthropic API. Best-effort — koog's Bedrock client may or may not accept a
+     * non-AWS gateway; if it doesn't, the caller falls back to skip.
+     */
+    fun fromBedrockEnv(): LlmClient? {
+      val token = System.getenv("ANTHROPIC_AUTH_TOKEN") ?: return null
+      val baseUrl = System.getenv("ANTHROPIC_BEDROCK_BASE_URL") ?: return null
+      val executor =
+        simpleBedrockExecutorWithBearerToken(token, BedrockClientSettings(endpointUrl = baseUrl))
+      return ClaudeLlmClient(executor, BedrockModels.AnthropicClaude45Opus)
+    }
+  }
+```
+
+Refactor the primary constructor to `class ClaudeLlmClient(private val executor: PromptExecutor, private val model: LLModel)` and make the existing `ClaudeLlmClient(apiKey: String)` a secondary constructor delegating via `simpleAnthropicExecutor(apiKey)` + `AnthropicModels.Sonnet_4_5`, so both real paths reuse one `route`/`fillSlots` body.
+
+For native tool-use in `fillSlots`, build the `input_schema` from `tool.slots` (map each `SlotSchema` to a JSON-schema property: `type` INT→`integer`/STRING,ENUM→`string`; ENUM adds `enum: values`; required names) and pass it as an Anthropic tool the model is forced to call; parse the tool-call arguments as the slot map. Keep the existing regex-JSON fallback for the non-tool-use path. (Consult the koog source at `~/code-clones/oss/koog` for the exact tool-descriptor/`tool_choice` API on `PromptExecutor.execute`; if the forced-tool API is not readily available in koog 1.1.1, keep the current prompt-based structured reply and note it — the Bedrock wiring is the priority.)
+
+- [ ] **Step 3: Prefer the Bedrock factory in `ClaudeDemo` and drive `ReasoningLayer`**
+
+Update `ClaudeDemo.main()` to `val llm = ClaudeLlmClient.fromBedrockEnv() ?: ClaudeLlmClient.fromEnv()`; if null, print the skip line and return. Otherwise boot `MockCpqServer` and drive a `ReasoningLayer(GraphRegistry.loadToolDefs(), llm = <wrap>, ...)` — note `ReasoningLayer` currently takes a `ScoringLlmClient`; for the demo, call the lower-level `Router`/`SlotFiller` with the real `llm` directly, OR add a demo path that routes+fills with the real client and prints the outcome. Keep it simple: the demo's job is to prove a live Claude call returns a graph + slots against the proxy.
+
+- [ ] **Step 4: Compile the claude source set (the gate)**
+
+Run: `./gradlew :agentic-harness:compileClaudeKotlin`
+Expected: BUILD SUCCESSFUL — koog Bedrock symbols resolve and the source set compiles.
+
+If it fails to resolve `simpleBedrockExecutorWithBearerToken` / `BedrockModels` / `BedrockClientSettings`: verify the import paths against the koog source; both `koog-agents` and `koog-agents-additions` are already deps. If it fails for another reason, capture the exact error, report `DONE_WITH_CONCERNS`, and STOP (do not touch main/test).
+
+- [ ] **Step 5: Confirm the default suite is still green and koog-free**
+
+Run: `./gradlew :agentic-harness:test`
+Expected: BUILD SUCCESSFUL — all deterministic tests pass; the build log shows NO `compileClaudeKotlin` task.
+
+- [ ] **Step 6 (best-effort, gated): try a live call against the Bedrock proxy**
+
+Only if the environment exports the Bedrock vars (they come from `~/.claude/settings.json`; export them into the shell first, e.g. `export ANTHROPIC_AUTH_TOKEN=... ANTHROPIC_BEDROCK_BASE_URL=...`). If Bedrock auth requires TLS to the SFDC gateway, this may need the workspace network:
+
+Run: `./gradlew :agentic-harness:claudeDemo -q`
+Expected (best case): live routing/slot-fill decisions from Claude via the proxy, executed against the mock. If the proxy rejects the request (auth/protocol/TLS), capture the exact error and report `DONE_WITH_CONCERNS` — the deterministic layer already proves the design; a live proxy call is a bonus.
+
+- [ ] **Step 7: Format and commit**
+
+```bash
+./gradlew spotlessApply
+git add agentic-harness/src/claude/kotlin/com/salesforce/revoman/harness/llm/claude/ClaudeLlmClient.kt \
+  agentic-harness/src/claude/kotlin/com/salesforce/revoman/harness/ClaudeDemo.kt
+git commit -m "feat(harness): real Claude via Bedrock-proxy bearer token + native tool-use (gated)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (the delta rows of the reasoning-layer scaffolds):**
+- Scaffold 2 (router returns `{graph_id, confidence}`) → Task 1 (`RouteDecision.confidence/margin` + `scores`). ✓
+- Scaffold 4 (retrieval pre-filter) → Task 2 (`RetrievalPreFilter.topK`). ✓
+- Scaffold 5 (confidence/disambiguation gate — the core) → Task 3 (`ConfidencePolicy`/`ReasoningOutcome`) + Task 4 (`DisambiguationGate`). ✓
+- Scaffold 6 (confirm gate preview object) → Task 3 (`ActionPreview`) + Task 5 (`ReasoningLayer.confirm`). ✓
+- End-to-end wiring (retrieve→route→fill→gate→ReVoman) → Task 5 (`ReasoningLayer` + `Stage5Demo`). ✓
+- Measurable: low-margin→ask, write→confirm, both empty-DB proofs → Tasks 4–5 tests. ✓
+- Native strict tool-use + Bedrock-proxy real client → Task 6 (gated, best-effort). ✓
+- Scaffolds 1, 3, 7, 8a (tool-def gen, slot-filler, confusion matrix, BFCL) reused as-is from Stages 1–4, not rebuilt. ✓
+
+**Placeholder scan:** No TBD/TODO/"add error handling"/"similar to Task N". Every deterministic step (Tasks 1–5) shows complete code. Task 6 (the isolated, best-effort koog path) intentionally gives the factory + wiring verbatim and directs the implementer to the koog source for the exact forced-tool API, because that one API surface is the sole genuinely-uncertain piece in this environment — flagged explicitly, with a `DONE_WITH_CONCERNS` fallback, not left vague.
+
+**Type consistency:** `RouteDecision(graphName, rationale, confidence=0.0, margin=0.0)` (Task 1) consumed by `DisambiguationGate.decide` (Task 4) and `ReasoningLayer` (Task 5). `ScoringLlmClient.scores` (Task 1) used in `ReasoningLayer` for `secondBestGraph` (Task 5). `RetrievalPreFilter.topK(intent, tools, k)` (Task 2) used in Task 5. `ConfidencePolicy.threshold/isWrite` + `ActionPreview(graph, slots, chain, isWrite)` + `ReasoningOutcome.{NoMatch,Clarify,ConfirmRequired,Proceed}` (Task 3) used in Tasks 4–5. `DisambiguationGate.decide(decision, secondBestGraph, fill, chain)` (Task 4) called by Task 5. Reuses verified APIs: `SlotFiller(llm).fill → FillResult.Valid/Invalid`, `GraphRunner.runChain(baseUrl, chain, seedEnv)`, `MockCpqServer.{start,stop,db}`, `GenAiTracer`/`NoopTracer` + attr helpers, `ToolDef`/`SlotSchema`/`SlotType`, `GraphRegistry.loadToolDefs`. ✓
+
+**Backward-compat:** the only shipped-code edits are `RouteDecision` (two defaulted fields — existing 2-arg constructions unaffected) and `ScoringLlmClient.route` (same return type, now with confidence/margin populated; `scores` is additive). Task 1 Step 5 re-runs the whole suite to confirm Stages 1–4 stay green. ✓
+
+**Known risks flagged in-plan:** Task 5 Step 4 (the ambiguous test needs an intent that scores two graphs — the intent string is chosen so both `configure` and `price` tokens are present); Task 6 (koog Bedrock client against a non-AWS SFDC gateway is best-effort → `DONE_WITH_CONCERNS`, never blocks, never touches main/test).

--- a/docs/superpowers/specs/2026-07-31-agentic-orchestrator-harness-design.md
+++ b/docs/superpowers/specs/2026-07-31-agentic-orchestrator-harness-design.md
@@ -1,0 +1,155 @@
+# Agentic API-Orchestration Harness — Design
+
+*Author: Gopal S Akshintala. Date: 2026-07-31. Status: design, pending review.*
+
+## Purpose
+
+Build a **local, runnable, end-to-end** agentic API-orchestration harness that puts every production concept from [`production-system-design.md`](file:///Users/gopala.akshintala/code-clones/my-github/overfullstack/life/career/gg/projects/async-orchestrator/production-system-design.md) "in action", so the design can be demoed and defended (see the companion `l6-interview-qa-prep.md`). The bias is **seeing it work over completeness**.
+
+The one idea the whole thing rests on (from the design doc): the LLM does exactly two probabilistic jobs — **pick a graph** and **fill its input slots**. Everything downstream is deterministic ReVoman execution, testable like ordinary software. This harness makes that split literal and runnable.
+
+## Hard constraints
+
+1. **Local-first, no Salesforce org.** A mock HTTP CPQ target (configure / price / quote) stands in for a real org, so ReVoman graphs execute against something real.
+2. **Never modify the ReVoman library.** The harness is a new, isolated Gradle module depending on the library as a normal project dependency.
+3. **LLM is pluggable behind an interface.** A deterministic **STUB** impl runs in tests/CI with no API key; a **REAL** impl (Claude via koog's Anthropic client) runs the live demo, gated on `ANTHROPIC_API_KEY`. Tests never require the key.
+4. **TDD throughout**, using the repo's Kotest setup.
+5. **Each stage runs on its own** and demonstrates its design-doc concepts with real command output.
+
+## Locked decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| Framework for the probabilistic layer | **koog 1.1.1** (JetBrains, Kotlin-native) | Ships an Anthropic client, an OpenTelemetry GenAI feature (`invoke_agent`/`execute_tool`/`chat` spans), and structured output. Matches ReVoman's Kotlin/Gradle idiom. Stage 1 needs no framework at all. |
+| Module location | **New Gradle subproject** `agentic-harness/` via `include(...)` | The same author's `ds-algo` repo already uses `include()` + `buildSrc` conventions. The library's `build.gradle.kts` and `src/` stay untouched; koog/LLM deps never leak into the published `revoman-*.jar`. |
+| Workflow representation | **A graph = a real ReVoman V3 collection directory** | Mirrors `src/integrationTest/resources/pm-templates/v3/core` exactly: `.resources/definition.yaml` + ordered `*.request.yaml`, edges are `{{var}}` threading. No invented format. |
+| Registry model | **Collapse to one graph registry** at v1 | One V3 collection = one graph = one LLM-selectable tool. Multi-graph intents are the router picking a *sequence* (graded as trajectory). No separate junction registry until workflows compose graphs across personas. Matches the doc's "static tool list at v1" YAGNI. |
+| Graph selection | **Static tool list** | Three graphs fit in context. Retrieval (hybrid + deferred loading) is a documented later drop-in, not built now. |
+
+## How agentic workflows are represented
+
+Each graph is a **ReVoman V3 collection directory**, the same format the library's own core integration templates use:
+
+- `.resources/definition.yaml` — `$kind: collection`, plus the graph's bearer auth (`token: "{{accessToken}}"`).
+- one `*.request.yaml` per API — `$kind: http-request` with `url` / `method` / `headers` / `body`, an `afterResponse` `scripts` block, and an `order:` field for sequencing.
+- **Edges = `{{var}}` environment-threading.** A step's `afterResponse` script does `pm.environment.set("configId", ...)`; a later step references `{{configId}}` in its URL or body. `order:` + the shared environment *is* the dependency graph. There is no `@{ref.id}` operator.
+
+The harness graphs (`configure`, `price`, `quote`) are authored in exactly this format but point `{{baseUrl}}` at the local mock server instead of a Salesforce org, so no org and no `{{accessToken}}` round-trip is required. We mirror the *format*, not the core endpoints.
+
+This representation is what feeds the probabilistic layer in Stage 2:
+
+- graph/folder name + `definition.yaml` description → seed for `when_to_use`
+- **unfilled `{{placeholders}}`** in request bodies/URLs → the input slots the slot-filler fills
+- **`pm.environment.set(...)` keys** → the graph's outputs / internal edges — the LLM never fills these (deterministic threading; the design's core claim)
+- a small hand-written OAS per endpoint → types for schema validation before execution
+
+## Architecture
+
+```
+agentic-harness/  (new Gradle module, depends on :revoman + koog)
+  Stage 1 — deterministic spine (no LLM, no koog)
+    MockCpqServer         http4k in-memory server: /configure /price /quote + a mock "DB" map
+    graphs/*              V3 collections (configure, price, quote) chaining via {{var}}
+    GraphRunner           wraps ReVoman.revUp(Kick): Rundown; prints Rundown.toJson
+    Layer1ContractTest    asserts on Rundown (all steps successful, stopReason)
+  Stage 2 — tool-def gen + probabilistic layer (koog)
+    ToolDefGenerator      pure fn: graph metadata + OAS -> 4-field tool def
+    LlmClient (interface) StubLlmClient (deterministic) | ClaudeLlmClient (koog Anthropic, key-gated)
+    Router                intent -> chosen graph
+    SlotFiller            fill placeholders, validate vs schema BEFORE revUp
+    Orchestrator          route -> slot-fill -> revUp -> Rundown-as-context
+  Stage 3 — evals + calibration
+    EvalSet               labeled utterance -> expected graph
+    ConfusionMatrix       run router over set, print matrix, show a miss move after a fix
+    BfclCheck             predicted slot-fill vs gold
+    TauBenchCheck         assert final mock-DB state
+    LlmJudge              fuzzy metric + deterministic ground-truth alongside
+  Stage 4 — observability + flywheel
+    Telemetry             koog OpenTelemetry feature -> GenAI spans to console/collector
+    ConfirmGate           confirm/edit/reject -> positive/correction-pair/negative labels
+    NightlyBatch          append confirmed turns to eval set; draft when_not_to_use from confusion pairs
+```
+
+### Concept-to-component map
+
+| # | Design-doc concept | Component | Stage |
+|---|---|---|---|
+| 1 | Deterministic worker | `MockCpqServer` + V3 graphs chaining via `{{var}}` | 1 |
+| 2 | `revUp(Kick): Rundown` | `GraphRunner` | 1 |
+| 3 | Evals Layer 1 (deterministic contract test) | `Layer1ContractTest` asserts on `Rundown` | 1 |
+| 4 | Tool-def auto-generation (4 fields) | `ToolDefGenerator` (pure, unit-tested) | 2 |
+| 5 | Router + slot-filler, schema validation | `Router`, `SlotFiller`, `LlmClient` | 2 |
+| 6 | Orchestrator-workers loop | `Orchestrator` | 2 |
+| 7 | Confusion matrix / prompt calibration | `ConfusionMatrix` eval runner | 3 |
+| 8 | BFCL + tau-bench idioms | `BfclCheck`, `TauBenchCheck` | 3 |
+| 9 | LLM-as-judge, bounded | `LlmJudge` + deterministic ground-truth | 3 |
+| 10 | OTel GenAI spans | `Telemetry` (koog OpenTelemetry) | 4 |
+| 11 | HITL confirm gate + feedback flywheel | `ConfirmGate`, `NightlyBatch` | 4 |
+
+## Stage 1 — deterministic spine (smallest runnable slice)
+
+**Goal:** the deterministic worker runs end-to-end, no LLM, no koog. This is the "evals Layer 1" beat.
+
+**Components:**
+
+1. **`MockCpqServer`** — http4k (already a `:revoman` `api` dependency, so no new deps for this stage). Three endpoints backed by an in-memory `MutableMap` "DB" (Stage 3's tau-bench asserts against it):
+   - `POST /configure` → `{ "configId": "..." }`
+   - `POST /price` (reads `configId`) → `{ "priceId": "...", "total": <n> }`
+   - `POST /quote` (reads `priceId`) → `{ "quoteId": "...", "status": "DRAFT" }`
+2. **V3 graph collections** — `configure`, `price`, `quote`, authored in the V3 format above, pointing at the mock server. Chaining is pure `{{var}}` threading: `configure` sets `{{configId}}`, `price` consumes it and sets `{{priceId}}`, `quote` consumes that.
+3. **`GraphRunner`** — builds `Kick.configure().templatePath(...).environmentPath(...)...off()`, calls `ReVoman.revUp(kick)`, returns the `Rundown`, and prints `rundown.toJson(SUMMARY)`.
+4. **`Layer1ContractTest`** (Kotest) — asserts `rundown.firstUnIgnoredUnsuccessfulStepReport() == null` (the library's confirmed happy-path check) and verifies the `stopReason` value. (The design doc names `stopReason == COMPLETED`; the exact enum symbol will be confirmed against the library API during implementation rather than assumed.)
+
+**Runnable proof:** a `main()` that boots the mock server, runs the three-graph chain, and prints the `Rundown`; plus `./gradlew :agentic-harness:test` green.
+
+## Stage 2 — tool-def generation + probabilistic layer
+
+**`ToolDefGenerator`** (pure function, unit-tested) reads a graph's `definition.yaml` + `*.request.yaml` files + a small hand-written OAS and produces the four fields the design mandates:
+
+- `when_to_use` — intents this graph serves (seeded from name + description)
+- `when_not_to_use` — near-miss intents that belong elsewhere (the field that stops `configure`/`price` confusion; grown in Stage 3)
+- `example_queries` — three to five real utterances
+- `input_examples` — filled parameter examples (Anthropic's 72%→90% lever)
+
+**`LlmClient` interface** — one method surface for both jobs (route, slot-fill). Two impls:
+
+- `StubLlmClient` — deterministic keyword/rule routing and slot extraction; no network, no key; the default in tests/CI.
+- `ClaudeLlmClient` — koog Anthropic client; constructed only when `ANTHROPIC_API_KEY` is present; used for the live demo.
+
+**`Router`** turns intent into a chosen graph. **`SlotFiller`** fills the graph's unfilled `{{placeholders}}` and **validates every argument against the OAS schema before ReVoman fires** — hallucinated/malformed args are rejected at the door (the design's runtime hallucination guard).
+
+**`Orchestrator`** wires the loop: `route → slot-fill → GraphRunner.revUp → Rundown.toJson back as context`. This is the orchestrator-workers pattern made literal.
+
+## Stage 3 — evals + calibration in action
+
+- **`EvalSet`** — a labeled `utterance → expected graph` dataset.
+- **`ConfusionMatrix`** — run the router over the set, compute graph-selection accuracy, print a confusion matrix. Demo beat: surface an off-diagonal miss, add a `when_not_to_use` clause, re-run, show the number move. That is prompt calibration, live.
+- **`BfclCheck`** — BFCL-style comparison of the predicted slot-fill call against gold.
+- **`TauBenchCheck`** — tau-bench-style assertion on the final mock-DB state (task success, not transcript).
+- **`LlmJudge`** — LLM-as-judge on one fuzzy metric (e.g. response helpfulness), with a deterministic ground-truth check alongside to show the judge only screens.
+
+## Stage 4 — observability + feedback flywheel
+
+- **`Telemetry`** — koog's OpenTelemetry feature emits GenAI-convention spans (`invoke_agent` per turn, `execute_tool` per graph run nesting Rundown stats, `chat` per LLM call with prompt version) to the console or a local collector.
+- **`ConfirmGate`** — simulates the HITL confirm gate on the one write (`quote`): confirm → positive label; edit-then-confirm → correction pair; reject → negative label.
+- **`NightlyBatch`** — a function that appends confirmed turns to the eval set and drafts `when_not_to_use` clauses from confusion pairs, demonstrating the CI gate tightening itself over time.
+
+## Testing strategy
+
+- **TDD per component**, Kotest (the repo convention), in `agentic-harness/src/test`.
+- Stage 1 is fully deterministic — no LLM, no key.
+- Stages 2–4 default to `StubLlmClient`, so the whole suite runs in CI with no `ANTHROPIC_API_KEY`. The real Claude path is exercised only in a manual/live demo run when the key is present, and is skipped (not failed) otherwise.
+- The mock server binds an ephemeral port per test to keep runs isolated and parallel-safe.
+
+## Explicitly out of scope (YAGNI for this harness)
+
+Retrieval-based selection, code-mode, real OAuth / RFC 8693 token exchange, ReBAC, Einstein Trust Layer, fine-tuning/DPO, Prompt Builder, multi-provider cross-session context, and load-testing ReVoman concurrency. Each is a documented later phase in the design doc; none is needed to prove the thesis locally. The registry is structured so retrieval can drop in without a rewrite, per the design.
+
+## Runnable proof per stage
+
+| Stage | Command | What it shows |
+|---|---|---|
+| 1 | `./gradlew :agentic-harness:test` + a `main()` run | Mock server up; three graphs chain via `{{var}}`; `Rundown` printed; Layer-1 contract green |
+| 2 | orchestrator `main()` (stub) + `./gradlew :agentic-harness:test` | intent → graph → slots (schema-validated) → `revUp` → Rundown context |
+| 3 | eval runner `main()` | printed confusion matrix; a miss moving after a `when_not_to_use` fix; BFCL + tau-bench checks |
+| 4 | demo `main()` (optionally with key + collector) | OTel spans on console; confirm-gate labels; nightly-batch appends + drafts |

--- a/docs/superpowers/specs/2026-07-31-reasoning-layer-scaffolds-design.md
+++ b/docs/superpowers/specs/2026-07-31-reasoning-layer-scaffolds-design.md
@@ -1,0 +1,137 @@
+# Reasoning-Layer Scaffolds — Design (Delta on `agentic-harness`)
+
+*Author: Gopal S Akshintala. Date: 2026-07-31. Status: design, pending review. Companion to `reasoning-layer.md`, `production-system-design.md`, `industry-scaffolding-research.md`.*
+
+## Purpose
+
+Complete the **reasoning layer** — the one probabilistic part of the agentic API-orchestration system — as the six reliability scaffolds named in `reasoning-layer.md`. Stages 1–4 of the `agentic-harness` module already built ~60% of these (tool-def generator, slot-filler + schema validation, router, eval set + confusion matrix, confirm-gate labels, OTel spans). This spec is the **delta**: the genuinely-missing scaffolds, built on the existing module, so the layer is complete and every reliability control is runnable and measurable locally.
+
+The layer's contract (from `reasoning-layer.md`): map `(user intent + API-graph descriptions) → {chosen graph, filled slots}` **reliably**, or — when uncertain — **ask instead of guess**. MCP is transport; this reasoning is the owned layer.
+
+## What already exists (reuse as-is, all green)
+
+| Scaffold | Component (built) |
+|---|---|
+| 1. Tool-def generator (4-field) | `tooldef.ToolDefGenerator` (+ `GraphOas`, `GraphMetadataParser`) |
+| 3. Slot-filler, validate-before-execute | `orchestrator.SlotFiller` → `FillResult.Valid/Invalid` |
+| 7. Eval set + confusion matrix | `eval.RouterEvaluator`, `eval.ConfusionMatrix`, `eval.EvalSet` |
+| 8a. Slot-fill valid rate (BFCL) | `eval.BfclCheck` |
+| Router (base) | `orchestrator.Router` + `llm.ScoringLlmClient` (calibration-aware, deterministic) |
+| Confirm-gate labels | `feedback.ConfirmGate` (confirm/edit/reject → labels) |
+| Deterministic execution | `GraphRunner.runChain` → `ReVoman.revUp` → `Rundown` |
+| Tracing | `telemetry.GenAiTracer` (invoke_agent/chat/execute_tool) |
+
+## What this spec builds (the delta)
+
+| # | Scaffold (reasoning-layer.md) | New component |
+|---|---|---|
+| 2 | Router returns `{graph_id, confidence}` | add `confidence`/`margin` to `RouteDecision`; `ScoringLlmClient` exposes per-graph scores |
+| 4 | Retrieval pre-filter (top-K) | `retrieval.RetrievalPreFilter` (embedding stub; no-op at 3, seam proven at 10) |
+| 5 | Confidence / disambiguation gate (**the core**) | `reasoning.ConfidencePolicy` + `reasoning.DisambiguationGate` → ask-don't-guess |
+| 6 | Confirm gate returns a preview object | `reasoning.ActionPreview` + confirm-gate wiring (preview, execute only on confirm) |
+| — | End-to-end wiring | `reasoning.ReasoningLayer.handle(intent): ReasoningOutcome` |
+| 8b | Low-margin → ask (not guess) test | test in `DisambiguationGateTest` / `ReasoningLayerTest` |
+| — | Native strict tool-use (real client) | `ClaudeLlmClient` sends OAS as Anthropic tool-use `input_schema` (claude source set, key-gated) |
+
+## Hard constraints
+
+- **Local-first, no Salesforce org.** Mock LLM + the 3 existing V3 graphs (configure / price / quote).
+- **LLM behind the existing `LlmClient` interface.** Deterministic STUB path (keyword/score, no key) drives all tests/CI. Real Claude path (koog, `ANTHROPIC_API_KEY`) stays in the isolated `claude` source set the default `test`/`build`/`check` never compiles. **Tests never require the key.**
+- **Structured output = "constrained decoding + validate-before-execute", implemented directly** (no Python libs). Real client uses Anthropic native tool-use `input_schema`; hand-rolled JSON-schema validation against the OAS runs on both paths before execute (the existing `SlotFiller` validation is that check, reused).
+- **Never modify the ReVoman library.** All work inside `agentic-harness/`.
+- **TDD throughout.** Every scaffold gets a failing test first. Stages 1–4 stay green after every change.
+- No koog / kotlinx.coroutines / OTel-SDK dependency in `src/main` or `src/test`.
+
+## Design decisions (locked)
+
+1. **Build mode: delta on the existing `agentic-harness` module.** Reuse the 60% already green; no duplicate tool-def gen / slot-filler / eval harness.
+2. **Confidence source: score-margin from `ScoringLlmClient`.** `confidence` = normalized top score; `margin` = (top1 − top2) normalized. Deterministic, already computed, and the gate triggers when `margin < threshold`. (Note: the client's `when_not_to_use` penalty requires ≥2 matching trigger tokens — an existing hardening; the confidence work only *reads* the resulting scores, it does not change scoring.)
+3. **Structured output: real client uses Anthropic tool-use `input_schema`; stub stays keyword/regex.** Validation-before-execute applies uniformly via the existing schema check.
+
+## Architecture
+
+```
+agentic-harness/src/main/kotlin/com/salesforce/revoman/harness/
+  llm/
+    LlmClient.kt            RouteDecision gains: confidence: Double, margin: Double (defaults keep old callers compiling)
+    ScoringLlmClient.kt     add fun scores(utterance, tools): Map<String, Int>; route() fills confidence+margin
+  retrieval/
+    RetrievalPreFilter.kt   topK(intent, tools, k): List<ToolDef> — token-overlap cosine stub; k>=size => all (no-op)
+  reasoning/
+    ConfidencePolicy.kt     thresholds (per-graph + default), writeGraphs set; writeGraphs default 0.90
+    ActionPreview.kt        data class: graph, slots, chain (graphs to run), isWrite
+    ReasoningOutcome.kt     sealed: NoMatch | Clarify | ConfirmRequired | Proceed
+    DisambiguationGate.kt   decide(routeDecision, fill, policy): ReasoningOutcome  (ask-don't-guess)
+    ReasoningLayer.kt       handle(intent): ReasoningOutcome — [retrieve]->route->fill->gate; confirm(preview)->execute
+  Stage5Demo.kt             runnable: 4 utterances (proceed / confirm / ask / no-match) + trace + confusion matrix
+  (claude source set)
+    ClaudeLlmClient.kt      add native Anthropic tool-use input_schema for slot-fill; validate before return
+```
+
+### Data flow
+
+```
+intent
+  -> RetrievalPreFilter.topK(intent, allTools, K)          # narrows N->K (no-op at 3)
+  -> Router.route(intent, candidates) : RouteDecision{graph, confidence, margin, rationale}
+  -> (graph == null)                    => ReasoningOutcome.NoMatch
+  -> (margin < policy.threshold(graph)) => ReasoningOutcome.Clarify(question, top-2 candidates)
+  -> SlotFiller.fill(intent, tool)
+       is Invalid                       => ReasoningOutcome.Clarify(question about missing/invalid slot)
+       is Valid ->
+         (graph in writeGraphs)         => ReasoningOutcome.ConfirmRequired(ActionPreview)   # no execution yet
+         else (read graph)              => ReasoningOutcome.Proceed(graph, slots)            # caller executes
+  # confirm path:
+  ReasoningLayer.confirm(preview, baseUrl) -> GraphRunner.runChain(baseUrl, preview.chain, preview.slots) -> Rundown
+```
+
+### `ReasoningOutcome` (sealed)
+
+- `NoMatch(intent)` — router returned no graph.
+- `Clarify(question, candidates)` — top-2 within margin, OR a required slot missing/low-confidence. **The ask-don't-guess result.**
+- `ConfirmRequired(preview: ActionPreview)` — write graph, confident, awaiting human; nothing executed.
+- `Proceed(graph, slots)` — read graph, confident; safe to auto-execute.
+
+### `ConfidencePolicy`
+
+`ConfidencePolicy(defaultThreshold: Double = 0.60, perGraphThreshold: Map<String, Double> = emptyMap(), writeGraphs: Set<String> = setOf("quote"))`. `fun threshold(graph): Double`. Write-graph default **0.90** (financial-services band, `industry-scaffolding-research.md` §5). Tunable: the demo shows lowering `quote`'s threshold changes ask-vs-confirm behavior.
+
+### `ActionPreview`
+
+`data class ActionPreview(val graph: String, val slots: Map<String, String>, val chain: List<String>, val isWrite: Boolean)`. Rendered for the human at the confirm gate; carries exactly what `GraphRunner.runChain` needs, so `confirm()` executes without re-deriving anything.
+
+## Retrieval pre-filter (scaffold 4)
+
+`object RetrievalPreFilter { fun topK(intent: String, tools: List<ToolDef>, k: Int): List<ToolDef> }`. Embedding stub = bag-of-tokens cosine similarity between the intent and each tool's `whenToUse + exampleQueries`. Returns the top-`k` by similarity; when `k >= tools.size` returns all (the **no-op at 3 graphs**, seam intact). Unit test proves it narrows a synthetic 10-graph set to the relevant 3.
+
+## Native structured output (real client, scaffold 3/4 pattern)
+
+In the `claude` source set only: `ClaudeLlmClient.fillSlots` builds an Anthropic tool-use `tool` whose `input_schema` is the graph's OAS (slot names, types, enums) and calls the model with `tool_choice` forcing that tool, so the model returns strict structured arguments (constrained decoding). The returned args then go through the **same** hand-rolled JSON-schema validation the stub path uses (`SlotFiller` over the `SlotSchema`) before execution — validate-before-execute, uniform across paths. This stays key-gated and CI-isolated; no automated test depends on it.
+
+## Measurable proof (scaffolds 7 + 8, extended)
+
+- **Graph-selection accuracy + confusion matrix** — already runnable (Stage 3 `runStage3Demo`), unchanged.
+- **Calibration live** — off-diagonal miss → `when_not_to_use` clause → 6/7 → 7/7, already proven.
+- **Slot-fill schema-valid rate** — `BfclCheck`, already runnable.
+- **NEW — low-margin → ask, not guess** — a test: an utterance whose top-2 graphs fall within the margin yields `ReasoningOutcome.Clarify`, and the mock DB stays empty (nothing executed). This is the single most important reliability rule, made a passing test.
+- **NEW — write-graph → confirm, not execute** — a `quote` (write) intent yields `ConfirmRequired(preview)` with an empty DB; only `confirm()` executes.
+
+## Testing strategy
+
+- TDD per scaffold, JUnit5 + Google Truth, in `agentic-harness/src/test`.
+- All new scaffolds are deterministic and koog-free — full suite runs in CI with no key.
+- `Orchestrator` (Stage 4) is left intact; `ReasoningLayer` is the new richer entry point that adds retrieval + the confidence gate around the same Router/SlotFiller. (The Stage-2 `Orchestrator` remains for the orchestrator-workers demos; `ReasoningLayer` is the reasoning-layer-complete entry point.)
+- Each new component is independently testable: retrieval, confidence math, gate decisions (table of cases), preview shape, end-to-end wiring.
+
+## Out of scope (YAGNI)
+
+Real embeddings/vector store (stub cosine suffices to prove the seam), reranking, multi-turn clarification dialogue state (the `Clarify` outcome is returned; managing the follow-up turn is the host's job per `reasoning-layer.md` open questions), production OTLP export, and any change to the ReVoman library.
+
+## Runnable proof
+
+| What | Command |
+|---|---|
+| Full suite green (all stages + new scaffolds), no key | `./gradlew :agentic-harness:test` |
+| Reasoning-layer demo: proceed / confirm-preview / **ask** / no-match, traced | `./gradlew :agentic-harness:runStage5Demo -q` |
+| Confusion-matrix calibration (existing) | `./gradlew :agentic-harness:runStage3Demo -q` |
+| Real Claude structured tool-use (key-gated, isolated) | `./gradlew :agentic-harness:compileClaudeKotlin` (+ `claudeDemo` with key) |

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -51,3 +51,5 @@ develocity {
 }
 
 rootProject.name = "revoman-root"
+
+include("agentic-harness")


### PR DESCRIPTION
## What & why

Adds **`agentic-harness`** — a new, isolated Gradle module that makes the agentic API-orchestration design ([production-system-design](https://docs.google.com/) / reasoning-layer) **runnable locally, end-to-end, with no Salesforce org**. It demonstrates every production concept as working, tested code on top of ReVoman as the deterministic execution engine.

**The ReVoman library is not modified.** The only change outside `agentic-harness/` is a single `include("agentic-harness")` line in `settings.gradle.kts`. New deps (koog) are quarantined to an opt-in source set the default build never compiles.

## What's in it

Built in stages, each independently runnable (`./gradlew :agentic-harness:runStage*Demo`):

- **Stage 1 — deterministic spine:** in-memory mock CPQ server (`configure`/`price`/`quote`) + three ReVoman V3 collections chaining via `{{var}}`, executed by `ReVoman.revUp`, with a Layer-1 contract test on the `Rundown`.
- **Stage 2 — probabilistic layer:** auto-generated 4-field tool defs, a pluggable `LlmClient` (deterministic stub + real Claude), router + slot-filler with schema validation before execution, and the orchestrator-workers loop.
- **Stage 3 — evals + calibration:** labeled eval set, confusion matrix, live calibration (add a `when_not_to_use` clause → accuracy 6/7 → 7/7), BFCL slot-fill check, tau-bench final-DB-state check, bounded LLM-as-judge alongside a deterministic ground-truth.
- **Stage 4 — observability + flywheel:** OpenTelemetry GenAI-convention spans (`invoke_agent`/`chat`/`execute_tool`), a HITL confirm gate (confirm/edit/reject → labels), and a nightly-batch that grows the eval set + drafts `when_not_to_use` from rejects.
- **Blue box — unified contract:** `GraphContract` fuses the metadata descriptor (`ToolDef`) + runtime outcome (`Rundown`) + data-lineage (which `{{var}}` came from which step) + a version envelope, with a tiered JSON renderer; plus `ContractFidelityCheck` (deterministic API-drift catch) and `ContractAblationEval` (measure accuracy delta from contract enrichment).
- **Green box — reasoning layer (6 scaffolds):** router with `{graph, confidence, margin}`, retrieval pre-filter, the confidence/disambiguation gate (**ask-don't-guess**: low margin or bad slots → clarify; writes → confirm-required, never auto-execute), and end-to-end `ReasoningLayer` wiring.

## Isolation & safety

- koog / coroutines live **only** in `src/claude` (a source set the default `test`/`build`/`check` never compiles). Grep-verified: no `ai.koog.*` / `kotlinx.coroutines.*` under `src/main` or `src/test`.
- No API key required for any test. The real Claude path is gated on env vars and skips cleanly when absent.

## Verification

```
./gradlew :agentic-harness:build   # spotless + detekt + all tests — green
./gradlew :agentic-harness:test    # 32 test classes
```

Runnable demos (deterministic, no key):

```
./gradlew :agentic-harness:runStage1Demo    # deterministic spine
./gradlew :agentic-harness:runStage2Demo    # orchestrator-workers loop
./gradlew :agentic-harness:runStage3Demo    # confusion matrix + calibration
./gradlew :agentic-harness:runStage4Demo    # spans + confirm gate + flywheel
./gradlew :agentic-harness:runStage5Demo    # full reasoning layer (proceed/confirm/ask/no-match)
./gradlew :agentic-harness:runContractDemo      # unified GraphContract, 3 verbosity tiers
./gradlew :agentic-harness:runContractEvalDemo  # fidelity + drift catch + ablation
```

## Known limit

The real Claude path compiles and targets this environment's AWS Bedrock proxy; the **live** call is best-effort (the gateway is reachable but koog's Bedrock client does not complete a request against the proxy's redirect/protocol). The deterministic stub path is the shippable deliverable and exercises the entire design in CI.

Design + implementation notes live under `docs/superpowers/specs/` and `docs/superpowers/plans/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
